### PR TITLE
ci: staging payroll phase2 flag rollout validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,21 @@ jobs:
             exit 1
           fi
 
+      - name: Validate staging feature flag value
+        env:
+          STAGING_PAYROLL_DEDUCTIONS_FLAG: ${{ vars.FLOWHR_PAYROLL_DEDUCTIONS_V1 || 'false' }}
+        run: |
+          value="$(echo -n "$STAGING_PAYROLL_DEDUCTIONS_FLAG" | tr '[:upper:]' '[:lower:]' | xargs)"
+          case "$value" in
+            true|false|1|0|yes|no|on|off)
+              echo "FLOWHR_PAYROLL_DEDUCTIONS_V1=$value"
+              ;;
+            *)
+              echo "::error::FLOWHR_PAYROLL_DEDUCTIONS_V1 must be one of true,false,1,0,yes,no,on,off"
+              exit 1
+              ;;
+          esac
+
       - name: Validate staging URL format
         env:
           STAGING_DATABASE_URL: ${{ secrets.FLOWHR_STAGING_DATABASE_URL }}
@@ -230,6 +245,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.FLOWHR_STAGING_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.FLOWHR_STAGING_SERVICE_ROLE_KEY }}
           FLOWHR_DATA_ACCESS: prisma
+          FLOWHR_PAYROLL_DEDUCTIONS_V1: ${{ vars.FLOWHR_PAYROLL_DEDUCTIONS_V1 || 'false' }}
         run: |
           npx prisma db execute --url "$DATABASE_URL" --stdin <<'SQL'
           DROP SCHEMA IF EXISTS "staging" CASCADE;
@@ -238,3 +254,4 @@ jobs:
           npm run prisma:validate --if-present
           npm run prisma:migrate:deploy --if-present
           npm run test:e2e:prisma --if-present
+          npm run test:e2e:prisma:phase2-flag --if-present

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Main-branch push runs Prisma-backed route e2e only when repository variable
 - `FLOWHR_STAGING_ANON_KEY`
 - `FLOWHR_STAGING_SERVICE_ROLE_KEY`
 
