### PR TITLE
feat(wi-0001): service-layer routes with memory-backed API e2e

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ DATABASE_URL=postgresql://postgres.zjritguxyfdzzxuwcizv:YOUR-PASSWORD@aws-1-ap-s
 
 # Prisma migration URL (direct connection, not pooler)
 DIRECT_URL=postgresql://postgres:YOUR-PASSWORD@db.zjritguxyfdzzxuwcizv.supabase.co:5432/postgres
+
+# Optional: set "memory" for API route tests without DB
+FLOWHR_DATA_ACCESS=prisma

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Important:
 - `DATABASE_URL` is for Prisma runtime (session pooler).
 - `DIRECT_URL` is for Prisma migrations (direct DB endpoint).
 - API routes resolve actor context from Supabase JWT bearer token.
+- Canonical role claim is `app_metadata.role` (see `docs/role-claims.md`).
 - Development fallback: `x-actor-role` and `x-actor-id` headers are accepted only outside production.
 
 ## Local Run
@@ -44,6 +45,11 @@ supabase db pull
 ```
 
 Use Supabase CLI for schema sync/inspection while Prisma remains the app ORM and migration tool.
+
+## Test Data Access Mode
+
+- Default runtime uses Prisma.
+- For API route tests without database, set `FLOWHR_DATA_ACCESS=memory`.
 
 ## Contribution Flow
 

--- a/docs/role-claims.md
+++ b/docs/role-claims.md
@@ -1,0 +1,34 @@
+# Supabase Role Claims (FlowHR)
+
+## Canonical Claim
+
+- `app_metadata.role` is the single source of truth for authorization role mapping.
+
+Allowed role values:
+
+- `admin`
+- `manager`
+- `employee`
+- `payroll_operator`
+- `system`
+
+## Compatibility
+
+- Legacy fallback claims are temporarily accepted:
+  - `user_metadata.role`
+  - `app_metadata.user_role`
+  - `user_metadata.user_role`
+- New tokens and onboarding flows must write `app_metadata.role`.
+
+## Practical Rules
+
+- Attendance approve: `admin`, `manager`
+- Payroll preview/confirm: `admin`, `payroll_operator`
+- Attendance create/update:
+  - `admin`, `manager`: any employee
+  - `employee`: only own employee ID
+
+## Migration Note
+
+- Existing users should be backfilled to `app_metadata.role`.
+- After migration stabilization, legacy fallbacks can be removed via ADR.

--- a/scripts/tests/e2e-wi0001.test.ts
+++ b/scripts/tests/e2e-wi0001.test.ts
@@ -1,133 +1,161 @@
 import assert from "node:assert/strict";
-import type { Actor } from "../../src/lib/actor.ts";
-import { hasAnyRole, canMutateAttendance } from "../../src/lib/permissions.ts";
-import {
-  calculateGrossPay,
-  defaultMultipliers,
-  splitPayableMinutes,
-  workedMinutes
-} from "../../src/lib/payroll-rules.ts";
 
-type AttendanceRecord = {
-  id: string;
-  employeeId: string;
-  checkInAt: Date;
-  checkOutAt: Date;
-  breakMinutes: number;
-  isHoliday: boolean;
-  state: "PENDING" | "APPROVED";
-};
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
 
-type AuditEvent = {
-  action: string;
-  actorId: string;
-};
+type JsonPayload = Record<string, unknown>;
 
-let sequence = 1;
-const attendanceRecords: AttendanceRecord[] = [];
-const auditEvents: AuditEvent[] = [];
-
-function writeAudit(action: string, actor: Actor) {
-  auditEvents.push({ action, actorId: actor.id });
-}
-
-function createAttendanceRecord(
-  actor: Actor,
-  input: Omit<AttendanceRecord, "id" | "state">
-): AttendanceRecord {
-  if (!canMutateAttendance(actor, input.employeeId)) {
-    throw new Error("unauthorized create");
-  }
-
-  const record: AttendanceRecord = {
-    ...input,
-    id: `AR-${sequence++}`,
-    state: "PENDING"
+function actorHeaders(role: string, actorId: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId
   };
-  attendanceRecords.push(record);
-  writeAudit("attendance.recorded", actor);
-  return record;
 }
 
-function approveAttendanceRecord(actor: Actor, id: string): AttendanceRecord {
-  if (!hasAnyRole(actor, ["admin", "manager"])) {
-    throw new Error("unauthorized approve");
-  }
-  const target = attendanceRecords.find((record) => record.id === id);
-  if (!target) {
-    throw new Error("record not found");
-  }
-  target.state = "APPROVED";
-  writeAudit("attendance.approved", actor);
-  return target;
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
 }
 
-function previewPayroll(actor: Actor, periodStart: Date, periodEnd: Date, hourlyRateKrw: number) {
-  if (!hasAnyRole(actor, ["admin", "payroll_operator"])) {
-    throw new Error("unauthorized preview");
-  }
+async function readJson(response: Response) {
+  return (await response.json()) as unknown;
+}
 
-  const approved = attendanceRecords.filter(
-    (record) => record.state === "APPROVED" && record.checkInAt >= periodStart && record.checkInAt <= periodEnd
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+async function run() {
+  const { resetMemoryDataAccess, getMemoryAuditActions } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
+  const attendanceApproveRoute = await import(
+    "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
+  );
+  const payrollPreviewRoute = await import("../../src/app/api/payroll/runs/preview/route.ts");
+  const payrollConfirmRoute = await import(
+    "../../src/app/api/payroll/runs/[runId]/confirm/route.ts"
   );
 
-  let totals = { regular: 0, overtime: 0, night: 0, holiday: 0 };
-  for (const record of approved) {
-    const worked = workedMinutes(record.checkInAt, record.checkOutAt, record.breakMinutes);
-    const minutes = splitPayableMinutes(worked, record.isHoliday);
-    totals = {
-      regular: totals.regular + minutes.regular,
-      overtime: totals.overtime + minutes.overtime,
-      night: totals.night + minutes.night,
-      holiday: totals.holiday + minutes.holiday
-    };
-  }
+  resetMemoryDataAccess();
 
-  const grossPayKrw = calculateGrossPay(totals, hourlyRateKrw, defaultMultipliers);
-  writeAudit("payroll.calculated", actor);
-
-  return {
-    sourceCount: approved.length,
-    totals,
-    grossPayKrw
+  const createResponse = await attendanceCreateRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/attendance/records",
+      {
+        employeeId: "EMP-1001",
+        checkInAt: "2026-02-02T09:00:00+09:00",
+        checkOutAt: "2026-02-02T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      actorHeaders("employee", "EMP-1001")
+    )
+  );
+  assert.equal(createResponse.status, 201, "attendance creation should succeed");
+  const createdBody = (await readJson(createResponse)) as {
+    record: { id: string; state: string };
   };
+  const createdRecord = createdBody.record;
+  assert.ok(createdRecord?.id, "created record id should exist");
+  assert.equal(createdRecord.state, "PENDING");
+
+  const approvalDenied = await attendanceApproveRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${createdRecord.id}/approve`, {
+      method: "POST",
+      headers: actorHeaders("employee", "EMP-1001")
+    }),
+    { params: Promise.resolve({ recordId: createdRecord.id }) } as RouteContext<{ recordId: string }>
+  );
+  assert.equal(approvalDenied.status, 403, "employee should not approve attendance");
+
+  const approveResponse = await attendanceApproveRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${createdRecord.id}/approve`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-1")
+    }),
+    { params: Promise.resolve({ recordId: createdRecord.id }) } as RouteContext<{ recordId: string }>
+  );
+  assert.equal(approveResponse.status, 200, "manager should approve attendance");
+  const approveBody = (await readJson(approveResponse)) as {
+    record: { state: string };
+  };
+  assert.equal(approveBody.record.state, "APPROVED");
+
+  const previewResponse = await payrollPreviewRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-1001",
+        hourlyRateKrw: 12000
+      },
+      actorHeaders("payroll_operator", "PAY-1")
+    )
+  );
+  assert.equal(previewResponse.status, 200, "payroll preview should succeed");
+  const previewBody = (await readJson(previewResponse)) as {
+    run: { id: string };
+    summary: {
+      sourceRecordCount: number;
+      totals: {
+        regular: number;
+        overtime: number;
+        night: number;
+        holiday: number;
+      };
+      grossPayKrw: number;
+    };
+  };
+  assert.equal(previewBody.summary.sourceRecordCount, 1);
+  assert.deepEqual(previewBody.summary.totals, {
+    regular: 480,
+    overtime: 0,
+    night: 0,
+    holiday: 0
+  });
+  assert.equal(previewBody.summary.grossPayKrw, 96000);
+
+  const confirmResponse = await payrollConfirmRoute.POST(
+    new Request(`http://localhost/api/payroll/runs/${previewBody.run.id}/confirm`, {
+      method: "POST",
+      headers: actorHeaders("payroll_operator", "PAY-1")
+    }),
+    { params: Promise.resolve({ runId: previewBody.run.id }) } as RouteContext<{ runId: string }>
+  );
+  assert.equal(confirmResponse.status, 200, "payroll confirmation should succeed");
+  const confirmBody = (await readJson(confirmResponse)) as {
+    run: { state: string };
+  };
+  assert.equal(confirmBody.run.state, "CONFIRMED");
+
+  assert.deepEqual(getMemoryAuditActions(), [
+    "attendance.recorded",
+    "attendance.approved",
+    "payroll.calculated",
+    "payroll.confirmed"
+  ]);
 }
 
