### PR TITLE
docs(payroll): add phase2 deduction-tax contract artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,9 @@ Details: `docs/staging-secrets.md`
   - `POST /api/leave/requests/{requestId}/cancel`
   - `GET /api/leave/balances/{employeeId}`
   - `POST /api/leave/accrual/settle`
+
+## Payroll Phase 2 Contract Artifacts
+
+- Work item: `work-items/WI-0005-payroll-phase2-deductions-tax-contract.md`
+- Contract: `specs/payroll/contract.yaml` (v1.1.0)
+- Compatibility matrix: `specs/payroll/phase2-compatibility-matrix.md`

--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -14,7 +14,7 @@ Exception:
 | Domain | Owned Tables | Published Events | Allowed Reads |
 | --- | --- | --- | --- |
 | Attendance | `AttendanceRecord` | `attendance.recorded.v1`, `attendance.corrected.v1`, `attendance.approved.v1` | Own tables, event projections |
-| Payroll | `PayrollRun` | `payroll.calculated.v1`, `payroll.confirmed.v1` | Own tables, attendance projections only |
+| Payroll | `PayrollRun` | `payroll.calculated.v1`, `payroll.confirmed.v1`, `payroll.deductions.calculated.v1` | Own tables, attendance projections only |
 | Leave | `LeaveRequest`, `LeaveApproval`, `LeaveBalanceProjection` | `leave.requested.v1`, `leave.approved.v1`, `leave.rejected.v1`, `leave.canceled.v1`, `leave.accrual.settled.v1` | Own tables, attendance/payroll read-model only |
 | Platform (Shared) | `AuditLog` | none | Read-only for operations and audits |
 | Orchestrator (Process) | none (artifact-driven process) | `workitem.assigned` | Aggregated operational projections |

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -29,7 +29,7 @@ Completed:
 
 Open gaps:
 
-- Payroll Phase 2 (deductions/tax/remittance) remains out of scope.
+- Payroll Phase 2 runtime implementation (deduction/tax calculation engine) remains out of scope.
 - Staging integration is disabled by default; continuous validation is not active until explicitly enabled.
 
 ## 2) Priority Roadmap
@@ -90,7 +90,7 @@ Tasks:
 
 1. Add external transport adapter for domain events (current implementation is in-process `noop`/`memory` only). (Completed: 2026-02-13)
 2. Implement leave accrual/carry-over settlement policy (WI-0003). (Completed: 2026-02-13)
-3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path.
+3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path. (Completed: 2026-02-13)
 4. Add spec-to-runtime drift check for table names and migration IDs. (Completed: 2026-02-13)
 5. Enable staging CI only when needed (`FLOWHR_ENABLE_STAGING_CI=true`) and keep schema isolation checks green.
 
@@ -136,5 +136,5 @@ Request template:
 
 Without additional input, the next executable step is:
 
-1. create payroll Phase 2 (deductions/tax) contract artifacts and compatibility matrix,
+1. implement payroll Phase 2 deduction/tax calculation runtime behind feature flag,
 2. enable staging CI with guarded secrets when staging DB is ready.

