### PR TITLE
ci/docs: enforce FlowHR staging schema isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,14 @@ jobs:
             echo "::error::FLOWHR_STAGING_DIRECT_URL must be a PostgreSQL connection string"
             exit 1
           fi
+          if [[ "$STAGING_DATABASE_URL" != *"schema=staging"* ]]; then
+            echo "::error::FLOWHR_STAGING_DATABASE_URL must include schema=staging to prevent prod schema writes"
+            exit 1
+          fi
+          if [[ "$STAGING_DIRECT_URL" != *"schema=staging"* ]]; then
+            echo "::error::FLOWHR_STAGING_DIRECT_URL must include schema=staging to prevent prod schema writes"
+            exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -202,6 +210,9 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.FLOWHR_STAGING_SERVICE_ROLE_KEY }}
           FLOWHR_DATA_ACCESS: prisma
         run: |
+          npx prisma db execute --url "$DATABASE_URL" --stdin <<'SQL'
+          CREATE SCHEMA IF NOT EXISTS "staging";
+          SQL
           npm run prisma:validate --if-present
           npm run prisma:migrate:deploy --if-present
           npm run test:e2e:prisma --if-present

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -18,7 +18,7 @@ Completed:
 Open gaps:
 
 - Role claim backfill/enforcement apply mode is not yet executed in target project.
-- Staging Prisma integration now requires five staging secrets and separate Supabase project hygiene.
+- Staging Prisma integration now requires five staging secrets and strict `schema=staging` isolation in DB URLs.
 - Leave accrual policy and carry-over settlement remain out of scope.
 
 ## 2) Priority Roadmap

--- a/docs/staging-secrets.md
+++ b/docs/staging-secrets.md
@@ -10,20 +10,21 @@
 
 ## Setup Rule
 
-- Use a dedicated Supabase staging project.
-- Do not reuse production project URL/keys in staging secrets.
+- Use the same FlowHR Supabase project but force `schema=staging` for all staging DB URLs.
+- Never use a URL without `schema=staging` in staging secrets.
 
 ## CLI Update Example
 
 ```bash
-gh secret set FLOWHR_STAGING_DATABASE_URL -b"<session-pooler-url>"
-gh secret set FLOWHR_STAGING_DIRECT_URL -b"<direct-or-reachable-url>"
-gh secret set FLOWHR_STAGING_SUPABASE_URL -b"https://<staging-ref>.supabase.co"
-gh secret set FLOWHR_STAGING_ANON_KEY -b"<staging-anon-key>"
-gh secret set FLOWHR_STAGING_SERVICE_ROLE_KEY -b"<staging-service-role-key>"
+gh secret set FLOWHR_STAGING_DATABASE_URL -b"<session-pooler-url>?schema=staging"
+gh secret set FLOWHR_STAGING_DIRECT_URL -b"<direct-or-reachable-url>?schema=staging"
+gh secret set FLOWHR_STAGING_SUPABASE_URL -b"https://<flowhr-project-ref>.supabase.co"
+gh secret set FLOWHR_STAGING_ANON_KEY -b"<flowhr-anon-key>"
+gh secret set FLOWHR_STAGING_SERVICE_ROLE_KEY -b"<flowhr-service-role-key>"
 ```
 
 ## Verification
 
 - `gh secret list` should include all five names.
+- `FLOWHR_STAGING_DATABASE_URL` and `FLOWHR_STAGING_DIRECT_URL` must include `schema=staging`.
 - On `main` push, `staging-prisma-integration` must run (not skip) and pass.


### PR DESCRIPTION
## Summary
- enforce schema=staging on staging DB secrets in CI validation
- create staging schema before prisma deploy in staging job
- align staging docs to single FlowHR project + schema isolation

## Validation
- python scripts/ci/check_contracts.py
- python scripts/ci/check_golden_fixtures.py
- npm run lint
- npm run typecheck
- npm test
