### PR TITLE
feat(leave): implement WI-0003 accrual/carry-over settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ Details: `docs/staging-secrets.md`
   - `POST /api/leave/requests/{requestId}/reject`
   - `POST /api/leave/requests/{requestId}/cancel`
   - `GET /api/leave/balances/{employeeId}`
+  - `POST /api/leave/accrual/settle`

--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -15,7 +15,7 @@ Exception:
 | --- | --- | --- | --- |
 | Attendance | `AttendanceRecord` | `attendance.recorded.v1`, `attendance.corrected.v1`, `attendance.approved.v1` | Own tables, event projections |
 | Payroll | `PayrollRun` | `payroll.calculated.v1`, `payroll.confirmed.v1` | Own tables, attendance projections only |
-| Leave | `LeaveRequest`, `LeaveApproval`, `LeaveBalanceProjection` | `leave.requested.v1`, `leave.approved.v1`, `leave.rejected.v1`, `leave.canceled.v1` | Own tables, attendance/payroll read-model only |
+| Leave | `LeaveRequest`, `LeaveApproval`, `LeaveBalanceProjection` | `leave.requested.v1`, `leave.approved.v1`, `leave.rejected.v1`, `leave.canceled.v1`, `leave.accrual.settled.v1` | Own tables, attendance/payroll read-model only |
 | Platform (Shared) | `AuditLog` | none | Read-only for operations and audits |
 | Orchestrator (Process) | none (artifact-driven process) | `workitem.assigned` | Aggregated operational projections |
 | QA | none (artifact-driven process) | `qa.gate.passed`, `qa.gate.failed` | All projection datasets for validation only |

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -19,13 +19,16 @@ Completed:
   - request/update/approve/reject/cancel
   - leave balance read model
   - memory/prisma e2e coverage
