### PR TITLE
docs: production payroll phase2 flag rollout baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Optional staging environment variable:
 - `FLOWHR_PAYROLL_DEDUCTIONS_V1` (`true|false`) for phase2 runtime rollout validation.
 
 Details: `docs/staging-secrets.md`
+Production rollout: `docs/production-rollout.md`
 
 ## Current API Surface (MVP)
 

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -26,10 +26,11 @@ Completed:
 - Golden fixtures (`GC-001` to `GC-005`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
+- Production environment baseline is prepared (`FLOWHR_PAYROLL_DEDUCTIONS_V1=false`).
 
 Open gaps:
 
-- Production runtime rollout for `FLOWHR_PAYROLL_DEDUCTIONS_V1` is not automated yet.
+- Production hosting platform variable sync (if runtime is outside GitHub Actions) is not enforced yet.
 
 ## 2) Priority Roadmap
 
@@ -93,6 +94,7 @@ Tasks:
 4. Add spec-to-runtime drift check for table names and migration IDs. (Completed: 2026-02-13)
 5. Implement payroll Phase 2 runtime path (`preview-with-deductions`) behind feature flag. (Completed: 2026-02-13)
 6. Enable staging CI with schema isolation checks and phase2 flag smoke validation. (Completed: 2026-02-13)
+7. Prepare production phase2 flag baseline and runbook. (Completed: 2026-02-13)
 
 Definition of Done:
 
@@ -126,11 +128,11 @@ Request template:
 ## 5) Inputs Needed From You (Conditional)
 
 1. To proceed with payroll Phase 2:
-   - Configure production runtime variable `FLOWHR_PAYROLL_DEDUCTIONS_V1` rollout order
+   - Confirm production hosting platform (GitHub Actions vs external) for runtime env sync
 
 ## 6) Immediate Next Actions
 
 Without additional input, the next executable step is:
 
 1. run phased rollout for `FLOWHR_PAYROLL_DEDUCTIONS_V1` by consumer validation order,
-2. connect production deployment platform env/flag controls to the same rollout policy.
+2. set production runtime flag to `true` after final consumer validation window.

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -1,0 +1,45 @@
+# Production Rollout: Payroll Phase2 Flag
+
+Target flag: `FLOWHR_PAYROLL_DEDUCTIONS_V1`
+
+## Current Baseline
+
+- GitHub environment `production`: created.
+- `FLOWHR_PAYROLL_DEDUCTIONS_V1=false` in `production` environment.
+
+## Rollout Policy
+
+1. Keep `false` while legacy consumers still rely on gross-only flow.
+2. Move to canary (`true`) only after staging CI and consumer checks pass.
+3. If issue occurs, immediately revert to `false`.
+
+## CLI Commands
+
+Set `false`:
+
+```bash
+gh variable set FLOWHR_PAYROLL_DEDUCTIONS_V1 --env production --body "false" -R yonghyeon-dev/FlowHR
+```
+
+Set `true`:
+
+```bash
+gh variable set FLOWHR_PAYROLL_DEDUCTIONS_V1 --env production --body "true" -R yonghyeon-dev/FlowHR
+```
+
+Verify:
+
+```bash
+gh variable list --env production -R yonghyeon-dev/FlowHR
+```
+
+## Runtime Note
+
+This GitHub environment variable affects workflows that bind `environment: production`.
+If production runtime is hosted outside GitHub Actions (for example Vercel/Render), set the same flag there too.
+
+## Rollback
+
+1. Set `FLOWHR_PAYROLL_DEDUCTIONS_V1=false`.
+2. Re-run production smoke/integration workflow if available.
+3. Keep gross-only endpoint (`/api/payroll/runs/preview`) as fallback path.

--- a/docs/staging-secrets.md
+++ b/docs/staging-secrets.md
@@ -36,3 +36,5 @@ gh variable set FLOWHR_PAYROLL_DEDUCTIONS_V1 --env staging --body "true"
 - `gh variable list --env staging` should include `FLOWHR_PAYROLL_DEDUCTIONS_V1`.
 - `FLOWHR_STAGING_DATABASE_URL` and `FLOWHR_STAGING_DIRECT_URL` must include `schema=staging`.
 - When `FLOWHR_ENABLE_STAGING_CI=true`, `staging-prisma-integration` must run and pass on `main` push.
+
+For production phase2 rollout, follow `docs/production-rollout.md`.


### PR DESCRIPTION
## Summary
- add docs/production-rollout.md for payroll phase2 production flag operations
- update execution plan with production baseline status
- link staging doc -> production rollout doc
- link README to production rollout runbook

## Operational actions already applied
- created GitHub environment: production
- set FLOWHR_PAYROLL_DEDUCTIONS_V1=false in production environment

## Validation
- npm.cmd run lint