### PR TITLE
feat(attendance): add rejection flow and payroll exclusion guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ FLOWHR_EVENT_HTTP_FAIL_OPEN=true
 
 # Optional: payroll phase2 deduction preview endpoint toggle
 FLOWHR_PAYROLL_DEDUCTIONS_V1=false
+
+# Optional: payroll phase2 deduction profile mode toggle (requires deductions_v1=true)
+FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=false

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Use Supabase CLI for schema sync/inspection while Prisma remains the app ORM and
 - For API route tests without database, set `FLOWHR_DATA_ACCESS=memory`.
 - For Prisma-backed route smoke test, run `npm run test:e2e:prisma` with DB env set.
 - Payroll phase2 preview endpoint is gated by `FLOWHR_PAYROLL_DEDUCTIONS_V1=true`.
+- Payroll deduction profile mode is additionally gated by `FLOWHR_PAYROLL_DEDUCTION_PROFILE_V1=true`.
 
 ## Domain Event Publication Adapter
 
@@ -106,6 +107,7 @@ Production rollout: `docs/production-rollout.md`
   - `POST /api/attendance/records`
   - `PATCH /api/attendance/records/{recordId}`
   - `POST /api/attendance/records/{recordId}/approve`
+  - `POST /api/attendance/records/{recordId}/reject`
 - Payroll:
   - `POST /api/payroll/runs/preview`
   - `POST /api/payroll/runs/preview-with-deductions` (feature flag: `FLOWHR_PAYROLL_DEDUCTIONS_V1=true`)
@@ -122,5 +124,5 @@ Production rollout: `docs/production-rollout.md`
 ## Payroll Phase 2 Contract Artifacts
 
 - Work item: `work-items/WI-0005-payroll-phase2-deductions-tax-contract.md`
-- Contract: `specs/payroll/contract.yaml` (v1.1.0)
+- Contract: `specs/payroll/contract.yaml` (v1.2.0)
 - Compatibility matrix: `specs/payroll/phase2-compatibility-matrix.md`

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -39,6 +39,10 @@ Completed:
   - duplicate attendance approval blocked (409)
   - duplicate payroll confirmation blocked (409)
   - memory/prisma e2e assertions added
+- WI-0009 attendance rejection flow is implemented:
+  - `POST /attendance/records/{recordId}/reject` added for admin/manager
+  - rejected attendance excluded from payroll aggregation path
+  - memory/prisma e2e assertions added
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -121,6 +125,7 @@ Tasks:
 14. Implement WI-0007 MVP operations console on `/`. (Completed: 2026-02-13)
 15. Sync production profile flag baseline to Vercel and re-verify production smoke. (Completed: 2026-02-13)
 16. Add WI-0008 duplicate transition guard for approval/confirmation flows. (Completed: 2026-02-13)
+17. Add WI-0009 attendance rejection flow and payroll exclusion regression coverage. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/specs/attendance/api.yaml
+++ b/specs/attendance/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Attendance API
-  version: 1.0.0
+  version: 1.1.0
 paths:
   /attendance/records:
     post:
@@ -33,3 +33,15 @@ paths:
       responses:
         "200":
           description: Approved
+  /attendance/records/{recordId}/reject:
+    post:
+      summary: Reject attendance record or correction
+      parameters:
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Rejected

--- a/specs/attendance/contract.yaml
+++ b/specs/attendance/contract.yaml
@@ -1,10 +1,10 @@
 owner: attendance-agent
-version: 1.0.1
+version: 1.1.0
 scope:
   in:
     - attendance record create/update
-    - correction approval flow
-    - approved attendance event publication
+    - correction approval/rejection flow
+    - approved/rejected attendance event publication
   out:
     - payroll tax and deduction
     - physical device protocol integration
@@ -18,7 +18,7 @@ api:
     - role: employee
       permission: create own attendance record
     - role: manager
-      permission: approve correction within assigned org
+      permission: approve/reject correction within assigned org
   endpoints:
     - method: POST
       path: /attendance/records