+Optional staging environment variable:
+
+- `FLOWHR_PAYROLL_DEDUCTIONS_V1` (`true|false`) for phase2 runtime rollout validation.
+
 Details: `docs/staging-secrets.md`
 
 ## Current API Surface (MVP)

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -25,11 +25,11 @@ Completed:
   - memory/prisma e2e coverage
 - Golden fixtures (`GC-001` to `GC-005`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
-- Staging Prisma integration is opt-in (default OFF) with schema isolation guardrails.
+- Staging Prisma integration is enabled with schema isolation guardrails.
 
 Open gaps:
 
-- Staging integration is disabled by default; continuous validation is not active until explicitly enabled.
+- Production runtime rollout for `FLOWHR_PAYROLL_DEDUCTIONS_V1` is not automated yet.
 
 ## 2) Priority Roadmap
 
@@ -92,7 +92,7 @@ Tasks:
 3. Define payroll Phase 2 contract set (deductions/tax) and non-breaking migration path. (Completed: 2026-02-13)
 4. Add spec-to-runtime drift check for table names and migration IDs. (Completed: 2026-02-13)
 5. Implement payroll Phase 2 runtime path (`preview-with-deductions`) behind feature flag. (Completed: 2026-02-13)
-6. Enable staging CI only when needed (`FLOWHR_ENABLE_STAGING_CI=true`) and keep schema isolation checks green.
+6. Enable staging CI with schema isolation checks and phase2 flag smoke validation. (Completed: 2026-02-13)
 
 Definition of Done:
 
@@ -125,16 +125,12 @@ Request template:
 
 ## 5) Inputs Needed From You (Conditional)
 
-1. To enable staging CI:
-   - Repository variable: `FLOWHR_ENABLE_STAGING_CI=true`
-   - Five `FLOWHR_STAGING_*` secrets
-
-2. To proceed with payroll Phase 2:
-   - Configure rollout policy for enabling `FLOWHR_PAYROLL_DEDUCTIONS_V1` in staging/prod
+1. To proceed with payroll Phase 2:
+   - Configure production runtime variable `FLOWHR_PAYROLL_DEDUCTIONS_V1` rollout order
 
 ## 6) Immediate Next Actions
 
 Without additional input, the next executable step is:
 
-1. enable staging CI with guarded secrets when staging DB is ready,
-2. run phased rollout for `FLOWHR_PAYROLL_DEDUCTIONS_V1` by consumer validation order.
+1. run phased rollout for `FLOWHR_PAYROLL_DEDUCTIONS_V1` by consumer validation order,
+2. connect production deployment platform env/flag controls to the same rollout policy.

--- a/docs/staging-secrets.md
+++ b/docs/staging-secrets.md
@@ -12,6 +12,7 @@
 
 - Staging CI is `OFF` by default.
 - Enable only when needed by setting repository variable `FLOWHR_ENABLE_STAGING_CI=true`.
+- Payroll phase2 runtime toggle for staging environment: `FLOWHR_PAYROLL_DEDUCTIONS_V1=true|false`.
 
 ## Setup Rule
 
@@ -26,10 +27,12 @@ gh secret set FLOWHR_STAGING_DIRECT_URL -b"<direct-or-reachable-url>?schema=stag
 gh secret set FLOWHR_STAGING_SUPABASE_URL -b"https://<flowhr-project-ref>.supabase.co"
 gh secret set FLOWHR_STAGING_ANON_KEY -b"<flowhr-anon-key>"
 gh secret set FLOWHR_STAGING_SERVICE_ROLE_KEY -b"<flowhr-service-role-key>"
+gh variable set FLOWHR_PAYROLL_DEDUCTIONS_V1 --env staging --body "true"
 ```
 
 ## Verification
 
 - `gh secret list` should include all five names.
+- `gh variable list --env staging` should include `FLOWHR_PAYROLL_DEDUCTIONS_V1`.
 - `FLOWHR_STAGING_DATABASE_URL` and `FLOWHR_STAGING_DIRECT_URL` must include `schema=staging`.
 - When `FLOWHR_ENABLE_STAGING_CI=true`, `staging-prisma-integration` must run and pass on `main` push.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2.test.ts",
     "test:e2e:leave": "tsx scripts/tests/e2e-wi0002-leave.test.ts",
     "test:e2e:prisma": "tsx scripts/tests/e2e-wi0001-prisma.test.ts && tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2-prisma.test.ts",
+    "test:e2e:prisma:phase2-flag": "tsx scripts/tests/e2e-wi0005-payroll-phase2-flag-prisma.test.ts",
     "test:e2e:prisma:leave": "tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts",
     "test:golden": "tsx scripts/tests/golden.test.ts",
     "roles:backfill:dry": "node scripts/supabase/backfill-role-claims.mjs --dry-run",

--- a/scripts/tests/e2e-wi0005-payroll-phase2-flag-prisma.test.ts
+++ b/scripts/tests/e2e-wi0005-payroll-phase2-flag-prisma.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "prisma";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+
+if (!runtimeEnv.DATABASE_URL || !runtimeEnv.DIRECT_URL) {
+  console.error("DATABASE_URL and DIRECT_URL are required for Prisma phase2 flag test.");
+  process.exit(1);
+}
+
+type JsonPayload = Record<string, unknown>;
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+function actorHeaders(role: string, actorId: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+function isFlagEnabled(value: string | undefined) {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  return normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on";
+}
+
+async function run() {
+  const startedAt = new Date();
+  const suffix = `${Date.now()}`;
+  const employeeId = `E2E-P2FLAG-EMP-${suffix}`;
+  const managerId = `E2E-P2FLAG-MGR-${suffix}`;
+  const payrollId = `E2E-P2FLAG-PAY-${suffix}`;
+  const markerNote = `e2e-p2flag-${suffix}`;
+  const deductionsEnabled = isFlagEnabled(runtimeEnv.FLOWHR_PAYROLL_DEDUCTIONS_V1);
+
+  const { prisma } = await import("../../src/lib/prisma.ts");
+  const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
+  const attendanceApproveRoute = await import(
+    "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
+  );
+  const payrollPreviewWithDeductionsRoute = await import(
+    "../../src/app/api/payroll/runs/preview-with-deductions/route.ts"
+  );
+  const payrollConfirmRoute = await import(
+    "../../src/app/api/payroll/runs/[runId]/confirm/route.ts"
+  );
+
+  let createdRecordId: string | null = null;
+  let createdRunId: string | null = null;
+
+  try {
+    const createResponse = await attendanceCreateRoute.POST(
+      jsonRequest(
+        "POST",
+        "/api/attendance/records",
+        {
+          employeeId,
+          checkInAt: "2026-02-12T09:00:00+09:00",
+          checkOutAt: "2026-02-12T18:00:00+09:00",
+          breakMinutes: 60,
+          isHoliday: false,
+          notes: markerNote
+        },
+        actorHeaders("employee", employeeId)
+      )
+    );
+    assert.equal(createResponse.status, 201, "attendance create should succeed");
+    const createBody = await readJson<{ record: { id: string } }>(createResponse);
+    createdRecordId = createBody.record.id;
+
+    const approveResponse = await attendanceApproveRoute.POST(
+      new Request(`http://localhost/api/attendance/records/${createdRecordId}/approve`, {
+        method: "POST",
+        headers: actorHeaders("manager", managerId)
+      }),
+      { params: Promise.resolve({ recordId: createdRecordId }) } as RouteContext<{ recordId: string }>
+    );
+    assert.equal(approveResponse.status, 200, "attendance approve should succeed");
+
+    const previewResponse = await payrollPreviewWithDeductionsRoute.POST(
+      jsonRequest(
+        "POST",
+        "/api/payroll/runs/preview-with-deductions",
+        {
+          periodStart: "2026-02-01T00:00:00+09:00",
+          periodEnd: "2026-02-28T23:59:59+09:00",
+          employeeId,
+          hourlyRateKrw: 12000,
+          deductions: {
+            withholdingTaxKrw: 5000,
+            socialInsuranceKrw: 3000,
+            otherDeductionsKrw: 1000
+          }
+        },
+        actorHeaders("payroll_operator", payrollId)
+      )
+    );
+
+    if (deductionsEnabled) {
+      assert.equal(previewResponse.status, 200, "phase2 flag on should allow deductions preview");
+      const previewBody = await readJson<{
+        run: { id: string };
+        summary: { grossPayKrw: number; totalDeductionsKrw: number; netPayKrw: number };
+      }>(previewResponse);
+      createdRunId = previewBody.run.id;
+      assert.equal(previewBody.summary.grossPayKrw, 96000);
+      assert.equal(previewBody.summary.totalDeductionsKrw, 9000);
+      assert.equal(previewBody.summary.netPayKrw, 87000);
+
+      const confirmResponse = await payrollConfirmRoute.POST(
+        new Request(`http://localhost/api/payroll/runs/${createdRunId}/confirm`, {
+          method: "POST",
+          headers: actorHeaders("payroll_operator", payrollId)
+        }),
+        { params: Promise.resolve({ runId: createdRunId }) } as RouteContext<{ runId: string }>
+      );
+      assert.equal(confirmResponse.status, 200, "phase2 confirm should succeed when flag is on");
+    } else {
+      assert.equal(previewResponse.status, 409, "phase2 flag off should block deductions preview");
+    }
+
+    const auditActions = await prisma.auditLog.findMany({
+      where: {
+        createdAt: { gte: startedAt },
+        actorId: { in: [employeeId, managerId, payrollId] }
+      },
+      orderBy: { createdAt: "asc" },
+      select: { action: true }
+    });
+
+    if (deductionsEnabled) {
+      assert.deepEqual(
+        auditActions.map((row: { action: string }) => row.action),
+        [
+          "attendance.recorded",
+          "attendance.approved",
+          "payroll.deductions_calculated",
+          "payroll.confirmed"
+        ]
+      );
+    } else {
+      assert.deepEqual(
+        auditActions.map((row: { action: string }) => row.action),
+        ["attendance.recorded", "attendance.approved"]
+      );
+    }
+  } finally {
+    await prisma.auditLog.deleteMany({
+      where: {
+        createdAt: { gte: startedAt },
+        actorId: { in: [employeeId, managerId, payrollId] }
+      }
+    });
+    await prisma.payrollRun.deleteMany({
+      where: { employeeId }
+    });
+    await prisma.attendanceRecord.deleteMany({
+      where: {
+        employeeId,
+        notes: markerNote
+      }
+    });
+    await prisma.$disconnect();
+  }
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0005-payroll-phase2-flag-prisma.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- set and validate staging runtime flag FLOWHR_PAYROLL_DEDUCTIONS_V1
- pass flag into staging-prisma-integration job
- add Prisma e2e smoke test that validates behavior based on runtime flag value
- update staging/runbook docs for phase2 rollout

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test:e2e:prisma:phase2-flag (flag=true)
- npm.cmd run test:e2e:prisma:phase2-flag (flag=false)

## Operational state
- GitHub environment variable set: FLOWHR_PAYROLL_DEDUCTIONS_V1=true on staging
