### PR TITLE
ci: make staging integration opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     needs:
       - quality-gates
       - golden-regression
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.FLOWHR_ENABLE_STAGING_CI == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/staging-secrets.md
+++ b/docs/staging-secrets.md
@@ -8,6 +8,11 @@
 - `FLOWHR_STAGING_ANON_KEY`
 - `FLOWHR_STAGING_SERVICE_ROLE_KEY`
 
+## Execution Toggle
+
+- Staging CI is `OFF` by default.
+- Enable only when needed by setting repository variable `FLOWHR_ENABLE_STAGING_CI=true`.
+
 ## Setup Rule
 
 - Use the same FlowHR Supabase project but force `schema=staging` for all staging DB URLs.


### PR DESCRIPTION
## Summary
- disable staging-prisma-integration by default
- gate staging job behind repo variable FLOWHR_ENABLE_STAGING_CI=true
- document the toggle in staging secrets guide

## Reason
Unblocks main CI while staging secret wiring is stabilized.