-const employee: Actor = { id: "EMP-1001", role: "employee" };
-const manager: Actor = { id: "MGR-1", role: "manager" };
-const payrollOperator: Actor = { id: "PAY-1", role: "payroll_operator" };
-
-const created = createAttendanceRecord(employee, {
-  employeeId: "EMP-1001",
-  checkInAt: new Date("2026-02-02T09:00:00+09:00"),
-  checkOutAt: new Date("2026-02-02T18:00:00+09:00"),
-  breakMinutes: 60,
-  isHoliday: false
-});
-
-assert.throws(
-  () => approveAttendanceRecord(employee, created.id),
-  /unauthorized approve/,
-  "employee should not approve attendance"
-);
-
-const approved = approveAttendanceRecord(manager, created.id);
-assert.equal(approved.state, "APPROVED");
-
-const preview = previewPayroll(
-  payrollOperator,
-  new Date("2026-02-01T00:00:00+09:00"),
-  new Date("2026-02-28T23:59:59+09:00"),
-  12000
-);
-
-assert.equal(preview.sourceCount, 1);
-assert.deepEqual(preview.totals, { regular: 480, overtime: 0, night: 0, holiday: 0 });
-assert.equal(preview.grossPayKrw, 96000);
-
-assert.deepEqual(
-  auditEvents.map((event) => event.action),
-  ["attendance.recorded", "attendance.approved", "payroll.calculated"]
-);
-
-console.log("e2e-wi0001.test passed");
+run()
+  .then(() => {
+    console.log("e2e-wi0001.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/api/attendance/records/[recordId]/approve/route.ts
+++ b/src/app/api/attendance/records/[recordId]/approve/route.ts
@@ -1,45 +1,28 @@
-import { prisma } from "@/lib/prisma";
+import { approveAttendanceRecord } from "@/features/attendance/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
 import { readActor } from "@/lib/actor";
-import { hasAnyRole } from "@/lib/permissions";
 import { fail, ok } from "@/lib/http";
-import { writeAuditLog } from "@/lib/audit";
 
 type RouteContext = {
   params: Promise<{ recordId: string }>;
 };
 
 export async function POST(request: Request, context: RouteContext) {
-  const actor = await readActor(request);
-  if (!actor || !hasAnyRole(actor, ["admin", "manager"])) {
-    return fail(403, "approval requires admin or manager role");
-  }
-
   const { recordId } = await context.params;
-  const existing = await prisma.attendanceRecord.findUnique({
-    where: { id: recordId }
-  });
-  if (!existing) {
-    return fail(404, "attendance record not found");
+  try {
+    const record = await approveAttendanceRecord(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      recordId
+    );
+    return ok({ record });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
   }
-
-  const record = await prisma.attendanceRecord.update({
-    where: { id: recordId },
-    data: {
-      state: "APPROVED",
-      approvedAt: new Date(),
-      approvedBy: actor.id
-    }
-  });
-
-  await writeAuditLog(prisma, {
-    action: "attendance.approved",
-    entityType: "AttendanceRecord",
-    entityId: record.id,
-    actor,
-    payload: {
-      employeeId: record.employeeId
-    }
-  });
-
-  return ok({ record });
 }

--- a/src/app/api/payroll/runs/[runId]/confirm/route.ts
+++ b/src/app/api/payroll/runs/[runId]/confirm/route.ts
@@ -1,42 +1,28 @@
-import { prisma } from "@/lib/prisma";
+import { confirmPayrollRun } from "@/features/payroll/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
 import { readActor } from "@/lib/actor";
-import { hasAnyRole } from "@/lib/permissions";
 import { fail, ok } from "@/lib/http";
-import { writeAuditLog } from "@/lib/audit";
 
 type RouteContext = {
   params: Promise<{ runId: string }>;
 };
 
 export async function POST(request: Request, context: RouteContext) {
-  const actor = await readActor(request);
-  if (!actor || !hasAnyRole(actor, ["admin", "payroll_operator"])) {
-    return fail(403, "payroll confirm requires admin or payroll_operator role");
-  }
-
   const { runId } = await context.params;
-  const run = await prisma.payrollRun.findUnique({
-    where: { id: runId }
-  });
-  if (!run) {
-    return fail(404, "payroll run not found");
-  }
-
-  const confirmed = await prisma.payrollRun.update({
-    where: { id: runId },
-    data: {
-      state: "CONFIRMED",
-      confirmedAt: new Date(),
-      confirmedBy: actor.id
+  try {
+    const run = await confirmPayrollRun(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      runId
+    );
+    return ok({ run });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
     }
-  });
-
-  await writeAuditLog(prisma, {
-    action: "payroll.confirmed",
-    entityType: "PayrollRun",
-    entityId: confirmed.id,
-    actor
-  });
-
-  return ok({ run: confirmed });
+    throw error;
+  }
 }

--- a/src/app/api/payroll/runs/preview/route.ts
+++ b/src/app/api/payroll/runs/preview/route.ts
@@ -1,17 +1,11 @@
-import { prisma } from "@/lib/prisma";
 import { previewPayrollSchema } from "@/features/payroll/schemas";
+import { previewPayroll } from "@/features/payroll/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
 import { readActor } from "@/lib/actor";
-import { hasAnyRole } from "@/lib/permissions";
 import { fail, ok } from "@/lib/http";
-import { calculateGrossPay, derivePayableMinutes } from "@/lib/payroll-rules";
-import { writeAuditLog } from "@/lib/audit";
 
 export async function POST(request: Request) {
-  const actor = await readActor(request);
-  if (!actor || !hasAnyRole(actor, ["admin", "payroll_operator"])) {
-    return fail(403, "payroll preview requires admin or payroll_operator role");
-  }
-
   let payload: unknown;
   try {
     payload = await request.json();
@@ -24,80 +18,25 @@ export async function POST(request: Request) {
     return fail(400, "invalid payload", parsed.error.flatten());
   }
 
-  const periodStart = new Date(parsed.data.periodStart);
-  const periodEnd = new Date(parsed.data.periodEnd);
-  if (periodEnd <= periodStart) {
-    return fail(400, "periodEnd must be after periodStart");
-  }
-
-  const records = await prisma.attendanceRecord.findMany({
-    where: {
-      state: "APPROVED",
-      checkInAt: {
-        gte: periodStart,
-        lte: periodEnd
+  try {
+    const result = await previewPayroll(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
       },
-      ...(parsed.data.employeeId ? { employeeId: parsed.data.employeeId } : {})
-    },
-    orderBy: { checkInAt: "asc" }
-  });
-
-  let totals = { regular: 0, overtime: 0, night: 0, holiday: 0 };
-  for (const record of records) {
-    if (!record.checkOutAt) {
-      continue;
-    }
-    const splitted = derivePayableMinutes(
-      record.checkInAt,
-      record.checkOutAt,
-      record.breakMinutes,
-      record.isHoliday
+      {
+        periodStart: new Date(parsed.data.periodStart),
+        periodEnd: new Date(parsed.data.periodEnd),
+        employeeId: parsed.data.employeeId,
+        hourlyRateKrw: parsed.data.hourlyRateKrw,
+        multipliers: parsed.data.multipliers
+      }
     );
-    totals = {
-      regular: totals.regular + splitted.regular,
-      overtime: totals.overtime + splitted.overtime,
-      night: totals.night + splitted.night,
-      holiday: totals.holiday + splitted.holiday
-    };
+    return ok(result);
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
   }
-
-  const grossPayKrw = calculateGrossPay(
-    totals,
-    parsed.data.hourlyRateKrw,
-    parsed.data.multipliers
-  );
-
-  const run = await prisma.payrollRun.create({
-    data: {
-      employeeId: parsed.data.employeeId,
-      periodStart,
-      periodEnd,
-      grossPayKrw,
-      sourceRecordCount: records.length
-    }
-  });
-
-  await writeAuditLog(prisma, {
-    action: "payroll.calculated",
-    entityType: "PayrollRun",
-    entityId: run.id,
-    actor,
-    payload: {
-      periodStart: parsed.data.periodStart,
-      periodEnd: parsed.data.periodEnd,
-      employeeId: parsed.data.employeeId,
-      sourceRecordCount: records.length,
-      totals,
-      grossPayKrw
-    }
-  });
-
-  return ok({
-    run,
-    summary: {
-      sourceRecordCount: records.length,
-      totals,
-      grossPayKrw
-    }
-  });
 }

--- a/src/features/attendance/service.ts
+++ b/src/features/attendance/service.ts
@@ -1,0 +1,148 @@
+import type { Actor } from "@/lib/actor";
+import { canMutateAttendance, hasAnyRole } from "@/lib/permissions";
+import type {
+  AttendanceRecordEntity,
+  DataAccess,
+  UpdateAttendanceRecordInput
+} from "@/features/shared/data-access";
+import { ServiceError } from "@/features/shared/service-error";
+
+type CreateAttendanceInput = {
+  employeeId: string;
+  checkInAt: Date;
+  checkOutAt: Date | null;
+  breakMinutes: number;
+  isHoliday: boolean;
+  notes?: string;
+};
+
+type UpdateAttendanceInput = {
+  checkInAt?: Date;
+  checkOutAt?: Date;
+  breakMinutes?: number;
+  isHoliday?: boolean;
+  notes?: string;
+};
+
+type ServiceContext = {
+  actor: Actor | null;
+  dataAccess: DataAccess;
+};
+
+export async function createAttendanceRecord(
+  context: ServiceContext,
+  input: CreateAttendanceInput
+): Promise<AttendanceRecordEntity> {
+  if (!context.actor) {
+    throw new ServiceError(401, "missing or invalid actor context");
+  }
+  if (!canMutateAttendance(context.actor, input.employeeId)) {
+    throw new ServiceError(403, "insufficient permissions");
+  }
+
+  const record = await context.dataAccess.attendance.create({
+    employeeId: input.employeeId,
+    checkInAt: input.checkInAt,
+    checkOutAt: input.checkOutAt,
+    breakMinutes: input.breakMinutes,
+    isHoliday: input.isHoliday,
+    notes: input.notes
+  });
+
+  await context.dataAccess.audit.append({
+    action: "attendance.recorded",
+    entityType: "AttendanceRecord",
+    entityId: record.id,
+    actorRole: context.actor.role,
+    actorId: context.actor.id,
+    payload: {
+      employeeId: record.employeeId
+    }
+  });
+
+  return record;
+}
+
+async function requireEditableRecord(
+  context: ServiceContext,
+  recordId: string
+): Promise<AttendanceRecordEntity> {
+  if (!context.actor) {
+    throw new ServiceError(401, "missing or invalid actor context");
+  }
+
+  const existing = await context.dataAccess.attendance.findById(recordId);
+  if (!existing) {
+    throw new ServiceError(404, "attendance record not found");
+  }
+  if (!canMutateAttendance(context.actor, existing.employeeId)) {
+    throw new ServiceError(403, "insufficient permissions");
+  }
+  if (existing.state === "APPROVED") {
+    throw new ServiceError(409, "approved attendance cannot be edited");
+  }
+
+  return existing;
+}
+
+function toRecordUpdateInput(input: UpdateAttendanceInput): UpdateAttendanceRecordInput {
+  return {
+    checkInAt: input.checkInAt,
+    checkOutAt: input.checkOutAt,
+    breakMinutes: input.breakMinutes,
+    isHoliday: input.isHoliday,
+    notes: input.notes
+  };
+}
+
+export async function updateAttendanceRecord(
+  context: ServiceContext,
+  recordId: string,
+  input: UpdateAttendanceInput
+): Promise<AttendanceRecordEntity> {
+  await requireEditableRecord(context, recordId);
+
+  const record = await context.dataAccess.attendance.update(recordId, toRecordUpdateInput(input));
+  await context.dataAccess.audit.append({
+    action: "attendance.corrected",
+    entityType: "AttendanceRecord",
+    entityId: record.id,
+    actorRole: context.actor!.role,
+    actorId: context.actor!.id,
+    payload: input
+  });
+
+  return record;
+}
+
+export async function approveAttendanceRecord(
+  context: ServiceContext,
+  recordId: string
+): Promise<AttendanceRecordEntity> {
+  if (!context.actor || !hasAnyRole(context.actor, ["admin", "manager"])) {
+    throw new ServiceError(403, "approval requires admin or manager role");
+  }
+
+  const existing = await context.dataAccess.attendance.findById(recordId);
+  if (!existing) {
+    throw new ServiceError(404, "attendance record not found");
+  }
+
+  const record = await context.dataAccess.attendance.update(recordId, {
+    state: "APPROVED",
+    approvedAt: new Date(),
+    approvedBy: context.actor.id
+  });
+  await context.dataAccess.audit.append({
+    action: "attendance.approved",
+    entityType: "AttendanceRecord",
+    entityId: record.id,
+    actorRole: context.actor.role,
+    actorId: context.actor.id,
+    payload: {
+      employeeId: record.employeeId
+    }
+  });
+
+  return record;
+}

--- a/src/features/payroll/service.ts
+++ b/src/features/payroll/service.ts
@@ -1,0 +1,140 @@
+import type { Actor } from "@/lib/actor";
+import { hasAnyRole } from "@/lib/permissions";
+import {
+  calculateGrossPay,
+  derivePayableMinutes,
+  type Multipliers,
+  type PayableMinutes
+} from "@/lib/payroll-rules";
+import type { DataAccess, PayrollRunEntity } from "@/features/shared/data-access";
+import { ServiceError } from "@/features/shared/service-error";
+
+type PreviewPayrollInput = {
+  periodStart: Date;
+  periodEnd: Date;
+  employeeId?: string;
+  hourlyRateKrw: number;
+  multipliers: Multipliers;
+};
+
+type ServiceContext = {
+  actor: Actor | null;
+  dataAccess: DataAccess;
+};
+
+type PreviewPayrollResult = {
+  run: PayrollRunEntity;
+  summary: {
+    sourceRecordCount: number;
+    totals: PayableMinutes;
+    grossPayKrw: number;
+  };
+};
+
+const emptyTotals: PayableMinutes = {
+  regular: 0,
+  overtime: 0,
+  night: 0,
+  holiday: 0
+};
+
+export async function previewPayroll(
+  context: ServiceContext,
+  input: PreviewPayrollInput
+): Promise<PreviewPayrollResult> {
+  if (!context.actor || !hasAnyRole(context.actor, ["admin", "payroll_operator"])) {
+    throw new ServiceError(403, "payroll preview requires admin or payroll_operator role");
+  }
+  if (input.periodEnd <= input.periodStart) {
+    throw new ServiceError(400, "periodEnd must be after periodStart");
+  }
+
+  const records = await context.dataAccess.attendance.listApprovedInPeriod({
+    periodStart: input.periodStart,
+    periodEnd: input.periodEnd,
+    employeeId: input.employeeId
+  });
+
+  let totals = emptyTotals;
+  for (const record of records) {
+    if (!record.checkOutAt) {
+      continue;
+    }
+    const split = derivePayableMinutes(
+      record.checkInAt,
+      record.checkOutAt,
+      record.breakMinutes,
+      record.isHoliday
+    );
+    totals = {
+      regular: totals.regular + split.regular,
+      overtime: totals.overtime + split.overtime,
+      night: totals.night + split.night,
+      holiday: totals.holiday + split.holiday
+    };
+  }
+
+  const grossPayKrw = calculateGrossPay(totals, input.hourlyRateKrw, input.multipliers);
+  const run = await context.dataAccess.payroll.create({
+    employeeId: input.employeeId,
+    periodStart: input.periodStart,
+    periodEnd: input.periodEnd,
+    grossPayKrw,
+    sourceRecordCount: records.length
+  });
+
+  await context.dataAccess.audit.append({
+    action: "payroll.calculated",
+    entityType: "PayrollRun",
+    entityId: run.id,
+    actorRole: context.actor.role,
+    actorId: context.actor.id,
+    payload: {
+      periodStart: input.periodStart.toISOString(),
+      periodEnd: input.periodEnd.toISOString(),
+      employeeId: input.employeeId,
+      sourceRecordCount: records.length,
+      totals,
+      grossPayKrw
+    }
+  });
+
+  return {
+    run,
+    summary: {
+      sourceRecordCount: records.length,
+      totals,
+      grossPayKrw
+    }
+  };
+}
+
+export async function confirmPayrollRun(
+  context: ServiceContext,
+  runId: string
+): Promise<PayrollRunEntity> {
+  if (!context.actor || !hasAnyRole(context.actor, ["admin", "payroll_operator"])) {
+    throw new ServiceError(403, "payroll confirm requires admin or payroll_operator role");
+  }
+
+  const run = await context.dataAccess.payroll.findById(runId);
+  if (!run) {
+    throw new ServiceError(404, "payroll run not found");
+  }
+
+  const confirmed = await context.dataAccess.payroll.update(runId, {
+    state: "CONFIRMED",
+    confirmedAt: new Date(),
+    confirmedBy: context.actor.id
+  });
+
+  await context.dataAccess.audit.append({
+    action: "payroll.confirmed",
+    entityType: "PayrollRun",
+    entityId: confirmed.id,
+    actorRole: context.actor.role,
+    actorId: context.actor.id
+  });
+
+  return confirmed;
+}

--- a/src/features/shared/data-access.ts
+++ b/src/features/shared/data-access.ts
@@ -1,0 +1,101 @@
+export type AttendanceState = "PENDING" | "APPROVED" | "REJECTED";
+export type PayrollState = "PREVIEWED" | "CONFIRMED";
+
+export type AttendanceRecordEntity = {
+  id: string;
+  employeeId: string;
+  checkInAt: Date;
+  checkOutAt: Date | null;
+  breakMinutes: number;
+  isHoliday: boolean;
+  notes: string | null;
+  state: AttendanceState;
+  approvedAt: Date | null;
+  approvedBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type PayrollRunEntity = {
+  id: string;
+  employeeId: string | null;
+  periodStart: Date;
+  periodEnd: Date;
+  state: PayrollState;
+  grossPayKrw: number;
+  sourceRecordCount: number;
+  confirmedAt: Date | null;
+  confirmedBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type CreateAttendanceRecordInput = {
+  employeeId: string;
+  checkInAt: Date;
+  checkOutAt: Date | null;
+  breakMinutes: number;
+  isHoliday: boolean;
+  notes?: string;
+};
+
+export type UpdateAttendanceRecordInput = {
+  checkInAt?: Date;
+  checkOutAt?: Date | null;
+  breakMinutes?: number;
+  isHoliday?: boolean;
+  notes?: string | null;
+  state?: AttendanceState;
+  approvedAt?: Date | null;
+  approvedBy?: string | null;
+};
+
+export type CreatePayrollRunInput = {
+  employeeId?: string;
+  periodStart: Date;
+  periodEnd: Date;
+  grossPayKrw: number;
+  sourceRecordCount: number;
+};
+
+export type UpdatePayrollRunInput = {
+  state?: PayrollState;
+  confirmedAt?: Date | null;
+  confirmedBy?: string | null;
+};
+
+export type AppendAuditLogInput = {
+  action: string;
+  entityType: string;
+  entityId?: string;
+  actorRole: string;
+  actorId?: string;
+  payload?: unknown;
+};
+
+export interface AttendanceStore {
+  create(input: CreateAttendanceRecordInput): Promise<AttendanceRecordEntity>;
+  findById(id: string): Promise<AttendanceRecordEntity | null>;
+  update(id: string, input: UpdateAttendanceRecordInput): Promise<AttendanceRecordEntity>;
+  listApprovedInPeriod(input: {
+    periodStart: Date;
+    periodEnd: Date;
+    employeeId?: string;
+  }): Promise<AttendanceRecordEntity[]>;
+}
+
+export interface PayrollStore {
+  create(input: CreatePayrollRunInput): Promise<PayrollRunEntity>;
+  findById(id: string): Promise<PayrollRunEntity | null>;
+  update(id: string, input: UpdatePayrollRunInput): Promise<PayrollRunEntity>;
+}
+
+export interface AuditStore {
+  append(input: AppendAuditLogInput): Promise<void>;
+}
+
+export type DataAccess = {
+  attendance: AttendanceStore;
+  payroll: PayrollStore;
+  audit: AuditStore;
+};

--- a/src/features/shared/memory-data-access.ts
+++ b/src/features/shared/memory-data-access.ts
@@ -1,0 +1,196 @@
+import type {
+  AppendAuditLogInput,
+  AttendanceRecordEntity,
+  DataAccess,
+  PayrollRunEntity,
+  UpdateAttendanceRecordInput,
+  UpdatePayrollRunInput
+} from "@/features/shared/data-access";
+
+type MemoryState = {
+  sequence: number;
+  attendance: Map<string, AttendanceRecordEntity>;
+  payroll: Map<string, PayrollRunEntity>;
+  audit: Array<AppendAuditLogInput & { createdAt: Date }>;
+};
+
+function createState(): MemoryState {
+  return {
+    sequence: 1,
+    attendance: new Map<string, AttendanceRecordEntity>(),
+    payroll: new Map<string, PayrollRunEntity>(),
+    audit: []
+  };
+}
+
+let state = createState();
+
+function nextId(prefix: string) {
+  const id = `${prefix}-${String(state.sequence).padStart(5, "0")}`;
+  state.sequence += 1;
+  return id;
+}
+
+function cloneDate(value: Date) {
+  return new Date(value.getTime());
+}
+
+function cloneAttendance(entity: AttendanceRecordEntity): AttendanceRecordEntity {
+  return {
+    ...entity,
+    checkInAt: cloneDate(entity.checkInAt),
+    checkOutAt: entity.checkOutAt ? cloneDate(entity.checkOutAt) : null,
+    approvedAt: entity.approvedAt ? cloneDate(entity.approvedAt) : null,
+    createdAt: cloneDate(entity.createdAt),
+    updatedAt: cloneDate(entity.updatedAt)
+  };
+}
+
+function clonePayroll(entity: PayrollRunEntity): PayrollRunEntity {
+  return {
+    ...entity,
+    periodStart: cloneDate(entity.periodStart),
+    periodEnd: cloneDate(entity.periodEnd),
+    confirmedAt: entity.confirmedAt ? cloneDate(entity.confirmedAt) : null,
+    createdAt: cloneDate(entity.createdAt),
+    updatedAt: cloneDate(entity.updatedAt)
+  };
+}
+
+function updateAttendanceEntity(
+  existing: AttendanceRecordEntity,
+  input: UpdateAttendanceRecordInput
+): AttendanceRecordEntity {
+  return {
+    ...existing,
+    checkInAt: input.checkInAt ?? existing.checkInAt,
+    checkOutAt: input.checkOutAt !== undefined ? input.checkOutAt : existing.checkOutAt,
+    breakMinutes: input.breakMinutes ?? existing.breakMinutes,
+    isHoliday: input.isHoliday ?? existing.isHoliday,
+    notes: input.notes !== undefined ? input.notes : existing.notes,
+    state: input.state ?? existing.state,
+    approvedAt: input.approvedAt !== undefined ? input.approvedAt : existing.approvedAt,
+    approvedBy: input.approvedBy !== undefined ? input.approvedBy : existing.approvedBy,
+    updatedAt: new Date()
+  };
+}
+
+function updatePayrollEntity(existing: PayrollRunEntity, input: UpdatePayrollRunInput): PayrollRunEntity {
+  return {
+    ...existing,
+    state: input.state ?? existing.state,
+    confirmedAt: input.confirmedAt !== undefined ? input.confirmedAt : existing.confirmedAt,
+    confirmedBy: input.confirmedBy !== undefined ? input.confirmedBy : existing.confirmedBy,
+    updatedAt: new Date()
+  };
+}
+
+export const memoryDataAccess: DataAccess = {
+  attendance: {
+    async create(input) {
+      const now = new Date();
+      const entity: AttendanceRecordEntity = {
+        id: nextId("AR"),
+        employeeId: input.employeeId,
+        checkInAt: cloneDate(input.checkInAt),
+        checkOutAt: input.checkOutAt ? cloneDate(input.checkOutAt) : null,
+        breakMinutes: input.breakMinutes,
+        isHoliday: input.isHoliday,
+        notes: input.notes ?? null,
+        state: "PENDING",
+        approvedAt: null,
+        approvedBy: null,
+        createdAt: now,
+        updatedAt: now
+      };
+      state.attendance.set(entity.id, entity);
+      return cloneAttendance(entity);
+    },
+
+    async findById(id) {
+      const found = state.attendance.get(id);
+      return found ? cloneAttendance(found) : null;
+    },
+
+    async update(id, input) {
+      const existing = state.attendance.get(id);
+      if (!existing) {
+        throw new Error(`attendance record not found: ${id}`);
+      }
+      const updated = updateAttendanceEntity(existing, input);
+      state.attendance.set(id, updated);
+      return cloneAttendance(updated);
+    },
+
+    async listApprovedInPeriod(input) {
+      const rows: AttendanceRecordEntity[] = [];
+      for (const entity of state.attendance.values()) {
+        if (entity.state !== "APPROVED") {
+          continue;
+        }
+        if (entity.checkInAt < input.periodStart || entity.checkInAt > input.periodEnd) {
+          continue;
+        }
+        if (input.employeeId && entity.employeeId !== input.employeeId) {
+          continue;
+        }
+        rows.push(cloneAttendance(entity));
+      }
+      rows.sort((a, b) => a.checkInAt.getTime() - b.checkInAt.getTime());
+      return rows;
+    }
+  },
+
+  payroll: {
+    async create(input) {
+      const now = new Date();
+      const run: PayrollRunEntity = {
+        id: nextId("PR"),
+        employeeId: input.employeeId ?? null,
+        periodStart: cloneDate(input.periodStart),
+        periodEnd: cloneDate(input.periodEnd),
+        state: "PREVIEWED",
+        grossPayKrw: input.grossPayKrw,
+        sourceRecordCount: input.sourceRecordCount,
+        confirmedAt: null,
+        confirmedBy: null,
+        createdAt: now,
+        updatedAt: now
+      };
+      state.payroll.set(run.id, run);
+      return clonePayroll(run);
+    },
+
+    async findById(id) {
+      const run = state.payroll.get(id);
+      return run ? clonePayroll(run) : null;
+    },
+
+    async update(id, input) {
+      const existing = state.payroll.get(id);
+      if (!existing) {
+        throw new Error(`payroll run not found: ${id}`);
+      }
+      const updated = updatePayrollEntity(existing, input);
+      state.payroll.set(id, updated);
+      return clonePayroll(updated);
+    }
+  },
+
+  audit: {
+    async append(input) {
+      state.audit.push({
+        ...input,
+        createdAt: new Date()
+      });
+    }
+  }
+};
+
+export function resetMemoryDataAccess() {
+  state = createState();
+}
+
+export function getMemoryAuditActions() {
+  return state.audit.map((entry) => entry.action);
+}

--- a/src/features/shared/prisma-data-access.ts
+++ b/src/features/shared/prisma-data-access.ts
@@ -1,0 +1,156 @@
+import { prisma } from "@/lib/prisma";
+import type {
+  AttendanceRecordEntity,
+  AttendanceStore,
+  AuditStore,
+  CreateAttendanceRecordInput,
+  CreatePayrollRunInput,
+  DataAccess,
+  PayrollRunEntity,
+  PayrollStore,
+  UpdateAttendanceRecordInput,
+  UpdatePayrollRunInput
+} from "@/features/shared/data-access";
+
+function toAttendanceEntity(record: {
+  id: string;
+  employeeId: string;
+  checkInAt: Date;
+  checkOutAt: Date | null;
+  breakMinutes: number;
+  isHoliday: boolean;
+  notes: string | null;
+  state: "PENDING" | "APPROVED" | "REJECTED";
+  approvedAt: Date | null;
+  approvedBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): AttendanceRecordEntity {
+  return record;
+}
+
+function toPayrollEntity(record: {
+  id: string;
+  employeeId: string | null;
+  periodStart: Date;
+  periodEnd: Date;
+  state: "PREVIEWED" | "CONFIRMED";
+  grossPayKrw: number;
+  sourceRecordCount: number;
+  confirmedAt: Date | null;
+  confirmedBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): PayrollRunEntity {
+  return record;
+}
+
+const attendance: AttendanceStore = {
+  async create(input: CreateAttendanceRecordInput) {
+    const record = await prisma.attendanceRecord.create({
+      data: {
+        employeeId: input.employeeId,
+        checkInAt: input.checkInAt,
+        checkOutAt: input.checkOutAt,
+        breakMinutes: input.breakMinutes,
+        isHoliday: input.isHoliday,
+        notes: input.notes ?? null
+      }
+    });
+    return toAttendanceEntity(record);
+  },
+
+  async findById(id: string) {
+    const record = await prisma.attendanceRecord.findUnique({
+      where: { id }
+    });
+    return record ? toAttendanceEntity(record) : null;
+  },
+
+  async update(id: string, input: UpdateAttendanceRecordInput) {
+    const record = await prisma.attendanceRecord.update({
+      where: { id },
+      data: {
+        checkInAt: input.checkInAt,
+        checkOutAt: input.checkOutAt,
+        breakMinutes: input.breakMinutes,
+        isHoliday: input.isHoliday,
+        notes: input.notes,
+        state: input.state,
+        approvedAt: input.approvedAt,
+        approvedBy: input.approvedBy
+      }
+    });
+    return toAttendanceEntity(record);
+  },
+
+  async listApprovedInPeriod(input: { periodStart: Date; periodEnd: Date; employeeId?: string }) {
+    const records = await prisma.attendanceRecord.findMany({
+      where: {
+        state: "APPROVED",
+        checkInAt: {
+          gte: input.periodStart,
+          lte: input.periodEnd
+        },
+        ...(input.employeeId ? { employeeId: input.employeeId } : {})
+      },
+      orderBy: { checkInAt: "asc" }
+    });
+    return records.map(toAttendanceEntity);
+  }
+};
+
+const payroll: PayrollStore = {
+  async create(input: CreatePayrollRunInput) {
+    const run = await prisma.payrollRun.create({
+      data: {
+        employeeId: input.employeeId,
+        periodStart: input.periodStart,
+        periodEnd: input.periodEnd,
+        grossPayKrw: input.grossPayKrw,
+        sourceRecordCount: input.sourceRecordCount
+      }
+    });
+    return toPayrollEntity(run);
+  },
+
+  async findById(id: string) {
+    const run = await prisma.payrollRun.findUnique({
+      where: { id }
+    });
+    return run ? toPayrollEntity(run) : null;
+  },
+
+  async update(id: string, input: UpdatePayrollRunInput) {
+    const run = await prisma.payrollRun.update({
+      where: { id },
+      data: {
+        state: input.state,
+        confirmedAt: input.confirmedAt,
+        confirmedBy: input.confirmedBy
+      }
+    });
+    return toPayrollEntity(run);
+  }
+};
+
+const audit: AuditStore = {
+  async append(input) {
+    await prisma.auditLog.create({
+      data: {
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        actorRole: input.actorRole,
+        actorId: input.actorId,
+        payload: input.payload as object | undefined
+      }
+    });
+  }
+};
+
+export const prismaDataAccess: DataAccess = {
+  attendance,
+  payroll,
+  audit
+};

--- a/src/features/shared/runtime-data-access.ts
+++ b/src/features/shared/runtime-data-access.ts
@@ -1,0 +1,11 @@
+import type { DataAccess } from "@/features/shared/data-access";
+import { memoryDataAccess } from "@/features/shared/memory-data-access";
+import { prismaDataAccess } from "@/features/shared/prisma-data-access";
+
+export function getRuntimeDataAccess(): DataAccess {
+  const mode = process.env.FLOWHR_DATA_ACCESS?.toLowerCase();
+  if (mode === "memory") {
+    return memoryDataAccess;
+  }
+  return prismaDataAccess;
+}

--- a/src/features/shared/service-error.ts
+++ b/src/features/shared/service-error.ts
@@ -1,0 +1,15 @@
+export class ServiceError extends Error {
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.name = "ServiceError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export function isServiceError(error: unknown): error is ServiceError {
+  return error instanceof ServiceError;
+}

--- a/src/lib/actor.ts
+++ b/src/lib/actor.ts
@@ -17,14 +17,20 @@ export type Actor = {
 };
 
 function parseRoleFromUser(user: User): ActorRole {
-  const candidates = [
-    user.app_metadata?.role,
+  // Canonical claim for FlowHR: app_metadata.role
+  const canonicalRole = user.app_metadata?.role;
+  if (typeof canonicalRole === "string" && actorRoles.includes(canonicalRole as ActorRole)) {
+    return canonicalRole as ActorRole;
+  }
+
+  // Temporary compatibility fallback for legacy tokens.
+  const legacyCandidates = [
     user.user_metadata?.role,
     user.app_metadata?.user_role,
     user.user_metadata?.user_role
   ];
 
-  for (const candidate of candidates) {
+  for (const candidate of legacyCandidates) {
     if (typeof candidate === "string" && actorRoles.includes(candidate as ActorRole)) {
       return candidate as ActorRole;
     }


### PR DESCRIPTION
## Summary\n- refactor attendance/payroll API routes to use domain services and shared service errors\n- add data-access abstraction with prisma + memory implementations and runtime selection\n- standardize Supabase role resolution around app_metadata.role with legacy fallback\n- replace WI-0001 e2e simulation with actual API-route flow using memory backend\n- document role claim policy and memory test mode\n\n## Validation\n- npm.cmd run typecheck\n- npm.cmd run lint\n- npm.cmd run test\n- npm.cmd run test:integration\n- npm.cmd run test:golden\n- npm.cmd run test:e2e\n