### PR TITLE
fix(ci): avoid workflow parse error on Slack step

### DIFF
--- a/.github/workflows/payroll-phase2-health.yml
+++ b/.github/workflows/payroll-phase2-health.yml
@@ -74,10 +74,14 @@ jobs:
             });
 
       - name: Notify Slack on failure
-        if: ${{ failure() && secrets.FLOWHR_ALERT_SLACK_WEBHOOK != '' }}
+        if: ${{ failure() }}
         env:
           WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification."
+            exit 0
+          fi
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           payload="{\"text\":\"[FlowHR] payroll-phase2-health failed: ${run_url}\"}"
           curl -X POST -H "Content-type: application/json" --data "$payload" "$WEBHOOK"

--- a/.github/workflows/payroll-phase2-rollback.yml
+++ b/.github/workflows/payroll-phase2-rollback.yml
@@ -105,10 +105,14 @@ jobs:
             });
 
       - name: Notify Slack on failure
-        if: ${{ failure() && secrets.FLOWHR_ALERT_SLACK_WEBHOOK != '' }}
+        if: ${{ failure() }}
         env:
           WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification."
+            exit 0
+          fi
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           payload="{\"text\":\"[FlowHR] payroll-phase2-rollback failed: ${run_url}\"}"
           curl -X POST -H "Content-type: application/json" --data "$payload" "$WEBHOOK"

--- a/.github/workflows/production-auth-smoke.yml
+++ b/.github/workflows/production-auth-smoke.yml
@@ -100,10 +100,14 @@ jobs:
             });
 
       - name: Notify Slack on failure
-        if: ${{ failure() && secrets.FLOWHR_ALERT_SLACK_WEBHOOK != '' }}
+        if: ${{ failure() }}
         env:
           WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
         run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification."
+            exit 0
+          fi
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           payload="{\"text\":\"[FlowHR] production-auth-smoke failed: ${run_url}\"}"
           curl -X POST -H "Content-type: application/json" --data "$payload" "$WEBHOOK"


### PR DESCRIPTION
## Summary\n- remove direct secrets context usage in step-level if expressions\n- keep failure-only behavior and guard Slack notification inside shell script\n- apply same fix to production-auth-smoke, payroll-phase2-health, payroll-phase2-rollback