### PR TITLE
ci: add production authenticated payroll smoke workflow

### DIFF
--- a/.github/workflows/production-auth-smoke.yml
+++ b/.github/workflows/production-auth-smoke.yml
@@ -1,0 +1,71 @@
+name: production-auth-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Optional production base URL override"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve base URL
+        env:
+          INPUT_BASE_URL: ${{ inputs.base_url }}
+          DEFAULT_BASE_URL: ${{ vars.FLOWHR_PRODUCTION_BASE_URL }}
+        run: |
+          selected="$INPUT_BASE_URL"
+          if [ -z "$selected" ]; then
+            selected="$DEFAULT_BASE_URL"
+          fi
+          if [ -z "$selected" ]; then
+            echo "::error::Missing base URL. Set workflow input base_url or vars.FLOWHR_PRODUCTION_BASE_URL."
+            exit 1
+          fi
+          echo "SMOKE_BASE_URL=$selected" >> "$GITHUB_ENV"
+
+      - name: Validate required production secrets
+        env:
+          PRODUCTION_SUPABASE_URL: ${{ secrets.FLOWHR_PRODUCTION_SUPABASE_URL }}
+          PRODUCTION_ANON_KEY: ${{ secrets.FLOWHR_PRODUCTION_ANON_KEY }}
+          PRODUCTION_SERVICE_ROLE_KEY: ${{ secrets.FLOWHR_PRODUCTION_SERVICE_ROLE_KEY }}
+          PRODUCTION_DATABASE_URL: ${{ secrets.FLOWHR_PRODUCTION_DATABASE_URL }}
+          PRODUCTION_DIRECT_URL: ${{ secrets.FLOWHR_PRODUCTION_DIRECT_URL }}
+        run: |
+          missing=()
+          for key in PRODUCTION_SUPABASE_URL PRODUCTION_ANON_KEY PRODUCTION_SERVICE_ROLE_KEY PRODUCTION_DATABASE_URL PRODUCTION_DIRECT_URL; do
+            if [ -z "${!key}" ]; then
+              missing+=("$key")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required production secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Run production auth smoke
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.FLOWHR_PRODUCTION_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.FLOWHR_PRODUCTION_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.FLOWHR_PRODUCTION_SERVICE_ROLE_KEY }}
+          DATABASE_URL: ${{ secrets.FLOWHR_PRODUCTION_DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.FLOWHR_PRODUCTION_DIRECT_URL }}
+        run: npm run test:smoke:production-auth --if-present

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -46,6 +46,28 @@ Vercel sync status:
 - Framework preset is controlled by `vercel.json` (`nextjs`)
 - Production env `FLOWHR_PAYROLL_DEDUCTIONS_V1=true`
 
+## Production Auth Smoke (GitHub Actions)
+
+Manual workflow: `.github/workflows/production-auth-smoke.yml`
+
+Required production environment variable:
+
+- `FLOWHR_PRODUCTION_BASE_URL` (example: `https://flowhr-two.vercel.app`)
+
+Required production environment secrets:
+
+- `FLOWHR_PRODUCTION_SUPABASE_URL`
+- `FLOWHR_PRODUCTION_ANON_KEY`
+- `FLOWHR_PRODUCTION_SERVICE_ROLE_KEY`
+- `FLOWHR_PRODUCTION_DATABASE_URL`
+- `FLOWHR_PRODUCTION_DIRECT_URL`
+
+Run command:
+
+```bash
+gh workflow run production-auth-smoke.yml -R yonghyeon-dev/FlowHR
+```
+
 ## Rollback
 
 1. Set `FLOWHR_PAYROLL_DEDUCTIONS_V1=false`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e:prisma:phase2-flag": "tsx scripts/tests/e2e-wi0005-payroll-phase2-flag-prisma.test.ts",
     "test:e2e:prisma:leave": "tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts",
     "test:golden": "tsx scripts/tests/golden.test.ts",
+    "test:smoke:production-auth": "tsx scripts/tests/production-auth-smoke.test.ts",
     "roles:backfill:dry": "node scripts/supabase/backfill-role-claims.mjs --dry-run",
     "roles:backfill:apply": "node scripts/supabase/backfill-role-claims.mjs --apply",
     "roles:claims:enforce": "node scripts/supabase/backfill-role-claims.mjs --enforce",