--- a/prisma/migrations/202602140003_payroll_phase2_contract_base/migration.sql
+++ b/prisma/migrations/202602140003_payroll_phase2_contract_base/migration.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "PayrollRun"
+  ADD COLUMN IF NOT EXISTS "withholdingTaxKrw" INTEGER;
+
+ALTER TABLE "PayrollRun"
+  ADD COLUMN IF NOT EXISTS "socialInsuranceKrw" INTEGER;
+
+ALTER TABLE "PayrollRun"
+  ADD COLUMN IF NOT EXISTS "otherDeductionsKrw" INTEGER;
+
+ALTER TABLE "PayrollRun"
+  ADD COLUMN IF NOT EXISTS "totalDeductionsKrw" INTEGER;
+
+ALTER TABLE "PayrollRun"
+  ADD COLUMN IF NOT EXISTS "netPayKrw" INTEGER;
+
+ALTER TABLE "PayrollRun"
+  ADD COLUMN IF NOT EXISTS "deductionBreakdown" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,12 @@ model PayrollRun {
   periodEnd         DateTime
   state             PayrollState @default(PREVIEWED)
   grossPayKrw       Int
+  withholdingTaxKrw Int?
+  socialInsuranceKrw Int?
+  otherDeductionsKrw Int?
+  totalDeductionsKrw Int?
+  netPayKrw         Int?
+  deductionBreakdown Json?
   sourceRecordCount Int      @default(0)
   confirmedAt       DateTime?
   confirmedBy       String?

--- a/qa/risk-matrix.md
+++ b/qa/risk-matrix.md
@@ -24,6 +24,7 @@
 - Rounding effects on payable amount.
 - Retroactive correction and recalculation.
 - Leave carry-over cap misapplication and duplicate-year settlement.
+- Deduction/tax aggregation mismatch impacting net pay.
 
 ## Migration Safety Risks
 

--- a/specs/common/time-and-payroll-rules.md
+++ b/specs/common/time-and-payroll-rules.md
@@ -47,6 +47,13 @@ This document is the shared source of truth for attendance-to-payroll calculatio
 - Carry-over formula: `min(max(remainingDays, 0), carryOverCapDays)`.
 - Duplicate settlement for same employee/year is rejected.
 
+## WI-0005 Payroll Deduction Rules (Contract)
+
+- Phase 2 is additive to WI-0001 gross-pay flow.
+- Total deductions: `withholdingTaxKrw + socialInsuranceKrw + otherDeductionsKrw`.
+- Net pay: `grossPayKrw - totalDeductionsKrw`.
+- Final amounts remain whole KRW integers.
+
 ## Calculation Priority
 
 1. Validate attendance record state (approved vs pending/canceled).

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.0.0
+  version: 1.1.0
 paths:
   /payroll/runs/preview:
     post:
@@ -9,6 +9,12 @@ paths:
       responses:
         "200":
           description: Preview generated
+  /payroll/runs/preview-with-deductions:
+    post:
+      summary: Create payroll preview with deduction and tax components (phase2)
+      responses:
+        "200":
+          description: Deduction preview generated
   /payroll/runs/{runId}/confirm:
     post:
       summary: Confirm payroll run

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,11 +1,13 @@
 owner: payroll-agent
-version: 1.0.1
+version: 1.1.0
 scope:
   in:
     - gross pay preview from approved attendance aggregates
     - payroll run trace and audit logging
+    - deduction and tax contract artifacts for phase 2 rollout
   out:
-    - tax deduction and external remittance
+    - country-specific tax engine implementation
+    - external remittance
     - bank transfer execution
 entities:
   - name: PayrollPeriod
@@ -25,6 +27,9 @@ api:
       path: /payroll/runs/preview
       description: Generate payroll gross pay preview for a period.
     - method: POST
+      path: /payroll/runs/preview-with-deductions
+      description: Generate payroll preview with deduction and tax components (phase2).
+    - method: POST
       path: /payroll/runs/{runId}/confirm
       description: Confirm a payroll run.
   events:
@@ -33,6 +38,8 @@ api:
         description: Emitted when gross pay calculation is completed.
       - name: payroll.confirmed.v1
         description: Emitted when payroll run is confirmed.
+      - name: payroll.deductions.calculated.v1
+        description: Emitted when deduction/tax preview is calculated.
     consumed:
       - name: attendance.approved.v1
         description: Approved attendance aggregate input.
@@ -44,10 +51,13 @@ db_changes:
       description: Create PayrollRun base table.
     - id: 202602130002_wi0001_api_extensions
       description: Extend PayrollRun and add AuditLog for payroll traceability.
+    - id: 202602140003_payroll_phase2_contract_base
+      description: Add additive deduction and net-pay trace fields to PayrollRun.
   backward_compatible: true
-  notes: Additive columns for future deduction components.
+  notes: Phase2 extends payroll payload with additive nullable deduction fields.
 invariants:
   - Gross pay is deterministic for same inputs and rules.
+  - Net pay equals gross pay minus total deductions when phase2 fields are populated.
   - Payroll preview includes source attendance snapshot reference.
   - Recalculation after correction keeps immutable audit trail.
 risk:
@@ -55,42 +65,51 @@ risk:
     - Unauthorized payroll run confirmation can lock wrong results.
   payroll_accuracy:
     - Misapplied overtime/night/holiday multipliers affect compensation.
+    - Miscalculated deduction aggregation affects net pay accuracy.
   legal:
     - Payroll trace must support audit and dispute resolution.
 test_plan:
   unit:
     - gross pay calculator with multiplier rules
+    - deduction and net-pay aggregation formula
     - rounding behavior for KRW totals
   integration:
     - consume attendance.approved and produce payroll preview
+    - preview-with-deductions and confirm flow
   regression:
     - replay GC-001 through GC-005 fixtures
   authorization:
     - payroll_operator role enforcement
   payroll_accuracy:
     - overtime/night/holiday category payout checks
+    - deduction sum and net-pay deterministic checks
 observability:
   audit_events:
     - payroll.calculated
+    - payroll.deductions_calculated
     - payroll.confirmed
   metrics:
     - payroll_run_duration_ms
     - payroll_recalculation_count
+    - payroll_deductions_preview_latency_ms
   logs:
     - payroll calculation error with run ID context
 rollout:
   feature_flags:
     - name: payroll_preview_v1
       default: "off"
+    - name: payroll_deductions_v1
+      default: "off"
   migration_strategy: expand-contract
 rollback:
-  strategy: disable payroll_preview_v1 and use previous payroll reader path
+  strategy: disable payroll_deductions_v1 and fallback to gross-only preview path
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Initial payroll gross pay contract for WI-0001. Downstream integrations are not yet enabled."
+consumer_impact: "Phase2 contract adds non-breaking deduction/net-pay fields and a feature-flagged preview endpoint."
 references:
   - specs/common/time-and-payroll-rules.md
+  - specs/payroll/phase2-compatibility-matrix.md
 approval:
   spec_owner: payroll-agent
   qa_owner: qa-agent

--- a/specs/payroll/db.md
+++ b/specs/payroll/db.md
@@ -2,15 +2,25 @@
 
 ## Planned Tables
 
-- `payroll_periods`
-- `payroll_runs`
-- `payroll_items`
+- `PayrollRun`
 
 ## Migration
 
-- `2026021302_payroll_base`
+- `202602130001_init_wi0001`
+- `202602130002_wi0001_api_extensions`
+- `202602140003_payroll_phase2_contract_base`
+
+## Phase 2 Additive Columns (PayrollRun)
+
+- `withholdingTaxKrw` (int, nullable)
+- `socialInsuranceKrw` (int, nullable)
+- `otherDeductionsKrw` (int, nullable)
+- `totalDeductionsKrw` (int, nullable)
+- `netPayKrw` (int, nullable)
+- `deductionBreakdown` (json, nullable)
 
 ## Compatibility
 
 - Expand-contract migration style.
 - Attendance data is consumed via API/events or projection only.
+- Existing gross-only path remains valid while `payroll_deductions_v1` is off.

--- a/specs/payroll/phase2-compatibility-matrix.md
+++ b/specs/payroll/phase2-compatibility-matrix.md
@@ -1,0 +1,40 @@
+# Payroll Phase 2 Compatibility Matrix
+
+## Intent
+
+This matrix defines how WI-0001 gross-pay behavior coexists with Phase 2 deduction/tax contract rollout.
+
+## Modes
+
+| Mode | Feature Flag | API Surface | Data Fields | Expected Consumer Impact |
+| --- | --- | --- | --- | --- |
+| Legacy (WI-0001) | `payroll_deductions_v1=off` | `POST /payroll/runs/preview`, `POST /payroll/runs/{runId}/confirm` | `grossPayKrw` only required | No impact |
+| Hybrid | `payroll_deductions_v1=on` for selected org | existing + `POST /payroll/runs/preview-with-deductions` | additive deduction/net columns populated when phase2 endpoint used | Existing consumers continue with gross-only path |
+| Phase2 Primary | `payroll_deductions_v1=on` default | deduction preview endpoint preferred | deduction and net fields expected for new consumers | Legacy consumers still supported during deprecation window |
+
+## Field Compatibility
+
+| Field | WI-0001 | Phase 2 | Compatibility |
+| --- | --- | --- | --- |
+| `grossPayKrw` | required | required | stable |
+| `withholdingTaxKrw` | absent/null | optional integer | additive |
+| `socialInsuranceKrw` | absent/null | optional integer | additive |
+| `otherDeductionsKrw` | absent/null | optional integer | additive |
+| `totalDeductionsKrw` | absent/null | optional integer | additive |
+| `netPayKrw` | absent/null | optional integer | additive |
+| `deductionBreakdown` | absent/null | optional JSON | additive |
+
+## Event Compatibility
+
+| Event | WI-0001 | Phase 2 | Compatibility |
+| --- | --- | --- | --- |
+| `payroll.calculated.v1` | emitted | emitted | stable |
+| `payroll.confirmed.v1` | emitted | emitted | stable |
+| `payroll.deductions.calculated.v1` | not emitted | emitted on phase2 path | additive |
+
+## Rollout Guardrails
+
+1. Expand-contract only: no breaking mutation of existing endpoints.
+2. Gross-only regression suite must remain green in CI.
+3. `payroll_deductions_v1` defaults to `off` until consumer validation is complete.
+4. Deprecation notice for gross-only integrations must follow `contracts/versioning.md` policy before default switch.

--- a/specs/payroll/rfc.md
+++ b/specs/payroll/rfc.md
@@ -1,16 +1,17 @@
-# Payroll RFC (WI-0001)
+# Payroll RFC (WI-0001 + WI-0005 Contract)
 
 ## Goal
 
-Provide payroll gross pay preview based on attendance aggregates for the first vertical slice.
+Provide payroll gross pay preview based on attendance aggregates and define phase2 deduction/tax contract expansion.
 
 ## Key Decisions
 
 - Payroll remains gross-pay only in MVP.
 - Input source is approved attendance events and projections.
 - Contract includes audit and deterministic recalculation invariants.
+- Phase2 deduction/tax path is feature-flagged and additive-only.
 
 ## Non-Goals
 
-- Tax deduction and social insurance computations.
+- Country-specific full tax engine implementation.
 - External remittance integration.

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -1,8 +1,8 @@
-# Payroll Test Cases
+# Payroll Test Cases (WI-0001 + WI-0005 Contract)
 
 ## Scope
 
-Payroll gross pay preview and confirmation behavior for WI-0001.
+Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 deduction/tax contract coverage.
 
 ## Functional Cases
 
@@ -10,12 +10,15 @@ Payroll gross pay preview and confirmation behavior for WI-0001.
 2. Confirm payroll run by payroll operator.
 3. Reject preview request for unauthorized role.
 4. Trigger recalculation when corrected attendance event arrives.
+5. Run deduction/tax preview with feature flag for phase2 contract path.
 
 ## Accuracy Cases
 
 1. Overtime, night, and holiday minute categories are paid with correct multipliers.
 2. Gross pay rounding follows common SSoT rules.
 3. Deterministic output for repeated same-input calculations.
+4. `totalDeductionsKrw` equals sum of deduction components.
+5. `netPayKrw` equals `grossPayKrw - totalDeductionsKrw`.
 
 ## Regression Linkage
 
@@ -29,3 +32,4 @@ Payroll gross pay preview and confirmation behavior for WI-0001.
 
 - Spec Gate: contract invariants and consumer impact present.
 - Code Gate: payroll unit/integration/regression checks pass.
+- Compatibility Gate: gross-only consumer path remains valid with phase2 flag off.

--- a/work-items/WI-0005-payroll-phase2-deductions-tax-contract.md
+++ b/work-items/WI-0005-payroll-phase2-deductions-tax-contract.md
@@ -1,0 +1,119 @@
+# WI-0005: Payroll Phase 2 Deductions and Tax Contract
+
+## Background and Problem
+
+FlowHR currently finalizes payroll at gross pay only.  
+For production payroll readiness, deduction and tax components need a contract-first design that can be rolled out without breaking WI-0001 behavior.
+
+## Scope
+
+### In Scope
+
+- Define Phase 2 payroll deduction/tax contract and compatibility policy.
+- Add additive payroll data fields for deduction totals and net pay trace.
+- Define feature-flagged API/event extensions for deduction preview and confirmation.
+- Provide backward-compatibility matrix for existing WI-0001 consumers.
+
+### Out of Scope
+
+- Country-specific full tax engine implementation.
+- External tax filing and remittance.
+- Bank transfer payout execution.
+
+## User Scenarios
+
+1. Payroll operator reviews gross pay with deduction preview before confirmation.
+2. Payroll operator confirms run with explicit deduction/tax breakdown trace.
+3. Existing gross-pay-only consumers continue to work during migration window.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth: `specs/common/time-and-payroll-rules.md`.
+- Phase 2 formula (contract):
+  - `totalDeductionsKrw = withholdingTaxKrw + socialInsuranceKrw + otherDeductionsKrw`
+  - `netPayKrw = grossPayKrw - totalDeductionsKrw`
+- KRW rounding remains integer at final amount.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | Payroll Operator |
+| --- | --- | --- | --- | --- |
+| Run gross-only preview | Allow | Deny | Deny | Allow |
+| Run deduction/tax preview | Allow | Deny | Deny | Allow |
+| Confirm payroll with deduction trace | Allow | Deny | Deny | Allow |
+
+## Data Changes (Tables and Migrations)
+
+- Tables:
+  - `PayrollRun`
+- Migration IDs:
+  - `202602130001_init_wi0001`
+  - `202602130002_wi0001_api_extensions`
+  - `202602140003_payroll_phase2_contract_base`
+- Backward compatibility plan:
+  - additive nullable columns only
+  - preserve existing grossPayKrw semantics
+
+## API and Event Changes
+
+- Endpoints:
+  - `POST /payroll/runs/preview` (v1 existing)
+  - `POST /payroll/runs/preview-with-deductions` (phase2, feature flag)
+  - `POST /payroll/runs/{runId}/confirm` (v1 existing)
+- Events published:
+  - `payroll.calculated.v1` (existing)
+  - `payroll.confirmed.v1` (existing)
+  - `payroll.deductions.calculated.v1` (phase2)
+- Events consumed:
+  - `attendance.approved.v1`
+  - `attendance.corrected.v1`
+
+## Test Plan
+
+- Unit:
+  - deduction aggregation and net pay formula
+- Integration:
+  - preview-with-deductions to confirm flow
+- Regression:
+  - gross-only WI-0001 regression remains green
+- Authorization:
+  - payroll_operator/admin-only phase2 operations
+- Payroll accuracy:
+  - deterministic total deduction and net pay output
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `payroll.calculated`
+  - `payroll.deductions_calculated`
+  - `payroll.confirmed`
+- Metrics:
+  - `payroll_deductions_preview_latency_ms`
+  - `payroll_netpay_mismatch_count`
+- Alert conditions:
+  - deduction preview failure spike
+
+## Rollback Plan
+
+- Feature flag behavior:
+  - disable `payroll_deductions_v1` and fallback to gross-only preview
+- DB rollback method:
+  - keep additive columns, stop phase2 writes
+- Recovery target time:
+  - 30 minutes
+
+## Definition of Ready (DoR)
+
+- [x] Requirements are unambiguous and testable.
+- [x] Payroll contract phase boundary documented.
+- [x] Backward-compatibility matrix prepared.
+- [x] Data migration impact assessed.
+- [x] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Phase 2 contract artifacts merged.
+- [ ] Compatibility matrix reviewed by QA persona.
+- [ ] Contract governance checks pass in CI.
+- [ ] Gross-only regression remains green.
+- [ ] ADR linked if architecture/compatibility changes are introduced.


### PR DESCRIPTION
## 요약
- WI-0005 payroll phase2(공제/세금) contract work item 추가
- payroll contract 버전 1.1.0 갱신 및 phase2 endpoint/event/feature flag 반영
- phase2 compatibility matrix 문서 추가
- payroll spec(api/db/rfc/test-cases)와 common rules 동기화
- PayrollRun additive 컬럼용 migration + prisma schema 반영
- execution-plan, data-ownership, risk-matrix, README 업데이트

## 검증
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- python scripts/ci/check_golden_fixtures.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd test
- npm.cmd run test:integration
- npm.cmd run test:e2e
- npm.cmd run test:golden
- npm.cmd run prisma:generate