### PR TITLE
feat(events): add external HTTP transport adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,12 @@ DIRECT_URL=postgresql://postgres:YOUR-PASSWORD@db.zjritguxyfdzzxuwcizv.supabase.
 # Optional: set "memory" for API route tests without DB
 FLOWHR_DATA_ACCESS=prisma
 
-# Optional: event publication adapter mode (noop|memory)
+# Optional: event publication adapter mode (noop|memory|http)
 FLOWHR_EVENT_PUBLISHER=noop
+
+# Optional: external HTTP event transport settings (used when FLOWHR_EVENT_PUBLISHER=http)
+FLOWHR_EVENT_HTTP_URL=
+FLOWHR_EVENT_HTTP_TOKEN=
+FLOWHR_EVENT_HTTP_TIMEOUT_MS=3000
+FLOWHR_EVENT_HTTP_RETRY_COUNT=2
+FLOWHR_EVENT_HTTP_FAIL_OPEN=true

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ Use Supabase CLI for schema sync/inspection while Prisma remains the app ORM and
 - Service layer emits contract event names (`*.v1`) through `DomainEventPublisher`.
 - Default runtime publisher is no-op (`FLOWHR_EVENT_PUBLISHER` unset or `noop`).
 - For local verification, set `FLOWHR_EVENT_PUBLISHER=memory`.
-- Current adapter is in-process only (no external event bus transport yet).
+- External HTTP transport mode:
+  - `FLOWHR_EVENT_PUBLISHER=http`
+  - `FLOWHR_EVENT_HTTP_URL=https://...`
+  - optional `FLOWHR_EVENT_HTTP_TOKEN`
+  - optional `FLOWHR_EVENT_HTTP_TIMEOUT_MS` (default `3000`)
+  - optional `FLOWHR_EVENT_HTTP_RETRY_COUNT` (default `2`)
+  - optional `FLOWHR_EVENT_HTTP_FAIL_OPEN` (default `true`)
 
 ## Role Claim Governance
 

--- a/docs/event-transport.md
+++ b/docs/event-transport.md
@@ -1,0 +1,67 @@
+# Domain Event Transport Rollout
+
+## Purpose
+
+FlowHR publishes domain events from service layer.  
+Runtime transport is selected by `FLOWHR_EVENT_PUBLISHER`.
+
+## Modes
+
+- `noop`: drop events (default safe mode)
+- `memory`: keep events in in-process memory (tests/local verification)
+- `http`: POST events to external endpoint
+
+## HTTP Transport Contract
+
+- Method: `POST`
+- Content-Type: `application/json`
+- Header:
+  - `x-flowhr-event-name: <event-name>`
+  - `authorization: Bearer <token>` (optional)
+- Body:
+
+```json
+{
+  "specVersion": "flowhr.domain-event.v1",
+  "event": {
+    "name": "attendance.recorded.v1",
+    "occurredAt": "2026-02-13T00:00:00.000Z",
+    "entityType": "AttendanceRecord"
+  }
+}
+```
+
+## Environment Variables
+
+- `FLOWHR_EVENT_PUBLISHER` = `noop|memory|http`
+- `FLOWHR_EVENT_HTTP_URL` (required for `http`)
+- `FLOWHR_EVENT_HTTP_TOKEN` (optional)
+- `FLOWHR_EVENT_HTTP_TIMEOUT_MS` (optional, default `3000`)
+- `FLOWHR_EVENT_HTTP_RETRY_COUNT` (optional, default `2`)
+- `FLOWHR_EVENT_HTTP_FAIL_OPEN` (optional, default `true`)
+
+## Fallback Policy
+
+- `fail-open=true`:
+  - delivery failure logs error and does not break business API flow
+- `fail-open=false`:
+  - delivery failure throws error and blocks API completion
+
+Recommendation:
+
+- start with `fail-open=true` in initial rollout
+- switch to `fail-open=false` only after receiver SLO and replay path are validated
+
+## Rollout Steps
+
+1. Deploy receiver endpoint in staging.
+2. Set staging env:
+   - `FLOWHR_EVENT_PUBLISHER=http`
+   - `FLOWHR_EVENT_HTTP_URL=<staging-endpoint>`
+   - token/timeout/retry values
+3. Verify:
+   - HTTP 2xx ratio
+   - payload schema compatibility
+   - duplicate/retry handling in receiver
+4. Promote to production with `fail-open=true`.
+5. Tighten policy (`fail-open=false`) only after 안정화.

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -30,7 +30,6 @@ Completed:
 Open gaps:
 
 - Payroll Phase 2 (deductions/tax/remittance) remains out of scope.