--- a/scripts/tests/production-auth-smoke.test.ts
+++ b/scripts/tests/production-auth-smoke.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { PrismaClient } from "@prisma/client";
+import { createClient } from "@supabase/supabase-js";
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`missing required env: ${name}`);
+  }
+  return value.trim();
+}
+
+async function readResponseBody(response: Response) {
+  const text = await response.text();
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+async function run() {
+  const baseUrl = requireEnv("SMOKE_BASE_URL").replace(/\/+$/, "");
+  const supabaseUrl = requireEnv("NEXT_PUBLIC_SUPABASE_URL");
+  const anonKey = requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+  requireEnv("DATABASE_URL");
+  requireEnv("DIRECT_URL");
+
+  const prisma = new PrismaClient();
+  const admin = createClient(supabaseUrl, serviceRoleKey);
+  const client = createClient(supabaseUrl, anonKey);
+
+  const suffix = `${Date.now()}`;
+  const email = `prod-smoke-${suffix}@flowhr.local`;
+  const password = "Flowhr!12345";
+  const employeeId = `PROD-SMOKE-EMP-${suffix}`;
+
+  let createdUserId: string | null = null;
+  let runId: string | null = null;
+
+  try {
+    const created = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      app_metadata: {
+        role: "payroll_operator"
+      }
+    });
+    if (created.error || !created.data.user?.id) {
+      throw new Error(`createUser failed: ${created.error?.message ?? "unknown"}`);
+    }
+    createdUserId = created.data.user.id;
+
+    const signedIn = await client.auth.signInWithPassword({ email, password });
+    if (signedIn.error || !signedIn.data.session?.access_token) {
+      throw new Error(`signInWithPassword failed: ${signedIn.error?.message ?? "unknown"}`);
+    }
+    const token = signedIn.data.session.access_token;
+
+    const previewResponse = await fetch(`${baseUrl}/api/payroll/runs/preview-with-deductions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId,
+        hourlyRateKrw: 12000,
+        deductions: {
+          withholdingTaxKrw: 0,
+          socialInsuranceKrw: 0,
+          otherDeductionsKrw: 0
+        }
+      })
+    });
+    const previewBody = await readResponseBody(previewResponse);
+    assert.equal(
+      previewResponse.status,
+      200,
+      `preview-with-deductions failed: ${JSON.stringify(previewBody)}`
+    );
+    if (
+      !previewBody ||
+      typeof previewBody !== "object" ||
+      !("run" in previewBody) ||
+      !previewBody.run ||
+      typeof previewBody.run !== "object" ||
+      !("id" in previewBody.run) ||
+      typeof previewBody.run.id !== "string"
+    ) {
+      throw new Error(`preview response missing run id: ${JSON.stringify(previewBody)}`);
+    }
+    runId = previewBody.run.id;
+
+    const confirmResponse = await fetch(`${baseUrl}/api/payroll/runs/${runId}/confirm`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const confirmBody = await readResponseBody(confirmResponse);
+    assert.equal(confirmResponse.status, 200, `confirm failed: ${JSON.stringify(confirmBody)}`);
+
+    console.log(
+      JSON.stringify({
+        ok: true,
+        baseUrl,
+        runId,
+        previewStatus: previewResponse.status,
+        confirmStatus: confirmResponse.status
+      })
+    );
+  } finally {
+    if (runId) {
+      await prisma.auditLog.deleteMany({
+        where: {
+          entityType: "PayrollRun",
+          entityId: runId
+        }
+      });
+      await prisma.payrollRun.deleteMany({
+        where: { id: runId }
+      });
+    }
+
+    if (createdUserId) {
+      await admin.auth.admin.deleteUser(createdUserId);
+    }
+
+    await prisma.$disconnect();
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add manual workflow .github/workflows/production-auth-smoke.yml
- add script scripts/tests/production-auth-smoke.test.ts
  - create temporary payroll_operator user
  - call protected phase2 preview endpoint with JWT
  - confirm payroll run
  - cleanup payroll/audit/user artifacts
- add npm script 	est:smoke:production-auth
- document required production vars/secrets in docs/production-rollout.md

## Production environment setup
- variable: FLOWHR_PRODUCTION_BASE_URL
- secrets:
  - FLOWHR_PRODUCTION_SUPABASE_URL
  - FLOWHR_PRODUCTION_ANON_KEY
  - FLOWHR_PRODUCTION_SERVICE_ROLE_KEY
  - FLOWHR_PRODUCTION_DATABASE_URL
  - FLOWHR_PRODUCTION_DIRECT_URL

## Validation
- npm.cmd run lint
- npm.cmd run typecheck