+- WI-0003 leave accrual/carry-over settlement is implemented:
+  - accrual settlement API and duplicate-year guard
+  - carry-over policy fields and migration
+  - memory/prisma e2e coverage
 - Golden fixtures (`GC-001` to `GC-005`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is opt-in (default OFF) with schema isolation guardrails.
 
 Open gaps:
 
-- Leave accrual/carry-over policy engine is not implemented yet.
 - Payroll Phase 2 (deductions/tax/remittance) remains out of scope.
 - Domain event publication adapter exists (`noop`/`memory`), but external transport integration is not implemented yet.
 - Staging integration is disabled by default; continuous validation is not active until explicitly enabled.
@@ -87,7 +90,7 @@ Objective: close functional/operational gaps before broader rollout.
 Tasks:
 
 1. Add external transport adapter for domain events (current implementation is in-process `noop`/`memory` only).
-2. Implement leave accrual/carry-over settlement policy (WI-0003).
+2. Implement leave accrual/carry-over settlement policy (WI-0003). (Completed: 2026-02-13)
 3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path.
 4. Add spec-to-runtime drift check for table names and migration IDs. (Completed: 2026-02-13)
 5. Enable staging CI only when needed (`FLOWHR_ENABLE_STAGING_CI=true`) and keep schema isolation checks green.
@@ -130,13 +133,10 @@ Request template:
 2. To proceed with payroll Phase 2:
    - Policy decisions for deductions/tax scope and rollout boundary
 
-3. To proceed with leave accrual engine:
-   - Accrual/carry-over policy defaults (or explicit placeholder policy approval)
-
 ## 6) Immediate Next Actions
 
 Without additional input, the next executable step is:
 
-1. create WI-0003 (leave accrual/carry-over) contract/test-case artifacts,
-2. add drift check for spec/work-item/prisma naming consistency in CI,
-3. define external domain-event transport rollout plan and fallback policy.
+1. define external domain-event transport rollout plan and fallback policy,
+2. create payroll Phase 2 (deductions/tax) contract artifacts and compatibility matrix,
+3. enable staging CI with guarded secrets when staging DB is ready.

--- a/prisma/migrations/202602140002_wi0003_leave_accrual/migration.sql
+++ b/prisma/migrations/202602140002_wi0003_leave_accrual/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "LeaveBalanceProjection"
+  ADD COLUMN IF NOT EXISTS "carryOverDays" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "LeaveBalanceProjection"
+  ADD COLUMN IF NOT EXISTS "lastAccrualYear" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,11 +60,13 @@ model LeaveApproval {
 }
 
 model LeaveBalanceProjection {
-  employeeId   String   @id
-  grantedDays  Int      @default(15)
-  usedDays     Int      @default(0)
-  remainingDays Int     @default(15)
-  updatedAt    DateTime @updatedAt
+  employeeId      String   @id
+  grantedDays     Int      @default(15)
+  usedDays        Int      @default(0)
+  remainingDays   Int      @default(15)
+  carryOverDays   Int      @default(0)
+  lastAccrualYear Int?
+  updatedAt       DateTime @updatedAt
 }
 
 model PayrollRun {

--- a/qa/risk-matrix.md
+++ b/qa/risk-matrix.md
@@ -14,6 +14,7 @@
 - Attendance record created/updated/deleted.
 - Approval actions (submit/approve/reject/cancel).
 - Payroll calculation executed/confirmed.
+- Leave accrual settlement applied/rejected.
 - Authorization and role change actions.
 
 ## Payroll and Timekeeping Risks
@@ -22,6 +23,7 @@
 - Overtime, night, holiday multipliers.
 - Rounding effects on payable amount.
 - Retroactive correction and recalculation.
+- Leave carry-over cap misapplication and duplicate-year settlement.
 
 ## Migration Safety Risks
 

--- a/specs/common/time-and-payroll-rules.md
+++ b/specs/common/time-and-payroll-rules.md
@@ -39,6 +39,14 @@ This document is the shared source of truth for attendance-to-payroll calculatio
   - first 480 minutes => holiday multiplier
   - beyond 480 minutes => holiday * overtime combined multiplier
 
+## WI-0003 Leave Accrual Rules
+
+- Yearly accrual settlement actor: `admin` or `payroll_operator`.
+- Default annual grant: `15` days.
+- Default carry-over cap: `5` days.
+- Carry-over formula: `min(max(remainingDays, 0), carryOverCapDays)`.
+- Duplicate settlement for same employee/year is rejected.
+
 ## Calculation Priority
 
 1. Validate attendance record state (approved vs pending/canceled).

--- a/specs/leave/api.yaml
+++ b/specs/leave/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Leave API
-  version: 1.1.0
+  version: 1.2.0
 paths:
   /leave/requests:
     post:
@@ -69,3 +69,9 @@ paths:
       responses:
         "200":
           description: Leave balance snapshot
+  /leave/accrual/settle:
+    post:
+      summary: Settle annual leave accrual and carry-over
+      responses:
+        "200":
+          description: Accrual settled

--- a/specs/leave/contract.yaml
+++ b/specs/leave/contract.yaml
@@ -1,12 +1,12 @@
-owner: attendance-agent
-version: 1.1.0
+owner: leave-agent
+version: 1.2.0
 scope:
   in:
     - leave request create/update/cancel flow
     - leave approve/reject flow with audit trace
     - leave balance read model contract
+    - annual leave accrual and carry-over settlement
   out:
-    - leave accrual and carry-over settlement
     - external calendar synchronization
 entities:
   - name: LeaveRequest
@@ -14,13 +14,15 @@ entities:
   - name: LeaveApproval
     description: Approval or rejection decision record with actor and reason.
   - name: LeaveBalanceProjection
-    description: Read model of granted, used, and remaining leave days.
+    description: Read model of granted, used, remaining, and carry-over leave days.
 api:
   auth:
     - role: employee
       permission: create/update own pending leave request
     - role: manager
       permission: approve or reject leave requests within scope
+    - role: payroll_operator
+      permission: settle leave accrual cycle and read leave balances
     - role: admin
       permission: full leave operations
   endpoints:
@@ -42,6 +44,9 @@ api:
     - method: GET
       path: /leave/balances/{employeeId}
       description: Retrieve leave balance snapshot.
+    - method: POST
+      path: /leave/accrual/settle
+      description: Settle annual leave accrual and carry-over for an employee.
   events:
     published:
       - name: leave.requested.v1
@@ -52,6 +57,8 @@ api:
         description: Emitted when leave request is rejected.
       - name: leave.canceled.v1
         description: Emitted when pending leave is canceled.
+      - name: leave.accrual.settled.v1
+        description: Emitted when annual accrual settlement is applied.
     consumed:
       - name: employee.profile.updated.v1
         description: Employee org/profile metadata updates.
@@ -59,59 +66,73 @@ db_changes:
   migrations:
     - id: 202602140001_wi0002_leave_base
       description: Create leave requests, approvals, and balance projection tables.
+    - id: 202602140002_wi0003_leave_accrual
+      description: Add carry-over and accrual settlement trace fields to LeaveBalanceProjection.
   backward_compatible: true
-  notes: Additive columns only in initial leave rollout.
+  notes: Additive schema change. Existing balance rows default carry-over to 0.
 invariants:
   - Final leave decisions are immutable and auditable.
   - Employee can mutate only own pending request.
   - Approved leave state is consumable for attendance/payroll downstream.
+  - Same employee/year accrual settlement cannot be applied more than once.
+  - Carry-over days are capped by policy and never negative.
 risk:
   permissions:
-    - Unauthorized approval can alter payroll and staffing plans.
+    - Unauthorized approval or accrual settlement can alter payroll and staffing plans.
   payroll_accuracy:
-    - Paid leave misclassification can distort gross-pay totals.
+    - Paid leave misclassification or incorrect carry-over cap can distort gross-pay totals.
   legal:
     - Leave decision history must be retained for dispute/audit handling.
 test_plan:
   unit:
     - leave state transition guard validation
     - leave date normalization by Asia/Seoul
+    - accrual settlement carry-over cap calculation
   integration:
     - create/update/approve leave flow
     - reject flow with reason and audit
+    - accrual settlement with duplicate-year protection
   regression:
     - overlap detection and boundary-date regressions
+    - leave balance continuity after yearly settlement
   authorization:
     - employee self-service boundary check
     - manager/admin approval check
+    - payroll_operator/admin-only accrual settlement check
   payroll_accuracy:
     - approved paid leave classification for payroll consumer compatibility
+    - carry-over cap and yearly reset rules
 observability:
   audit_events:
     - leave.requested
     - leave.approved
     - leave.rejected
     - leave.canceled
+    - leave.accrual_settled
   metrics:
     - leave_approval_latency_ms
     - leave_request_rejection_rate
+    - leave_accrual_settlement_count
   logs:
     - leave authorization denied with actor role
+    - leave accrual duplicate-year rejection logs
 rollout:
   feature_flags:
     - name: leave_request_v1
       default: "off"
     - name: leave_approval_v1
       default: "off"
+    - name: leave_accrual_v1
+      default: "off"
   migration_strategy: expand-contract
 rollback:
-  strategy: disable leave flags and route to manual approval process
+  strategy: disable leave flags and route accrual settlement to manual operations
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "WI-0002 implementation adds cancel endpoint and leave balance projection behavior."
+consumer_impact: "WI-0003 adds accrual settlement endpoint and leave balance fields without breaking existing consumers."
 references:
   - specs/common/time-and-payroll-rules.md
 approval:
-  spec_owner: attendance-agent
+  spec_owner: leave-agent
   qa_owner: qa-agent

--- a/specs/leave/db.md
+++ b/specs/leave/db.md
@@ -2,13 +2,19 @@
 
 ## Planned Tables
 
-- `leave_requests`
-- `leave_approvals`
-- `leave_balances_projection`
+- `LeaveRequest`
+- `LeaveApproval`
+- `LeaveBalanceProjection`
 
 ## Migration
 
 - `202602140001_wi0002_leave_base`
+- `202602140002_wi0003_leave_accrual`
+
+## WI-0003 Additive Columns
+
+- `LeaveBalanceProjection.carryOverDays` (int, default 0)
+- `LeaveBalanceProjection.lastAccrualYear` (int, nullable)
 
 ## Compatibility
 

--- a/specs/leave/rfc.md
+++ b/specs/leave/rfc.md
@@ -1,17 +1,18 @@
-# Leave RFC (WI-0002)
+# Leave RFC (WI-0002 + WI-0003)
 
 ## Goal
 
-Define contract-first leave request and approval behavior with auditability and downstream compatibility for attendance/payroll.
+Define contract-first leave lifecycle plus yearly accrual settlement behavior with auditability and downstream compatibility for attendance/payroll.
 
 ## Key Decisions
 
 - Request/approval state transitions are explicit and append-only in audit trail.
 - Authorization is role-gated with self-service boundary for employees.
 - Approved leave events are published for attendance/payroll consumers.
+- Yearly accrual settlement applies carry-over cap and blocks duplicate-year settlement.
 
 ## Non-Goals
 
-- Leave accrual settlement engine.
 - External calendar synchronization.
 - Country-specific leave law expansions beyond KR baseline.
+- Automatic batch scheduling for accrual settlement.

--- a/specs/leave/test-cases.md
+++ b/specs/leave/test-cases.md
@@ -11,6 +11,7 @@ Leave request lifecycle, role authorization, and approved leave output compatibi
 3. Manager approves request and audit trail is appended.
 4. Manager rejects request with mandatory reason.
 5. Employee cancels pending request and final state is reflected.
+6. Payroll operator settles yearly leave accrual for employee.
 
 ## Boundary and Accuracy Cases
 
@@ -18,13 +19,16 @@ Leave request lifecycle, role authorization, and approved leave output compatibi
 2. Multi-day leave request spanning month boundary.
 3. Overlapping leave requests for same employee are rejected.
 4. Rejected/canceled requests are excluded from payable-time consumers.
+5. Carry-over uses `min(max(remainingDays, 0), carryOverCapDays)`.
+6. Same employee/year accrual settlement is rejected as duplicate.
 
 ## Regression Linkage
 
 - Future fixtures will be added under `qa/golden/fixtures` for leave+attendance impacts.
 - Existing payroll fixtures must remain unaffected by leave contract introduction.
+- Leave balance continuity must remain valid after yearly settlement.
 
 ## QA Gate Expectations
 
 - Spec Gate: leave contract completeness, role matrix, and invariant checks.
-- Code Gate: unit/integration tests, authorization tests, and audit log assertions.
+- Code Gate: unit/integration tests, authorization tests, audit log, and settlement idempotency assertions.

--- a/src/app/api/leave/accrual/settle/route.ts
+++ b/src/app/api/leave/accrual/settle/route.ts
@@ -1,0 +1,36 @@
+import { settleLeaveAccrualSchema } from "@/features/leave/schemas";
+import { settleLeaveAccrual } from "@/features/leave/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
+import { readActor } from "@/lib/actor";
+import { fail, ok } from "@/lib/http";
+
+export async function POST(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return fail(400, "invalid JSON body");
+  }
+
+  const parsed = settleLeaveAccrualSchema.safeParse(payload);
+  if (!parsed.success) {
+    return fail(400, "invalid payload", parsed.error.flatten());
+  }
+
+  try {
+    const balance = await settleLeaveAccrual(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      parsed.data
+    );
+    return ok({ balance });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
+}

--- a/src/features/leave/schemas.ts
+++ b/src/features/leave/schemas.ts
@@ -27,3 +27,10 @@ export const rejectLeaveRequestSchema = z.object({
 export const cancelLeaveRequestSchema = z.object({
   reason: z.string().min(1).max(1000).optional()
 });
+
+export const settleLeaveAccrualSchema = z.object({
+  employeeId: z.string().min(1),
+  year: z.number().int().min(2000).max(9999),
+  annualGrantDays: z.number().int().positive().optional(),
+  carryOverCapDays: z.number().int().min(0).optional()
+});

--- a/src/features/shared/data-access.ts
+++ b/src/features/shared/data-access.ts
@@ -58,6 +58,8 @@ export type LeaveBalanceEntity = {
   grantedDays: number;
   usedDays: number;
   remainingDays: number;
+  carryOverDays: number;
+  lastAccrualYear: number | null;
   updatedAt: Date;
 };
 
@@ -172,6 +174,13 @@ export interface LeaveBalanceStore {
   applyUsage(input: {
     employeeId: string;
     usedDaysDelta: number;
+    defaultGrantedDays: number;
+  }): Promise<LeaveBalanceEntity>;
+  settleAccrual(input: {
+    employeeId: string;
+    year: number;
+    annualGrantDays: number;
+    carryOverCapDays: number;
     defaultGrantedDays: number;
   }): Promise<LeaveBalanceEntity>;
 }

--- a/src/features/shared/domain-event-publisher.ts
+++ b/src/features/shared/domain-event-publisher.ts
@@ -7,7 +7,8 @@ export const domainEventNames = [
   "leave.requested.v1",
   "leave.approved.v1",
   "leave.rejected.v1",
-  "leave.canceled.v1"
+  "leave.canceled.v1",
+  "leave.accrual.settled.v1"
 ] as const;
 
 export type DomainEventName = (typeof domainEventNames)[number];

--- a/src/features/shared/memory-data-access.ts
+++ b/src/features/shared/memory-data-access.ts
@@ -282,6 +282,8 @@ export const memoryDataAccess: DataAccess = {
         grantedDays: defaultGrantedDays,
         usedDays: 0,
         remainingDays: defaultGrantedDays,
+        carryOverDays: 0,
+        lastAccrualYear: null,
         updatedAt: now
       };
       state.leaveBalances.set(employeeId, created);
@@ -294,6 +296,24 @@ export const memoryDataAccess: DataAccess = {
         ...current,
         usedDays: current.usedDays + input.usedDaysDelta,
         remainingDays: current.grantedDays - (current.usedDays + input.usedDaysDelta),
+        updatedAt: new Date()
+      };
+      state.leaveBalances.set(input.employeeId, next);
+      return cloneLeaveBalance(next);
+    },
+
+    async settleAccrual(input) {
+      const current = await this.ensure(input.employeeId, input.defaultGrantedDays);
+      const carryOverDays = Math.min(input.carryOverCapDays, Math.max(0, current.remainingDays));
+      const grantedDays = input.annualGrantDays + carryOverDays;
+
+      const next: LeaveBalanceEntity = {
+        ...current,
+        grantedDays,
+        usedDays: 0,
+        remainingDays: grantedDays,
+        carryOverDays,
+        lastAccrualYear: input.year,
         updatedAt: new Date()
       };
       state.leaveBalances.set(input.employeeId, next);

--- a/work-items/WI-0003-leave-accrual-carryover.md
+++ b/work-items/WI-0003-leave-accrual-carryover.md
@@ -1,0 +1,109 @@
+# WI-0003: Leave Accrual and Carry-Over Settlement
+
+## Background and Problem
+
+FlowHR currently supports leave request lifecycle but does not provide yearly accrual/carry-over settlement.
+Without settlement, leave balance resets are manual and error-prone, causing payroll and audit risks.
+
+## Scope
+
+### In Scope
+
+- Annual leave accrual settlement API for a target employee.
+- Carry-over cap rule application and yearly balance reset.
+- Duplicate-year settlement guard.
+- Contract/test artifact updates for leave domain.
+
+### Out of Scope
+
+- Multi-policy accrual by employee grade/tenure.
+- Automatic scheduler/batch orchestration.
+- External calendar/groupware synchronization.
+
+## User Scenarios
+
+1. Payroll operator settles year-end leave for an employee.
+2. System applies carry-over cap and resets used days for new cycle.
+3. Duplicate settlement for the same employee/year is blocked with auditable evidence.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth: `specs/common/time-and-payroll-rules.md`.
+- Carry-over formula: `min(max(remainingDays, 0), carryOverCapDays)`.
+- New cycle granted days: `annualGrantDays + carryOverAppliedDays`.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | Payroll Operator |
+| --- | --- | --- | --- | --- |
+| Settle leave accrual | Allow | Deny | Deny | Allow |
+| Read leave balance | Allow | Allow | Allow (self) | Allow |
+| Approve/reject leave request | Allow | Allow | Deny | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables:
+  - `LeaveBalanceProjection`
+- Migration IDs:
+  - `202602140001_wi0002_leave_base`
+  - `202602140002_wi0003_leave_accrual`
+- Backward compatibility plan:
+  - Additive columns only (carryOverDays, lastAccrualYear) with safe defaults.
+
+## API and Event Changes
+
+- Endpoints:
+  - `POST /leave/accrual/settle`
+- Events published:
+  - `leave.accrual.settled.v1`
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - carry-over cap and yearly grant calculations
+- Integration:
+  - approve leave -> settle accrual flow
+  - duplicate-year settlement rejection
+- Regression:
+  - leave balance continuity for subsequent request cycles
+- Authorization:
+  - admin/payroll operator allow, employee/manager deny
+- Payroll accuracy:
+  - carry-over cap and yearly reset output validation
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `leave.accrual_settled`
+- Metrics:
+  - `leave_accrual_settlement_count`
+  - `leave_accrual_duplicate_reject_count`
+- Alert conditions:
+  - abnormal duplicate settlement reject spikes
+
+## Rollback Plan
+
+- Feature flag behavior:
+  - `leave_accrual_v1` off -> revert to manual settlement operation.
+- DB rollback method:
+  - additive columns remain; stop writes and ignore new fields.
+- Recovery target time:
+  - 30 minutes
+
+## Definition of Ready (DoR)
+
+- [x] Requirements are unambiguous and testable.
+- [x] Domain contract drafted or updated.
+- [x] Role matrix reviewed by QA.
+- [x] Data migration impact assessed.
+- [x] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## 요약
- WI-0003 문서/스펙 추가: work-item, leave contract 1.2.0, API/DB/test-case/rfc 갱신
- LeaveBalanceProjection에 carryOverDays, lastAccrualYear 추가 및 마이그레이션 적용
- leave accrual 정산 서비스/저장소(memory+prisma) 구현
- 신규 API 추가: POST /api/leave/accrual/settle
- e2e(memory/prisma) 시나리오에 정산/중복정산/권한 검증 추가
- data-ownership, risk-matrix, execution-plan, README 동기화

## 검증
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- python scripts/ci/check_golden_fixtures.py
- npm.cmd run prisma:generate
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd test
- npm.cmd run test:integration
- npm.cmd run test:e2e
- npm.cmd run test:golden
- DATABASE_URL/DIRECT_URL 임시값으로 prisma validate 확인