### PR TITLE
feat: add domain event publication adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ DIRECT_URL=postgresql://postgres:YOUR-PASSWORD@db.zjritguxyfdzzxuwcizv.supabase.
 
 # Optional: set "memory" for API route tests without DB
 FLOWHR_DATA_ACCESS=prisma
+
+# Optional: event publication adapter mode (noop|memory)
+FLOWHR_EVENT_PUBLISHER=noop

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Use Supabase CLI for schema sync/inspection while Prisma remains the app ORM and
 - For API route tests without database, set `FLOWHR_DATA_ACCESS=memory`.
 - For Prisma-backed route smoke test, run `npm run test:e2e:prisma` with DB env set.
 
+## Domain Event Publication Adapter
+
+- Service layer emits contract event names (`*.v1`) through `DomainEventPublisher`.
+- Default runtime publisher is no-op (`FLOWHR_EVENT_PUBLISHER` unset or `noop`).
+- For local verification, set `FLOWHR_EVENT_PUBLISHER=memory`.
+- Current adapter is in-process only (no external event bus transport yet).
+
 ## Role Claim Governance
 
 - Canonical role claim: `app_metadata.role` (`docs/role-claims.md`).

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -27,7 +27,7 @@ Open gaps:
 
 - Leave accrual/carry-over policy engine is not implemented yet.
 - Payroll Phase 2 (deductions/tax/remittance) remains out of scope.
-- Contracts describe published domain events (`*.v1`), but runtime currently persists audit logs only (no event bus adapter yet).
+- Domain event publication adapter exists (`noop`/`memory`), but external transport integration is not implemented yet.
 - Staging integration is disabled by default; continuous validation is not active until explicitly enabled.
 
 ## 2) Priority Roadmap
@@ -86,7 +86,7 @@ Objective: close functional/operational gaps before broader rollout.
 
 Tasks:
 
-1. Add explicit event publication adapter (or formally constrain contract semantics to audit-only until event bus exists).
+1. Add external transport adapter for domain events (current implementation is in-process `noop`/`memory` only).
 2. Implement leave accrual/carry-over settlement policy (WI-0003).
 3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path.
 4. Add spec-to-runtime drift check for table names and migration IDs.
@@ -138,5 +138,5 @@ Request template:
 Without additional input, the next executable step is:
 
 1. create WI-0003 (leave accrual/carry-over) contract/test-case artifacts,
-2. add event publication adapter interface (no-op default, contract-visible),
-3. add drift check for spec/work-item/prisma naming consistency in CI.
+2. add drift check for spec/work-item/prisma naming consistency in CI,
+3. define external domain-event transport rollout plan and fallback policy.

--- a/scripts/tests/e2e-wi0001.test.ts
+++ b/scripts/tests/e2e-wi0001.test.ts
@@ -8,6 +8,7 @@ runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
 runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
 runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
 
 type JsonPayload = Record<string, unknown>;
 
@@ -39,6 +40,9 @@ async function run() {
   const { resetMemoryDataAccess, getMemoryAuditActions } = await import(
     "../../src/features/shared/memory-data-access.ts"
   );
+  const { resetRuntimeMemoryDomainEvents, getRuntimeMemoryDomainEvents } = await import(
+    "../../src/features/shared/runtime-domain-event-publisher.ts"
+  );
   const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
   const attendanceApproveRoute = await import(
     "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
@@ -49,6 +53,7 @@ async function run() {
   );
 
   resetMemoryDataAccess();
+  resetRuntimeMemoryDomainEvents();
 
   const createResponse = await attendanceCreateRoute.POST(
     jsonRequest(
@@ -149,6 +154,15 @@ async function run() {
     "payroll.calculated",
     "payroll.confirmed"
   ]);
+  assert.deepEqual(
+    getRuntimeMemoryDomainEvents().map((event) => event.name),
+    [
+      "attendance.recorded.v1",
+      "attendance.approved.v1",
+      "payroll.calculated.v1",
+      "payroll.confirmed.v1"
+    ]
+  );
 }
 
 run()

--- a/src/features/shared/domain-event-publisher.ts
+++ b/src/features/shared/domain-event-publisher.ts
@@ -1,0 +1,61 @@
+export const domainEventNames = [
+  "attendance.recorded.v1",
+  "attendance.corrected.v1",
+  "attendance.approved.v1",
+  "payroll.calculated.v1",
+  "payroll.confirmed.v1",
+  "leave.requested.v1",
+  "leave.approved.v1",
+  "leave.rejected.v1",
+  "leave.canceled.v1"
+] as const;
+
+export type DomainEventName = (typeof domainEventNames)[number];
+
+export type DomainEvent = {
+  name: DomainEventName;
+  occurredAt: string;
+  entityType: string;
+  entityId?: string;
+  actorId?: string;
+  actorRole?: string;
+  payload?: Record<string, unknown>;
+};
+
+export interface DomainEventPublisher {
+  publish(event: DomainEvent): Promise<void>;
+}
+
+class NoOpDomainEventPublisher implements DomainEventPublisher {
+  async publish(_event: DomainEvent): Promise<void> {
+    void _event;
+    return;
+  }
+}
+
+export const noOpDomainEventPublisher: DomainEventPublisher = new NoOpDomainEventPublisher();
+
+export interface MemoryDomainEventPublisher extends DomainEventPublisher {
+  list(): DomainEvent[];
+  reset(): void;
+}
+
+class InMemoryDomainEventPublisher implements MemoryDomainEventPublisher {
+  private readonly events: DomainEvent[] = [];
+
+  async publish(event: DomainEvent): Promise<void> {
+    this.events.push({ ...event });
+  }
+
+  list(): DomainEvent[] {
+    return this.events.map((event) => ({ ...event }));
+  }
+
+  reset(): void {
+    this.events.length = 0;
+  }
+}
+
+export function createMemoryDomainEventPublisher(): MemoryDomainEventPublisher {
+  return new InMemoryDomainEventPublisher();
+}

--- a/src/features/shared/runtime-domain-event-publisher.ts
+++ b/src/features/shared/runtime-domain-event-publisher.ts
@@ -1,0 +1,23 @@
+import {
+  createMemoryDomainEventPublisher,
+  noOpDomainEventPublisher,
+  type DomainEventPublisher
+} from "@/features/shared/domain-event-publisher";
+
+const memoryDomainEventPublisher = createMemoryDomainEventPublisher();
+
+export function getRuntimeDomainEventPublisher(): DomainEventPublisher {
+  const mode = process.env.FLOWHR_EVENT_PUBLISHER?.toLowerCase();
+  if (mode === "memory") {
+    return memoryDomainEventPublisher;
+  }
+  return noOpDomainEventPublisher;
+}
+
+export function resetRuntimeMemoryDomainEvents() {
+  memoryDomainEventPublisher.reset();
+}
+
+export function getRuntimeMemoryDomainEvents() {
+  return memoryDomainEventPublisher.list();
+}


### PR DESCRIPTION
## Summary
- add DomainEventPublisher contract with runtime adapters (
oop, memory)
- wire attendance/payroll/leave services to publish contract event names (*.v1)
- keep runtime default non-breaking via no-op publisher
- add memory-mode event assertions to WI-0001/WI-0002 e2e tests
- document adapter mode in README/.env.example and sync execution-plan wording

## Validation
- python scripts/ci/check_contracts.py
- python scripts/ci/check_golden_fixtures.py
- npm run lint
- npm run typecheck
- npm test
- npm run test:integration
- npm run test:e2e
- npm run test:golden
- npm run test:e2e:prisma
- npm run build
