### PR TITLE
docs(ops): sync production flag status with runtime

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -39,6 +39,7 @@ Completed:
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
 - Production runtime flag is active (`FLOWHR_PAYROLL_DEDUCTIONS_V1=true`) on GitHub env and Vercel.
+- Production profile flag baseline is synced (`FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false`) on GitHub env and Vercel.
 
 Open gaps:
 
@@ -114,6 +115,7 @@ Tasks:
 12. Draft WI-0006 deduction profile contract + ADR + golden baseline. (Completed: 2026-02-13)
 13. Implement WI-0006 runtime (profile CRUD + profile mode preview path). (Completed: 2026-02-13)
 14. Implement WI-0007 MVP operations console on `/`. (Completed: 2026-02-13)
+15. Sync production profile flag baseline to Vercel and re-verify production smoke. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -6,7 +6,7 @@ Target flags: `FLOWHR_PAYROLL_DEDUCTIONS_V1`, `FLOWHR_PAYROLL_DEDUCTION_PROFILE_
 
 - GitHub environment `production`: created.
 - `FLOWHR_PAYROLL_DEDUCTIONS_V1=true` in `production` environment.
-- `FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false` (planned WI-0006 runtime gate).
+- `FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false` in `production` environment.
 - External runtime sync completed on Vercel project `flowhr`.
 
 ## Rollout Policy
@@ -14,7 +14,7 @@ Target flags: `FLOWHR_PAYROLL_DEDUCTIONS_V1`, `FLOWHR_PAYROLL_DEDUCTION_PROFILE_
 1. Keep `false` while legacy consumers still rely on gross-only flow.
 2. Move to canary (`true`) only after staging CI and consumer checks pass.
 3. If issue occurs, immediately revert to `false`.
-4. Keep `FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false` until WI-0006 runtime tests pass.
+4. Keep `FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false` until business sign-off for profile-mode rollout.
 
 ## CLI Commands
 
@@ -47,6 +47,7 @@ Vercel sync status:
 - Production URL: `https://flowhr-two.vercel.app`
 - Framework preset is controlled by `vercel.json` (`nextjs`)
 - Production env `FLOWHR_PAYROLL_DEDUCTIONS_V1=true`
+- Production env `FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false`
 
 ## Production Auth Smoke (GitHub Actions)
 


### PR DESCRIPTION
## Summary\n- update production rollout baseline to reflect current GitHub + Vercel profile flag state\n- update execution plan with completed production profile-flag sync and smoke re-verification\n\n## Validation\n- docs-only change