### PR TITLE
feat(attendance): use Supabase JWT for actor resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Important:
 
 - `DATABASE_URL` is for Prisma runtime (session pooler).
 - `DIRECT_URL` is for Prisma migrations (direct DB endpoint).
+- API routes resolve actor context from Supabase JWT bearer token.
+- Development fallback: `x-actor-role` and `x-actor-id` headers are accepted only outside production.
 
 ## Local Run
 

--- a/src/app/api/attendance/records/[recordId]/approve/route.ts
+++ b/src/app/api/attendance/records/[recordId]/approve/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
 };
 
 export async function POST(request: Request, context: RouteContext) {
-  const actor = readActor(request);
+  const actor = await readActor(request);
   if (!actor || !hasAnyRole(actor, ["admin", "manager"])) {
     return fail(403, "approval requires admin or manager role");
   }

--- a/src/app/api/attendance/records/[recordId]/route.ts
+++ b/src/app/api/attendance/records/[recordId]/route.ts
@@ -10,7 +10,7 @@ type RouteContext = {
 };
 
 export async function PATCH(request: Request, context: RouteContext) {
-  const actor = readActor(request);
+  const actor = await readActor(request);
   if (!actor) {
     return fail(401, "missing or invalid actor context");
   }

--- a/src/app/api/attendance/records/route.ts
+++ b/src/app/api/attendance/records/route.ts
@@ -6,7 +6,7 @@ import { fail, ok } from "@/lib/http";
 import { writeAuditLog } from "@/lib/audit";
 
 export async function POST(request: Request) {
-  const actor = readActor(request);
+  const actor = await readActor(request);
   if (!actor) {
     return fail(401, "missing or invalid actor context");
   }

--- a/src/app/api/payroll/runs/[runId]/confirm/route.ts
+++ b/src/app/api/payroll/runs/[runId]/confirm/route.ts
@@ -9,7 +9,7 @@ type RouteContext = {
 };
 
 export async function POST(request: Request, context: RouteContext) {
-  const actor = readActor(request);
+  const actor = await readActor(request);
   if (!actor || !hasAnyRole(actor, ["admin", "payroll_operator"])) {
     return fail(403, "payroll confirm requires admin or payroll_operator role");
   }

--- a/src/app/api/payroll/runs/preview/route.ts
+++ b/src/app/api/payroll/runs/preview/route.ts
@@ -7,7 +7,7 @@ import { calculateGrossPay, splitPayableMinutes, workedMinutes } from "@/lib/pay
 import { writeAuditLog } from "@/lib/audit";
 
 export async function POST(request: Request) {
-  const actor = readActor(request);
+  const actor = await readActor(request);
   if (!actor || !hasAnyRole(actor, ["admin", "payroll_operator"])) {
     return fail(403, "payroll preview requires admin or payroll_operator role");
   }

--- a/src/lib/actor.ts
+++ b/src/lib/actor.ts
@@ -1,3 +1,6 @@
+import { User } from "@supabase/supabase-js";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+
 export const actorRoles = [
   "admin",
   "manager",
@@ -13,7 +16,24 @@ export type Actor = {
   role: ActorRole;
 };
 
-export function readActor(request: Request): Actor | null {
+function parseRoleFromUser(user: User): ActorRole {
+  const candidates = [
+    user.app_metadata?.role,
+    user.user_metadata?.role,
+    user.app_metadata?.user_role,
+    user.user_metadata?.user_role
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && actorRoles.includes(candidate as ActorRole)) {
+      return candidate as ActorRole;
+    }
+  }
+
+  return "employee";
+}
+
+function readActorFromHeaders(request: Request): Actor | null {
   const roleValue = request.headers.get("x-actor-role");
   if (!roleValue || !actorRoles.includes(roleValue as ActorRole)) {
     return null;
@@ -22,4 +42,36 @@ export function readActor(request: Request): Actor | null {
     id: request.headers.get("x-actor-id") ?? "unknown",
     role: roleValue as ActorRole
   };
+}
+
+function readBearerToken(request: Request) {
+  const authorization = request.headers.get("authorization");
+  if (!authorization) {
+    return null;
+  }
+  const [scheme, token] = authorization.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return null;
+  }
+  return token;
+}
+
+export async function readActor(request: Request): Promise<Actor | null> {
+  const token = readBearerToken(request);
+  if (token) {
+    const { data, error } = await supabaseAdmin.auth.getUser(token);
+    if (!error && data.user) {
+      return {
+        id: data.user.id,
+        role: parseRoleFromUser(data.user)
+      };
+    }
+  }
+
+  // Temporary non-prod fallback for local/dev tooling without JWT.
+  if (process.env.NODE_ENV !== "production") {
+    return readActorFromHeaders(request);
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- Switched actor resolution from header-only to Supabase JWT bearer verification
- Added role extraction from Supabase user metadata/app metadata
- Kept non-production header fallback for local tooling
- Updated attendance/payroll route handlers to await async actor resolution

## Files
- src/lib/actor.ts
- src/app/api/attendance/records/*
- src/app/api/payroll/runs/*
- README.md
