### PR TITLE
docs: sync execution plan with current state

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -1,164 +1,142 @@
-# FlowHR Execution Plan (Priority-Driven)
+﻿# FlowHR Execution Plan (Priority-Driven)
 
 Date: 2026-02-13  
-Goal: Deliver a stable contract-first HRM vertical slice with enforceable QA gates.
+Goal: Keep contract-first delivery speed while preserving merge/release safety for a 1-person operator model.
 
 ## 1) Current Baseline
 
 Completed:
 
-- Governance scaffold (`docs`, `specs`, `contracts`, `qa`, `.github`).
-- Contract templates and CI checks (`check_contracts.py`, `check_golden_fixtures.py`).
-- Initial vertical slice artifacts (`WI-0001`, attendance/payroll contracts and test cases).
-- Branch protection on `main` applied via GitHub API.
-- Agent model document created (`docs/agents.md`).
-- WI-0001 service-layer refactor and route-level e2e gate merged.
-- Canonical Supabase role claim policy documented (`app_metadata.role`).
+- Governance scaffold is in place (`docs`, `specs`, `contracts`, `qa`, `.github`).
+- Branch protection is active on `main` with required checks (`contract-governance`, `quality-gates`, `golden-regression`).
+- PR template, CODEOWNERS, RACI, break-glass, data ownership, and QA gate documents are applied.
+- Contract governance check is hardened to YAML parse + JSON schema + versioning rules.
+- WI-0001 vertical slice is implemented:
+  - attendance record/create/update/approve
+  - payroll preview/confirm
+  - audit logs and memory/prisma e2e coverage
+- WI-0002 leave slice is implemented:
+  - request/update/approve/reject/cancel
+  - leave balance read model
+  - memory/prisma e2e coverage
+- Golden fixtures (`GC-001` to `GC-005`) are validated in CI and executable tests.
+- Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
+- Staging Prisma integration is opt-in (default OFF) with schema isolation guardrails.
 
 Open gaps:
 
-- Role claim backfill/enforcement apply mode is not yet executed in target project.
-- Staging Prisma integration now requires five staging secrets and strict `schema=staging` isolation in DB URLs.
-- Leave accrual policy and carry-over settlement remain out of scope.
+- Leave accrual/carry-over policy engine is not implemented yet.
+- Payroll Phase 2 (deductions/tax/remittance) remains out of scope.
+- Contracts describe published domain events (`*.v1`), but runtime currently persists audit logs only (no event bus adapter yet).
+- Staging integration is disabled by default; continuous validation is not active until explicitly enabled.
 
 ## 2) Priority Roadmap
 
-## P0. Governance Hardening (Immediate)
+## P0. Governance Guardrails (Completed)
 
-Objective: Make policy violations unmergeable.
+Objective: make unsafe changes unmergeable.
 
-Tasks:
+Delivered:
 
-1. Keep single-owner `CODEOWNERS` mapping and document persona-based review rule.
-2. Validate branch protection settings against policy document.
-3. Add README section for contribution flow and PR gate expectations.
+1. Required status checks + branch protection.
+2. Contract/version gate + golden fixture gate.
+3. PR checklist and break-glass policy.
 
-Definition of Done:
+Definition of Done: achieved.
 
-- PR flow works in 1-person mode without policy bypass.
-- Required checks are blocking merges.
-- Team can follow one documented merge flow.
+## P1. Runtime Foundation (Completed)
 
-## P1. Runtime Foundation (Next)
+Objective: executable baseline with repeatable quality checks.
 
-Objective: Create executable app baseline for WI-0001.
+Delivered:
 
-Tasks:
+1. Next.js + Supabase + Prisma runtime.
+2. Migration baseline and route-level API structure.
+3. Test scripts wired to CI.
 
-1. Initialize backend stack (NestJS or Express + TypeScript).
-2. Configure PostgreSQL + Prisma schema/migration baseline.
-3. Add test stack (`jest`, `supertest`, `playwright` skeleton).
-4. Wire CI scripts to actual npm scripts.
+Definition of Done: achieved.
 
-Definition of Done:
+## P2. Attendance -> Payroll Slice (Completed)
 
-- `npm run lint`, `npm run typecheck`, `npm test` all run.
-- Prisma validate + migration smoke works in CI.
-- API server boots locally.
+Objective: validated WI-0001 business path.
 
-## P2. Attendance Domain Implementation
+Delivered:
 
-Objective: Implement attendance contract v1 with auditability.
+1. Attendance create/update/approve APIs.
+2. Payroll preview/confirm APIs.
+3. E2E + golden regression + prisma-backed route tests.
 
-Tasks:
+Definition of Done: achieved.
 
-1. Implement attendance record create/update/approve APIs.
-2. Persist attendance entities and approval transitions.
-3. Emit `attendance.recorded.v1`, `attendance.corrected.v1`, `attendance.approved.v1`.
-4. Add authorization and audit log coverage.
+## P3. Leave Request/Approval Slice (Completed for MVP)
 
-Definition of Done:
+Objective: validated WI-0002 leave lifecycle and auth rules.
 
-- Contract tests pass for attendance flows.
-- Unauthorized actions are blocked and logged.
-- Spec Gate and Code Gate both pass.
+Delivered:
 
-## P3. Payroll Domain Implementation
+1. Leave request lifecycle APIs.
+2. Balance read model behavior.
+3. Audit and authorization assertions in e2e/prisma tests.
 