@@ -29,12 +29,17 @@ api:
     - method: POST
       path: /attendance/records/{recordId}/approve
       description: Approve attendance record or correction.
+    - method: POST
+      path: /attendance/records/{recordId}/reject
+      description: Reject attendance record or correction.
   events:
     published:
       - name: attendance.recorded.v1
         description: Emitted when attendance record is created.
       - name: attendance.approved.v1
         description: Emitted when attendance is approved and payable.
+      - name: attendance.rejected.v1
+        description: Emitted when attendance is rejected and excluded from payroll aggregation.
       - name: attendance.corrected.v1
         description: Emitted when correction is approved.
     consumed:
@@ -50,11 +55,14 @@ db_changes:
   notes: Expand-contract pattern for future attendance payload updates.
 invariants:
   - An approved attendance record cannot be silently overwritten.
+  - A rejected attendance record cannot transition directly to approved.
+  - Rejected attendance record is excluded from payroll aggregation.
   - Attendance timestamps are interpreted in Asia/Seoul.
-  - Approved attendance emits exactly one approval event per final state.
+  - Approved/rejected attendance emits exactly one final state event.
 risk:
   permissions:
     - Unauthorized approval could alter payroll amount.
+    - Unauthorized rejection could omit payable minutes.
   payroll_accuracy:
     - Incorrect overnight boundary handling can misclassify payable minutes.
   legal:
@@ -65,10 +73,11 @@ test_plan:
     - correction state transition validation
   integration:
     - create record to approve flow
+    - create record to reject flow
   regression:
     - replay GC-001, GC-002, GC-003, GC-005
   authorization:
-    - manager-only approval check
+    - manager-only approval/rejection check
   payroll_accuracy:
     - approved minutes match aggregation contract
 observability:
@@ -76,9 +85,11 @@ observability:
     - attendance.recorded
     - attendance.corrected
     - attendance.approved
+    - attendance.rejected
   metrics:
     - attendance_approval_latency_ms
     - attendance_correction_count
+    - attendance_rejection_count
   logs:
     - authorization denied logs for attendance approval
 rollout:
@@ -91,9 +102,10 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "New attendance contract for WI-0001. No existing consumer break expected."
+consumer_impact: "Contract v1.1.0 adds non-breaking attendance rejection endpoint and event."
 references:
   - specs/common/time-and-payroll-rules.md
+  - work-items/WI-0009-attendance-rejection-flow.md
 approval:
   spec_owner: attendance-agent
   qa_owner: qa-agent

--- a/specs/attendance/rfc.md
+++ b/specs/attendance/rfc.md
@@ -6,8 +6,8 @@ Deliver attendance contract and API behavior needed for the first vertical slice
 
 ## Key Decisions
 
-- Contract-first schema and approval flow.
-- Event publication after approval to feed payroll aggregation.
+- Contract-first schema and approval/rejection flow.
+- Event publication after approval/rejection to feed payroll aggregation.
 - Time normalization delegated to common SSoT rules.
 
 ## Non-Goals

--- a/specs/attendance/test-cases.md
+++ b/specs/attendance/test-cases.md
@@ -9,8 +9,9 @@ Attendance create/update/approval behavior and output consistency for payroll ag
 1. Create attendance record within same business day.
 2. Update attendance before approval.
 3. Approve correction by manager role.
-4. Reject unauthorized approval attempt.
-5. Emit approval event once for final state.
+4. Reject attendance by manager role and verify exclusion from payroll aggregation.
+5. Reject unauthorized approval/rejection attempt.
+6. Emit final-state event once (`approved` or `rejected`).
 
 ## Boundary and Accuracy Cases
 

