### PR TITLE
feat(core): guard duplicate approval and confirmation transitions

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -35,6 +35,10 @@ Completed:
   - single-screen flow execution for attendance/payroll/leave/profile APIs
   - API response log panel for manual verification
   - mobile-compatible layout and build validation
+- WI-0008 state transition hardening is implemented:
+  - duplicate attendance approval blocked (409)
+  - duplicate payroll confirmation blocked (409)
+  - memory/prisma e2e assertions added
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -116,6 +120,7 @@ Tasks:
 13. Implement WI-0006 runtime (profile CRUD + profile mode preview path). (Completed: 2026-02-13)
 14. Implement WI-0007 MVP operations console on `/`. (Completed: 2026-02-13)
 15. Sync production profile flag baseline to Vercel and re-verify production smoke. (Completed: 2026-02-13)
+16. Add WI-0008 duplicate transition guard for approval/confirmation flows. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/scripts/tests/e2e-wi0001-prisma.test.ts
+++ b/scripts/tests/e2e-wi0001-prisma.test.ts
@@ -88,6 +88,15 @@ async function run() {
     );
     assert.equal(approveResponse.status, 200, "attendance approve should succeed");
 
+    const duplicateApproveResponse = await attendanceApproveRoute.POST(
+      new Request(`http://localhost/api/attendance/records/${createdRecordId}/approve`, {
+        method: "POST",
+        headers: actorHeaders("manager", managerId)
+      }),
+      { params: Promise.resolve({ recordId: createdRecordId }) } as RouteContext<{ recordId: string }>
+    );
+    assert.equal(duplicateApproveResponse.status, 409, "duplicate attendance approval should be rejected");
+
     const previewResponse = await payrollPreviewRoute.POST(
       jsonRequest(
         "POST",
@@ -131,6 +140,15 @@ async function run() {
     assert.equal(confirmResponse.status, 200, "payroll confirmation should succeed");
     const confirmBody = await readJson<{ run: { state: string } }>(confirmResponse);
     assert.equal(confirmBody.run.state, "CONFIRMED");
+
+    const duplicateConfirmResponse = await payrollConfirmRoute.POST(
+      new Request(`http://localhost/api/payroll/runs/${createdRunId}/confirm`, {
+        method: "POST",
+        headers: actorHeaders("payroll_operator", payrollId)
+      }),
+      { params: Promise.resolve({ runId: createdRunId }) } as RouteContext<{ runId: string }>
+    );
+    assert.equal(duplicateConfirmResponse.status, 409, "duplicate payroll confirmation should be rejected");
 
     const auditActions = await prisma.auditLog.findMany({
       where: {

--- a/scripts/tests/e2e-wi0001.test.ts
+++ b/scripts/tests/e2e-wi0001.test.ts
@@ -99,6 +99,15 @@ async function run() {
   };
   assert.equal(approveBody.record.state, "APPROVED");
 
+  const duplicateApproveResponse = await attendanceApproveRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${createdRecord.id}/approve`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-1")
+    }),
+    { params: Promise.resolve({ recordId: createdRecord.id }) } as RouteContext<{ recordId: string }>
+  );
+  assert.equal(duplicateApproveResponse.status, 409, "duplicate attendance approval should be rejected");
+
   const previewResponse = await payrollPreviewRoute.POST(
     jsonRequest(
       "POST",
@@ -147,6 +156,15 @@ async function run() {
     run: { state: string };
   };
   assert.equal(confirmBody.run.state, "CONFIRMED");
+
+  const duplicateConfirmResponse = await payrollConfirmRoute.POST(
+    new Request(`http://localhost/api/payroll/runs/${previewBody.run.id}/confirm`, {
+      method: "POST",
+      headers: actorHeaders("payroll_operator", "PAY-1")
+    }),
+    { params: Promise.resolve({ runId: previewBody.run.id }) } as RouteContext<{ runId: string }>
+  );
+  assert.equal(duplicateConfirmResponse.status, 409, "duplicate payroll confirmation should be rejected");
 
   assert.deepEqual(getMemoryAuditActions(), [
     "attendance.recorded",

--- a/src/features/attendance/service.ts
+++ b/src/features/attendance/service.ts
@@ -156,6 +156,9 @@ export async function approveAttendanceRecord(
   if (!existing) {
     throw new ServiceError(404, "attendance record not found");
   }
+  if (existing.state !== "PENDING") {
+    throw new ServiceError(409, "only pending attendance can be approved");
+  }
 
   const record = await context.dataAccess.attendance.update(recordId, {
     state: "APPROVED",

--- a/src/features/payroll/service.ts
+++ b/src/features/payroll/service.ts
@@ -433,6 +433,9 @@ export async function confirmPayrollRun(
   if (!run) {
     throw new ServiceError(404, "payroll run not found");
   }
+  if (run.state !== "PREVIEWED") {
+    throw new ServiceError(409, "only previewed payroll run can be confirmed");
+  }
 
   const confirmed = await context.dataAccess.payroll.update(runId, {
     state: "CONFIRMED",

--- a/work-items/WI-0008-state-transition-idempotency-guard.md
+++ b/work-items/WI-0008-state-transition-idempotency-guard.md
@@ -1,0 +1,49 @@
+# WI-0008: State Transition Idempotency Guard
+
+## Background and Problem
+
+Core approval/confirmation endpoints must reject duplicate state transitions to prevent duplicate audit/event emissions and accidental repeated actions.
+
+## Scope
+
+### In Scope
+
+- Reject duplicate attendance approvals when state is not `PENDING`.
+- Reject duplicate payroll confirmations when state is not `PREVIEWED`.
+- Add regression assertions for memory/prisma e2e flows.
+
+### Out of Scope
+
+- Generic idempotency-key middleware across all endpoints.
+- Distributed lock strategy for multi-region concurrency.
+
+## User Scenarios
+
+1. Manager accidentally retries attendance approval request.
+2. Payroll operator retries payroll confirmation request after success.
+3. System preserves single source of truth for approval/confirm transitions.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | Payroll Operator |
+| --- | --- | --- | --- | --- |
+| Attendance approve (first) | Allow | Allow | Deny | Deny |
+| Attendance approve (duplicate) | 409 | 409 | Deny | Deny |
+| Payroll confirm (first) | Allow | Deny | Deny | Allow |
+| Payroll confirm (duplicate) | 409 | Deny | Deny | 409 |
+
+## Test Plan
+
+- Memory e2e:
+  - duplicate attendance approval returns `409`
+  - duplicate payroll confirmation returns `409`
+- Prisma e2e:
+  - duplicate attendance approval returns `409`
+  - duplicate payroll confirmation returns `409`
+
+## Definition of Done (DoD)
+
+- [x] Duplicate state transition guard implemented.
+- [x] Memory/prisma e2e regression assertions added.
+- [x] Existing audit/event sequence remains deterministic.
+- [ ] QA Spec Gate and Code Gate are both passed.


### PR DESCRIPTION
## Summary\n- add attendance approval state guard: only PENDING can be approved\n- add payroll confirmation state guard: only PREVIEWED can be confirmed\n- add memory/prisma e2e assertions for duplicate approval/confirmation returning 409\n- add WI-0008 work item and execution-plan progress update\n\n## Validation\n- npm run lint\n- npm run typecheck\n- python scripts/ci/check_traceability.py\n- npm run test:e2e\n- npm run test:e2e:prisma\n- npm run build