-- Domain event publication adapter exists (`noop`/`memory`), but external transport integration is not implemented yet.
 - Staging integration is disabled by default; continuous validation is not active until explicitly enabled.
 
 ## 2) Priority Roadmap
@@ -89,7 +88,7 @@ Objective: close functional/operational gaps before broader rollout.
 
 Tasks:
 
-1. Add external transport adapter for domain events (current implementation is in-process `noop`/`memory` only).
+1. Add external transport adapter for domain events (current implementation is in-process `noop`/`memory` only). (Completed: 2026-02-13)
 2. Implement leave accrual/carry-over settlement policy (WI-0003). (Completed: 2026-02-13)
 3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path.
 4. Add spec-to-runtime drift check for table names and migration IDs. (Completed: 2026-02-13)
@@ -137,6 +136,5 @@ Request template:
 
 Without additional input, the next executable step is:
 
-1. define external domain-event transport rollout plan and fallback policy,
-2. create payroll Phase 2 (deductions/tax) contract artifacts and compatibility matrix,
-3. enable staging CI with guarded secrets when staging DB is ready.
+1. create payroll Phase 2 (deductions/tax) contract artifacts and compatibility matrix,
+2. enable staging CI with guarded secrets when staging DB is ready.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "tsx scripts/tests/unit.test.ts",
-    "test:integration": "tsx scripts/tests/integration.test.ts",
+    "test:integration": "tsx scripts/tests/integration.test.ts && tsx scripts/tests/event-transport-http.test.ts",
     "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts",
     "test:e2e:leave": "tsx scripts/tests/e2e-wi0002-leave.test.ts",
     "test:e2e:prisma": "tsx scripts/tests/e2e-wi0001-prisma.test.ts && tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts",

