### PR TITLE
fix(migration): scope enum existence checks to current schema

### DIFF
--- a/prisma/migrations/202602130002_wi0001_api_extensions/migration.sql
+++ b/prisma/migrations/202602130002_wi0001_api_extensions/migration.sql
@@ -1,13 +1,25 @@
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'AttendanceState') THEN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'AttendanceState'
+      AND n.nspname = current_schema()
+  ) THEN
     CREATE TYPE "AttendanceState" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PayrollState') THEN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'PayrollState'
+      AND n.nspname = current_schema()
+  ) THEN
     CREATE TYPE "PayrollState" AS ENUM ('PREVIEWED', 'CONFIRMED');
   END IF;
 END $$;

--- a/prisma/migrations/202602140001_wi0002_leave_base/migration.sql
+++ b/prisma/migrations/202602140001_wi0002_leave_base/migration.sql
@@ -1,20 +1,38 @@
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'LeaveType') THEN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'LeaveType'
+      AND n.nspname = current_schema()
+  ) THEN
     CREATE TYPE "LeaveType" AS ENUM ('ANNUAL', 'SICK', 'UNPAID');
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'LeaveRequestState') THEN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'LeaveRequestState'
+      AND n.nspname = current_schema()
+  ) THEN
     CREATE TYPE "LeaveRequestState" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'CANCELED');
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'LeaveDecisionAction') THEN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'LeaveDecisionAction'
+      AND n.nspname = current_schema()
+  ) THEN
     CREATE TYPE "LeaveDecisionAction" AS ENUM ('APPROVED', 'REJECTED', 'CANCELED');
   END IF;
 END $$;


### PR DESCRIPTION
## 요약
- staging schema 기반 migrate deploy 실패 원인 수정
- enum 존재 확인 쿼리를 DB 전역이 아닌 current_schema 기준으로 변경
- 대상 마이그레이션:
  - 202602130002_wi0001_api_extensions
  - 202602140001_wi0002_leave_base

## 배경
- schema=staging 연결에서 public schema 타입이 이미 존재하면 enum 생성이 스킵되어,
  테이블 생성 시 	ype ... does not exist 오류가 발생함

## 검증
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd test
- npm.cmd run test:integration