--- a/src/app/api/attendance/records/[recordId]/reject/route.ts
+++ b/src/app/api/attendance/records/[recordId]/reject/route.ts
@@ -1,0 +1,28 @@
+import { rejectAttendanceRecord } from "@/features/attendance/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
+import { readActor } from "@/lib/actor";
+import { fail, ok } from "@/lib/http";
+
+type RouteContext = {
+  params: Promise<{ recordId: string }>;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const { recordId } = await context.params;
+  try {
+    const record = await rejectAttendanceRecord(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      recordId
+    );
+    return ok({ record });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
+}

--- a/src/features/shared/domain-event-publisher.ts
+++ b/src/features/shared/domain-event-publisher.ts
@@ -2,6 +2,7 @@ export const domainEventNames = [
   "attendance.recorded.v1",
   "attendance.corrected.v1",
   "attendance.approved.v1",
+  "attendance.rejected.v1",
   "payroll.calculated.v1",
   "payroll.deductions.calculated.v1",
   "payroll.deduction_profile.updated.v1",

--- a/work-items/WI-0009-attendance-rejection-flow.md
+++ b/work-items/WI-0009-attendance-rejection-flow.md
@@ -1,0 +1,99 @@
+# WI-0009: Attendance Rejection Flow and Payroll Exclusion Guard
+
+## Background and Problem
+
+Current attendance flow supports create/update/approve only.  
+Operationally, managers need an explicit rejection action to block invalid records from payroll aggregation without deleting history.
+
+## Scope
+
+### In Scope
+
+- Add manager/admin rejection endpoint for attendance records.
+- Enforce `PENDING -> REJECTED` transition guard.
+- Ensure rejected records are excluded from payroll preview aggregation.
+- Emit audit/domain events for rejection action.
+
+### Out of Scope
+
+- Attendance delete/hard-delete behavior.
+- Rejection reason capture schema migration.
+- Reopen/resubmission workflow for rejected attendance.
+
+## User Scenarios
+
+1. Manager rejects an invalid pending attendance record and the record transitions to `REJECTED`.
+2. Payroll operator runs preview and rejected attendance is not included in `sourceRecordCount` or totals.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: payroll aggregation includes `APPROVED` attendance only.
+- Rounding rule: existing KRW/minute rounding rules remain unchanged.
+- Exception handling rule: duplicate rejection attempts fail with `409`.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | System |
+| --- | --- | --- | --- | --- |
+| Reject attendance record | Allow | Allow | Deny | Deny |
+| Approve attendance record | Allow | Allow | Deny | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: `AttendanceRecord`, `AuditLog`
+- Migration IDs: none
+- Backward compatibility plan: additive API/event change only, no schema migration
+
+## API and Event Changes
+
+- Endpoints:
+  - `POST /api/attendance/records/{recordId}/reject`
+- Events published:
+  - `attendance.rejected.v1`
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - state transition guard (`PENDING` only)
+- Integration:
+  - manager rejection success
+  - duplicate rejection blocked (`409`)
+- Regression:
+  - WI-0001 memory/prisma e2e remains green
+- Authorization:
+  - employee rejection denied (`403`)
+- Payroll accuracy:
+  - rejected record excluded from preview `sourceRecordCount`
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `attendance.rejected`
+- Metrics:
+  - `attendance_rejection_count`
+- Alert conditions:
+  - rejection failure spike (`4xx/5xx`)
+
+## Rollback Plan
+
+- Feature flag behavior: no new flag, rollback by reverting route/service change.
+- DB rollback method: not applicable (no migration).
+- Recovery target time: 30m.
+
+## Definition of Ready (DoR)
+
+- [ ] Requirements are unambiguous and testable.
+- [ ] Domain contract drafted or updated.
+- [ ] Role matrix reviewed by QA.
+- [ ] Data migration impact assessed.
+- [ ] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## Summary
- add attendance reject API and service transition guard
- emit attendance.rejected audit/domain events
- extend memory/prisma e2e with rejected-record payroll exclusion checks
- sync attendance contract/docs and add WI-0009

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- python scripts/ci/check_traceability.py
- python scripts/ci/check_contracts.py
- python scripts/ci/check_golden_fixtures.py
- npm.cmd run test:e2e
- npm.cmd run test:e2e:prisma
- npm.cmd run build