--- a/scripts/tests/event-transport-http.test.ts
+++ b/scripts/tests/event-transport-http.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import {
+  getRuntimeDomainEventPublisher,
+  resetRuntimeMemoryDomainEvents
+} from "../../src/features/shared/runtime-domain-event-publisher.ts";
+
+const ENV_KEYS = [
+  "FLOWHR_EVENT_PUBLISHER",
+  "FLOWHR_EVENT_HTTP_URL",
+  "FLOWHR_EVENT_HTTP_TOKEN",
+  "FLOWHR_EVENT_HTTP_TIMEOUT_MS",
+  "FLOWHR_EVENT_HTTP_RETRY_COUNT",
+  "FLOWHR_EVENT_HTTP_FAIL_OPEN"
+] as const;
+
+function setEnv(key: (typeof ENV_KEYS)[number], value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
+
+async function run() {
+  const before = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+    (typeof ENV_KEYS)[number],
+    string | undefined
+  >;
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+
+  try {
+    // case 1: http transport success path
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input, init) => {
+      calls.push({ input, init });
+      return new Response(null, { status: 202 });
+    }) as typeof fetch;
+
+    setEnv("FLOWHR_EVENT_PUBLISHER", "http");
+    setEnv("FLOWHR_EVENT_HTTP_URL", "https://events.example.internal/ingest");
+    setEnv("FLOWHR_EVENT_HTTP_TOKEN", "token-123");
+    setEnv("FLOWHR_EVENT_HTTP_TIMEOUT_MS", "1000");
+    setEnv("FLOWHR_EVENT_HTTP_RETRY_COUNT", "0");
+    setEnv("FLOWHR_EVENT_HTTP_FAIL_OPEN", "false");
+    resetRuntimeMemoryDomainEvents();
+
+    await getRuntimeDomainEventPublisher().publish({
+      name: "attendance.recorded.v1",
+      occurredAt: "2026-02-13T00:00:00.000Z",
+      entityType: "AttendanceRecord",
+      entityId: "AR-1",
+      actorRole: "employee",
+      actorId: "EMP-1",
+      payload: { employeeId: "EMP-1" }
+    });
+
+    assert.equal(calls.length, 1, "http transport should send one request");
+    assert.equal(String(calls[0].input), "https://events.example.internal/ingest");
+    assert.equal(calls[0].init?.method, "POST");
+    assert.equal(calls[0].init?.headers instanceof Object, true);
+
+    // case 2: fail-open true should swallow errors
+    globalThis.fetch = (async () => {
+      throw new Error("network failure");
+    }) as typeof fetch;
+
+    setEnv("FLOWHR_EVENT_HTTP_FAIL_OPEN", "true");
+    resetRuntimeMemoryDomainEvents();
+    const failOpenErrors: string[] = [];
+    console.error = ((message?: unknown) => {
+      failOpenErrors.push(String(message ?? ""));
+    }) as typeof console.error;
+    await getRuntimeDomainEventPublisher().publish({
+      name: "payroll.calculated.v1",
+      occurredAt: "2026-02-13T00:00:00.000Z",
+      entityType: "PayrollRun",
+      entityId: "PR-1"
+    });
+    assert.equal(failOpenErrors.length, 1, "fail-open should log one delivery error");
+    assert.match(failOpenErrors[0], /external event transport failed/);
+    console.error = originalConsoleError;
+
+    // case 3: fail-open false should throw
+    setEnv("FLOWHR_EVENT_HTTP_FAIL_OPEN", "false");
+    resetRuntimeMemoryDomainEvents();
+    await assert.rejects(
+      getRuntimeDomainEventPublisher().publish({
+        name: "leave.approved.v1",
+        occurredAt: "2026-02-13T00:00:00.000Z",
+        entityType: "LeaveRequest",
+        entityId: "LR-1"
+      }),
+      /external event transport failed/
+    );
+  } finally {
+    for (const key of ENV_KEYS) {
+      setEnv(key, before[key]);
+    }
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+    resetRuntimeMemoryDomainEvents();
+  }
+}
+
+run()
+  .then(() => {
+    console.log("event-transport-http.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/features/shared/http-domain-event-publisher.ts
+++ b/src/features/shared/http-domain-event-publisher.ts
@@ -1,0 +1,88 @@
+import type { DomainEvent, DomainEventPublisher } from "@/features/shared/domain-event-publisher";
+
+export type HttpDomainEventPublisherOptions = {
+  endpointUrl: string;
+  authToken?: string;
+  timeoutMs: number;
+  retryCount: number;
+  failOpen: boolean;
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function postEvent(
+  options: HttpDomainEventPublisherOptions,
+  event: DomainEvent
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    return await fetch(options.endpointUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(options.authToken ? { authorization: `Bearer ${options.authToken}` } : {}),
+        "x-flowhr-event-name": event.name
+      },
+      body: JSON.stringify({
+        specVersion: "flowhr.domain-event.v1",
+        event
+      }),
+      signal: controller.signal
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export class HttpDomainEventPublisher implements DomainEventPublisher {
+  constructor(private readonly options: HttpDomainEventPublisherOptions) {}
+
+  async publish(event: DomainEvent): Promise<void> {
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt <= this.options.retryCount; attempt += 1) {
+      try {
+        const response = await postEvent(this.options, event);
+        if (!response.ok) {
+          throw new Error(
+            `event transport responded with ${response.status} for ${event.name}`
+          );
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+        const isLastAttempt = attempt === this.options.retryCount;
+        if (isLastAttempt) {
+          break;
+        }
+        await delay(100 * (attempt + 1));
+      }
+    }
+
+    const message = [
+      "external event transport failed",
+      `name=${event.name}`,
+      `entityType=${event.entityType}`,
+      `entityId=${event.entityId ?? "-"}`,
+      `retries=${this.options.retryCount}`,
+      `reason=${lastError instanceof Error ? lastError.message : "unknown"}`
+    ].join(" ");
+
+    if (this.options.failOpen) {
+      console.error(message);
+      return;
+    }
+
+    throw new Error(message);
+  }
+}
+
+export function createHttpDomainEventPublisher(
+  options: HttpDomainEventPublisherOptions
+): DomainEventPublisher {
+  return new HttpDomainEventPublisher(options);
+}

--- a/src/features/shared/runtime-domain-event-publisher.ts
+++ b/src/features/shared/runtime-domain-event-publisher.ts
@@ -1,21 +1,88 @@
-import {
+﻿import {
   createMemoryDomainEventPublisher,
   noOpDomainEventPublisher,
   type DomainEventPublisher
 } from "@/features/shared/domain-event-publisher";
+import { createHttpDomainEventPublisher } from "@/features/shared/http-domain-event-publisher";
 
 const memoryDomainEventPublisher = createMemoryDomainEventPublisher();
+let httpDomainEventPublisher: DomainEventPublisher | null = null;
+let httpDomainEventPublisherKey: string | null = null;
+let warnedMissingHttpEndpoint = false;
+
+function parseNumber(input: string | undefined, fallback: number) {
+  if (!input) {
+    return fallback;
+  }
+  const value = Number(input);
+  if (!Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function parseBoolean(input: string | undefined, fallback: boolean) {
+  if (!input) {
+    return fallback;
+  }
+  const normalized = input.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0" || normalized === "no") {
+    return false;
+  }
+  return fallback;
+}
+
+function getHttpDomainEventPublisher(): DomainEventPublisher {
+  const endpointUrl = process.env.FLOWHR_EVENT_HTTP_URL?.trim();
+  if (!endpointUrl) {
+    if (!warnedMissingHttpEndpoint) {
+      console.warn(
+        "FLOWHR_EVENT_PUBLISHER=http but FLOWHR_EVENT_HTTP_URL is missing. Falling back to noop publisher."
+      );
+      warnedMissingHttpEndpoint = true;
+    }
+    return noOpDomainEventPublisher;
+  }
+
+  const authToken = process.env.FLOWHR_EVENT_HTTP_TOKEN?.trim() || "";
+  const timeoutMs = parseNumber(process.env.FLOWHR_EVENT_HTTP_TIMEOUT_MS, 3000);
+  const retryCount = parseNumber(process.env.FLOWHR_EVENT_HTTP_RETRY_COUNT, 2);
+  const failOpen = parseBoolean(process.env.FLOWHR_EVENT_HTTP_FAIL_OPEN, true);
+  const key = [endpointUrl, authToken, String(timeoutMs), String(retryCount), String(failOpen)].join("|");
+
+  if (!httpDomainEventPublisher || httpDomainEventPublisherKey !== key) {
+    httpDomainEventPublisher = createHttpDomainEventPublisher({
+      endpointUrl,
+      authToken: authToken || undefined,
+      timeoutMs,
+      retryCount,
+      failOpen
+    });
+    httpDomainEventPublisherKey = key;
+  }
+
+  return httpDomainEventPublisher;
+}
 
 export function getRuntimeDomainEventPublisher(): DomainEventPublisher {
   const mode = process.env.FLOWHR_EVENT_PUBLISHER?.toLowerCase();
   if (mode === "memory") {
     return memoryDomainEventPublisher;
   }
+  if (mode === "http") {
+    return getHttpDomainEventPublisher();
+  }
   return noOpDomainEventPublisher;
 }
 
 export function resetRuntimeMemoryDomainEvents() {
   memoryDomainEventPublisher.reset();
+  httpDomainEventPublisher = null;
+  httpDomainEventPublisherKey = null;
+  warnedMissingHttpEndpoint = false;
 }
 
 export function getRuntimeMemoryDomainEvents() {

--- a/work-items/WI-0004-domain-event-http-transport.md
+++ b/work-items/WI-0004-domain-event-http-transport.md
@@ -1,0 +1,103 @@
+﻿# WI-0004: External Domain Event HTTP Transport
+
+## Background and Problem
+
+FlowHR publishes contract events in-process only (`noop`/`memory`) and lacks external delivery path.
+Without external transport, downstream integrations cannot subscribe to operational events in real time.
+
+## Scope
+
+### In Scope
+
+- Runtime transport mode `http` for domain events.
+- Configurable timeout/retry/fail-open policy.
+- Delivery header/body contract documentation.
+- Integration test for transport success/failure behavior.
+
+### Out of Scope
+
+- Kafka/SQS/NATS specific adapters.
+- Consumer-side replay and dead-letter queue implementation.
+- Guaranteed exactly-once semantics.
+
+## User Scenarios
+
+1. Operator enables `FLOWHR_EVENT_PUBLISHER=http` and events are POSTed to receiver endpoint.
+2. Temporary receiver outage occurs and fail-open policy keeps core API flow available.
+3. Strict mode (`fail-open=false`) blocks API completion on transport failure.
+
+## Payroll Accuracy and Calculation Rules
+
+- Not directly changing payroll formulas.
+- Event emission must not alter payroll calculation result determinism.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | Payroll Operator |
+| --- | --- | --- | --- | --- |
+| Configure runtime event transport env | Allow | Deny | Deny | Allow (ops policy dependent) |
+| Trigger domain event via business API | Allow | Allow | Allow (authorized scope) | Allow |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan:
+  - no DB schema impact
+
+## API and Event Changes
+
+- Endpoints:
+  - internal outbound POST to configured event receiver
+- Events published:
+  - existing domain events (`*.v1`) without name changes
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - runtime publisher mode selection
+- Integration:
+  - HTTP delivery success path
+  - fail-open/fail-closed behavior
+- Regression:
+  - existing e2e event assertions remain green
+- Authorization:
+  - unchanged (existing business API authorization reused)
+- Payroll accuracy:
+  - no calculation logic change
+
+## Observability and Audit Logging
+
+- Audit events:
+  - business audit events unchanged
+- Metrics:
+  - transport success/failure count (receiver side and app logs)
+- Alert conditions:
+  - repeated transport failures within retry budget
+
+## Rollback Plan
+
+- Feature flag behavior:
+  - set `FLOWHR_EVENT_PUBLISHER=noop` for immediate rollback
+- DB rollback method:
+  - not applicable
+- Recovery target time:
+  - 10 minutes
+
+## Definition of Ready (DoR)
+
+- [x] Requirements are unambiguous and testable.
+- [x] Domain contract impact reviewed.
+- [x] Failure policy (fail-open/fail-closed) defined.
+- [x] Test strategy prepared.
+- [x] Rollback path documented.
+
+## Definition of Done (DoD)
+
+- [ ] HTTP transport mode works in integration tests.
+- [ ] Existing CI quality gates stay green.
+- [ ] Runtime configuration guide is documented.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## 요약
- 외부 도메인 이벤트 HTTP 전송 어댑터 추가
- 런타임 모드 확장: FLOWHR_EVENT_PUBLISHER=http
- timeout/retry/fail-open 설정 지원
- 이벤트 전송 통합 테스트 추가 (event-transport-http.test.ts)
- 운영 문서 추가 (docs/event-transport.md) 및 WI-0004 생성
- .env.example, README, execution-plan 갱신

## 검증
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- python scripts/ci/check_golden_fixtures.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd test
- npm.cmd run test:integration
- npm.cmd run test:e2e
- npm.cmd run test:golden