-Objective: Implement payroll preview from attendance aggregates.
+Definition of Done: achieved for MVP scope.
+
+## P4. Next Hardening Wave (Next)
+
+Objective: close functional/operational gaps before broader rollout.
 
 Tasks:
 
-1. Implement payroll preview and confirm APIs.
-2. Consume approved attendance projection/event data.
-3. Apply SSoT rules (timezone/boundary/rounding/multipliers).
-4. Persist payroll runs/items and emit audit events.
+1. Add explicit event publication adapter (or formally constrain contract semantics to audit-only until event bus exists).
+2. Implement leave accrual/carry-over settlement policy (WI-0003).
+3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path.
+4. Add spec-to-runtime drift check for table names and migration IDs.
+5. Enable staging CI only when needed (`FLOWHR_ENABLE_STAGING_CI=true`) and keep schema isolation checks green.
 
 Definition of Done:
 
-- Deterministic gross-pay results from same input.
-- Recalculation path works for corrections.
-- QA checks pass for accuracy and authorization.
-
-## P4. End-to-End Vertical Slice Validation
-
-Objective: Validate `attendance -> aggregation -> payroll` as one releasable path.
-
-Tasks:
-
-1. Implement golden regression execution against fixtures.
-2. Add integration test for WI-0001 full path.
-3. Add release checklist with rollback steps.
-4. Create release candidate PR and run full gates.
-
-Definition of Done:
-
-- Golden regression passes in CI.
-- WI-0001 integration test passes.
-- Merge approved without policy bypass.
-
-## P5. Leave and Identity Hardening (Current)
-
-Objective: Prepare next domain slice and tighten auth/runtime operations.
-
-Tasks:
-
-1. Add WI-0002 leave request/approval contract-first artifacts.
-2. Implement WI-0002 leave runtime API/service/store with audit traces.
-3. Add role-claim backfill/enforcement script for Supabase users.
-4. Add staging Prisma-backed route integration job in CI.
-
-Definition of Done:
-
-- WI-0002 work item + leave contract/API/DB/test-case docs exist.
-- Leave API route e2e passes for memory and Prisma-backed modes.
-- `app_metadata.role` governance can be dry-run/applied/enforced by script.
-- Main-branch push can run Prisma integration test when staging secrets exist.
+- Event/audit semantics are unambiguous in contracts and code.
+- WI-0003 contract + tests are merged.
+- Phase 2 payroll contracts are approved with compatibility strategy.
+- Drift check blocks mismatched docs/spec/runtime identifiers.
 
 ## 3) Workstream Ownership
 
 | Priority | Owner | Primary Outputs |
 | --- | --- | --- |
-| P0 | Orchestrator + QA | CODEOWNERS, branch policy validation |
-| P1 | Orchestrator + Domain Agents | app scaffold, Prisma, test wiring |
-| P2 | Attendance Agent | attendance APIs/events/tests |
-| P3 | Payroll Agent | payroll APIs/calculators/tests |
-| P4 | QA Agent + Orchestrator | E2E regression proof and release gate |
+| P0 | Orchestrator + QA | merge policy, quality gates, branch controls |
+| P1 | Orchestrator + Domain Agents | runtime stack, migrations, test wiring |
+| P2 | Attendance + Payroll Agents | WI-0001 APIs, rules, regression coverage |
+| P3 | Leave Agent + QA | WI-0002 lifecycle and authorization validation |
+| P4 | Orchestrator + Domain + QA | event semantics, WI-0003, phase-2 contracts |
 
 ## 4) Execution Style (No-Lazy Rule)
 
 Principle:
 
-- Agent executes directly whenever permissions and inputs are sufficient.
-- Agent asks only for missing facts that cannot be inferred safely.
-- Every ask is a one-line unblocker.
+- Execute directly when inputs and permissions are sufficient.
+- Ask only for unknowns that cannot be inferred safely.
+- Every unblock request is one clear line.
 
 Request template:
 
 - "X 값을 주시면 제가 Y를 바로 적용하겠습니다."
 
-## 5) Minimal Inputs Needed From You
+## 5) Inputs Needed From You (Conditional)
 
-1. Supabase keys  
-Format: `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+1. To enable staging CI:
+   - Repository variable: `FLOWHR_ENABLE_STAGING_CI=true`
+   - Five `FLOWHR_STAGING_*` secrets
 
-2. Database password fill-in  
-Format: replace `YOUR-PASSWORD` in `.env.local` for `DATABASE_URL` and `DIRECT_URL`
+2. To proceed with payroll Phase 2:
+   - Policy decisions for deductions/tax scope and rollout boundary
 
-## 6) Immediate Next Actions After Inputs
+3. To proceed with leave accrual engine:
+   - Accrual/carry-over policy defaults (or explicit placeholder policy approval)
 
-Once you provide the 2 inputs above, I will directly:
+## 6) Immediate Next Actions
 
-1. keep governance in single-operator persona mode,
-2. run first Prisma migration and generate client,
-3. implement WI-0001 API skeleton with tests wired to CI.
+Without additional input, the next executable step is:
+
+1. create WI-0003 (leave accrual/carry-over) contract/test-case artifacts,
+2. add event publication adapter interface (no-op default, contract-visible),
+3. add drift check for spec/work-item/prisma naming consistency in CI.


### PR DESCRIPTION
## Summary
- refresh docs/execution-plan.md to match current repo/CI/runtime state
- mark completed phases (P0~P3 MVP) and redefine next hardening wave (P4)
- remove stale input assumptions and add conditional inputs for staging/phase2/accrual
