### PR TITLE
feat(payroll): add expected profile version guard for phase2 preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Production rollout: `docs/production-rollout.md`
   - `POST /api/attendance/records/{recordId}/reject`
 - Payroll:
   - `POST /api/payroll/runs/preview`
-  - `POST /api/payroll/runs/preview-with-deductions` (feature flag: `FLOWHR_PAYROLL_DEDUCTIONS_V1=true`)
+  - `POST /api/payroll/runs/preview-with-deductions` (feature flag: `FLOWHR_PAYROLL_DEDUCTIONS_V1=true`, profile mode optional `expectedProfileVersion`)
   - `POST /api/payroll/runs/{runId}/confirm`
 - Leave:
   - `POST /api/leave/requests`
@@ -124,5 +124,5 @@ Production rollout: `docs/production-rollout.md`
 ## Payroll Phase 2 Contract Artifacts
 
 - Work item: `work-items/WI-0005-payroll-phase2-deductions-tax-contract.md`
-- Contract: `specs/payroll/contract.yaml` (v1.2.0)
+- Contract: `specs/payroll/contract.yaml` (v1.3.0)
 - Compatibility matrix: `specs/payroll/phase2-compatibility-matrix.md`

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -43,6 +43,10 @@ Completed:
   - `POST /attendance/records/{recordId}/reject` added for admin/manager
   - rejected attendance excluded from payroll aggregation path
   - memory/prisma e2e assertions added
+- WI-0010 payroll profile version guard is implemented:
+  - profile-mode preview accepts optional `expectedProfileVersion`
+  - stale profile version requests are blocked with `409`
+  - memory/prisma e2e assertions added
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -126,6 +130,7 @@ Tasks:
 15. Sync production profile flag baseline to Vercel and re-verify production smoke. (Completed: 2026-02-13)
 16. Add WI-0008 duplicate transition guard for approval/confirmation flows. (Completed: 2026-02-13)
 17. Add WI-0009 attendance rejection flow and payroll exclusion regression coverage. (Completed: 2026-02-13)
+18. Add WI-0010 profile-mode expected version guard for deduction preview. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.2.0
+  version: 1.3.0
 paths:
   /payroll/runs/preview:
     post:
@@ -12,6 +12,7 @@ paths:
   /payroll/runs/preview-with-deductions:
     post:
       summary: Create payroll preview with deduction and tax components (manual/profile mode)
+      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`.
       responses:
         "200":
           description: Deduction preview generated

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,11 +1,12 @@
 owner: payroll-agent
-version: 1.2.0
+version: 1.3.0
 scope:
   in:
     - gross pay preview from approved attendance aggregates
     - payroll run trace and audit logging
     - deduction and tax contract artifacts for phase 2 rollout
     - deduction profile policy and profile-mode preview
+    - profile version expectation guard for deterministic preview
   out:
     - country-specific legal tax engine implementation
     - external remittance and filing
@@ -72,6 +73,7 @@ invariants:
   - Gross pay is deterministic for same inputs and rules.
   - Net pay equals gross pay minus total deductions when phase2 fields are populated.
   - Profile-mode preview must persist profile ID and version trace.
+  - Profile-mode preview rejects request when expected profile version mismatches current profile version.
   - Payroll preview includes source attendance snapshot reference.
   - Recalculation after correction keeps immutable audit trail.
 risk:
@@ -93,6 +95,7 @@ test_plan:
     - consume attendance.approved and produce payroll preview
     - preview-with-deductions and confirm flow
     - deduction profile CRUD and authorization checks
+    - profile mode preview rejects stale expected profile version
   regression:
     - replay GC-001 through GC-006 fixtures
   authorization:
@@ -129,12 +132,13 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.2.0 adds non-breaking deduction profile endpoints and profile-mode metadata for phase2 preview."
+consumer_impact: "Contract v1.3.0 adds non-breaking expectedProfileVersion guard for profile-mode deduction preview."
 references:
   - specs/common/time-and-payroll-rules.md
   - specs/payroll/phase2-compatibility-matrix.md
   - specs/payroll/deduction-profile.md
   - work-items/WI-0006-payroll-phase2-deduction-policy-runtime.md
+  - work-items/WI-0010-payroll-profile-version-guard.md
   - adr/ADR-0002-payroll-phase2-auto-deduction-policy.md
 approval:
   spec_owner: payroll-agent

--- a/specs/payroll/deduction-profile.md
+++ b/specs/payroll/deduction-profile.md
@@ -36,9 +36,11 @@ Rounding follows `specs/common/time-and-payroll-rules.md`.
 - Profile-mode preview persists:
   - `deductionProfileId`
   - `deductionProfileVersion`
+- Profile-mode preview may include optional `expectedProfileVersion` request field for optimistic version guard.
 
 ## Validation Rules
 
 - Reject when any calculated deduction component is negative.
 - Reject when `netPayKrw < 0`.
 - Reject when profile is inactive.
+- Reject when `expectedProfileVersion` is provided and does not match the current profile version.

--- a/specs/payroll/phase2-compatibility-matrix.md
+++ b/specs/payroll/phase2-compatibility-matrix.md
@@ -11,7 +11,7 @@ This matrix defines how WI-0001 gross-pay behavior coexists with Phase 2 deducti
 | Legacy (WI-0001) | `payroll_deductions_v1=off` | `POST /payroll/runs/preview`, `POST /payroll/runs/{runId}/confirm` | `grossPayKrw` only required | No impact |
 | Hybrid | `payroll_deductions_v1=on` for selected org | existing + `POST /payroll/runs/preview-with-deductions` | additive deduction/net columns populated when phase2 endpoint used | Existing consumers continue with gross-only path |
 | Phase2 Primary | `payroll_deductions_v1=on` default | deduction preview endpoint preferred | deduction and net fields expected for new consumers | Legacy consumers still supported during deprecation window |
-| Phase2 Profile Mode (WI-0006) | `payroll_deductions_v1=on` + `payroll_deduction_profile_v1=on` | existing + `GET/PUT /payroll/deduction-profiles/{profileId}` | additive profile trace fields populated when profile mode is used | Manual phase2 consumers remain valid |
+| Phase2 Profile Mode (WI-0006 + WI-0010) | `payroll_deductions_v1=on` + `payroll_deduction_profile_v1=on` | existing + `GET/PUT /payroll/deduction-profiles/{profileId}` | additive profile trace fields populated when profile mode is used | Manual phase2 consumers remain valid |
 
 ## Field Compatibility
 
@@ -36,10 +36,17 @@ This matrix defines how WI-0001 gross-pay behavior coexists with Phase 2 deducti
 | `payroll.deductions.calculated.v1` | not emitted | emitted on phase2 path | additive |
 | `payroll.deduction_profile.updated.v1` | not emitted | emitted on profile configuration update | additive |
 
+## Request Compatibility
+
+| Request Field | WI-0001 | Phase 2 | Compatibility |
+| --- | --- | --- | --- |
+| `expectedProfileVersion` (profile mode) | absent | optional integer | additive |
+
 ## Rollout Guardrails
 
 1. Expand-contract only: no breaking mutation of existing endpoints.
 2. Gross-only regression suite must remain green in CI.
 3. `payroll_deductions_v1` defaults to `off` until consumer validation is complete.
 4. `payroll_deduction_profile_v1` defaults to `off` until profile auth/audit tests are green.
-5. Deprecation notice for gross-only integrations must follow `contracts/versioning.md` policy before default switch.
+5. `expectedProfileVersion` remains optional for backward compatibility; stale mismatch must return `409`.
+6. Deprecation notice for gross-only integrations must follow `contracts/versioning.md` policy before default switch.

--- a/specs/payroll/rfc.md
+++ b/specs/payroll/rfc.md
@@ -1,4 +1,4 @@
-# Payroll RFC (WI-0001 + WI-0005 + WI-0006 Contract)
+# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 Contract)
 
 ## Goal
 
@@ -11,6 +11,7 @@ Provide payroll gross pay preview based on attendance aggregates, phase2 deducti
 - Contract includes audit and deterministic recalculation invariants.
 - Phase2 deduction/tax path is feature-flagged and additive-only.
 - WI-0006 introduces profile-mode deduction calculation with versioned trace metadata.
+- WI-0010 introduces optional expected profile version guard to reject stale profile preview requests.
 
 ## Non-Goals
 

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -13,6 +13,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 5. Run deduction/tax preview with feature flag for phase2 contract path.
 6. Create/update deduction profile and read latest profile by ID.
 7. Run deduction/tax preview in `profile` mode without explicit deduction values.
+8. Reject profile-mode preview when `expectedProfileVersion` is stale.
 
 ## Accuracy Cases
 
@@ -22,6 +23,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 4. `totalDeductionsKrw` equals sum of deduction components.
 5. `netPayKrw` equals `grossPayKrw - totalDeductionsKrw`.
 6. Profile-mode calculation stores profile ID/version trace and remains deterministic.
+7. Profile-mode stale version guard returns deterministic `409` mismatch error.
 
 ## Regression Linkage
 

--- a/src/app/api/payroll/runs/preview-with-deductions/route.ts
+++ b/src/app/api/payroll/runs/preview-with-deductions/route.ts
@@ -35,7 +35,8 @@ export async function POST(request: Request) {
             hourlyRateKrw: parsed.data.hourlyRateKrw,
             multipliers: parsed.data.multipliers,
             deductionMode: "profile" as const,
-            profileId: parsed.data.profileId!
+            profileId: parsed.data.profileId!,
+            expectedProfileVersion: parsed.data.expectedProfileVersion
           }
         : {
             periodStart: new Date(parsed.data.periodStart),

--- a/src/features/payroll/schemas.ts
+++ b/src/features/payroll/schemas.ts
@@ -31,6 +31,7 @@ export const previewPayrollWithDeductionsSchema = previewPayrollSchema
   .extend({
     deductionMode: z.enum(["manual", "profile"]).default("manual"),
     profileId: z.string().min(1).optional(),
+    expectedProfileVersion: z.number().int().positive().optional(),
     deductions: manualDeductionsSchema.optional()
   })
   .superRefine((value, ctx) => {
@@ -46,6 +47,13 @@ export const previewPayrollWithDeductionsSchema = previewPayrollSchema
         code: z.ZodIssueCode.custom,
         path: ["profileId"],
         message: "profileId is required when deductionMode is profile"
+      });
+    }
+    if (value.deductionMode === "manual" && value.expectedProfileVersion !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["expectedProfileVersion"],
+        message: "expectedProfileVersion is supported only when deductionMode is profile"
       });
     }
   });

--- a/src/features/payroll/service.ts
+++ b/src/features/payroll/service.ts
@@ -32,6 +32,7 @@ type ManualDeductions = {
 type ProfileDeductions = {
   deductionMode: "profile";
   profileId: string;
+  expectedProfileVersion?: number;
 };
 
 type PreviewPayrollWithDeductionsInput = PreviewPayrollInput & (ManualDeductions | ProfileDeductions);
@@ -288,6 +289,12 @@ export async function previewPayrollWithDeductions(
     }
     if (profile.mode !== "profile") {
       throw new ServiceError(409, "deduction profile mode is not profile");
+    }
+    if (
+      input.expectedProfileVersion !== undefined &&
+      input.expectedProfileVersion !== profile.version
+    ) {
+      throw new ServiceError(409, "deduction profile version mismatch");
     }
 
     const withholdingRate = toRateNumber(profile.withholdingRate, "withholdingRate") ?? 0;

--- a/work-items/WI-0010-payroll-profile-version-guard.md
+++ b/work-items/WI-0010-payroll-profile-version-guard.md
@@ -1,0 +1,99 @@
+# WI-0010: Payroll Profile Version Guard for Deduction Preview
+
+## Background and Problem
+
+Profile-mode deduction preview currently uses the latest profile version by `profileId`.  
+When operators prepare a run with an older profile snapshot, a silent profile update can change net pay unexpectedly.
+
+## Scope
+
+### In Scope
+
+- Add optional `expectedProfileVersion` to profile-mode preview request.
+- Reject preview when expected version and current profile version do not match.
+- Extend memory/prisma e2e tests for stale-version rejection and successful retry.
+
+### Out of Scope
+
+- DB schema change for version locking.
+- Multi-profile fallback selection logic.
+- Legal tax rule engine expansion.
+
+## User Scenarios
+
+1. Payroll operator requests profile-mode preview with expected version and receives deterministic result.
+2. Payroll operator requests profile-mode preview with stale expected version and receives `409`.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: profile mode reads current profile by ID and validates expected version when provided.
+- Rounding rule: existing KRW rounding behavior remains unchanged.
+- Exception handling rule: stale profile mismatch returns `409 deduction profile version mismatch`.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Payroll Operator | Manager | Employee |
+| --- | --- | --- | --- | --- |
+| Run profile-mode preview with expected version | Allow | Allow | Deny | Deny |
+| Confirm payroll run | Allow | Allow | Deny | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: `DeductionProfile`, `PayrollRun`, `AuditLog`
+- Migration IDs: none
+- Backward compatibility plan: additive request field only; existing callers remain valid
+
+## API and Event Changes
+
+- Endpoints:
+  - `POST /api/payroll/runs/preview-with-deductions` (optional `expectedProfileVersion`)
+- Events published:
+  - no new event type; existing `payroll.deductions.calculated.v1` reused
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - profile version mismatch guard logic
+- Integration:
+  - stale version request returns `409`
+  - matching version request succeeds
+- Regression:
+  - WI-0006 memory/prisma e2e remains green
+- Authorization:
+  - payroll role enforcement unchanged
+- Payroll accuracy:
+  - successful profile-mode preview keeps deterministic deduction/net pay totals
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `payroll.preview_with_deductions.failed` (stale version path)
+  - `payroll.deductions_calculated` (success path)
+- Metrics:
+  - `payroll_deduction_profile_miss_count`
+- Alert conditions:
+  - stale-version reject spike
+
+## Rollback Plan
+
+- Feature flag behavior: disable `payroll_deduction_profile_v1` if guard causes operational issues.
+- DB rollback method: not applicable (no migration).
+- Recovery target time: 30m.
+
+## Definition of Ready (DoR)
+
+- [ ] Requirements are unambiguous and testable.
+- [ ] Domain contract drafted or updated.
+- [ ] Role matrix reviewed by QA.
+- [ ] Data migration impact assessed.
+- [ ] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## Summary
- add optional expectedProfileVersion request field for profile-mode payroll preview
- reject stale profile-version requests with 409 mismatch error
- extend WI-0006 memory/prisma e2e to validate stale-version rejection and successful retry
- bump payroll contract to v1.3.0 and sync compatibility/test/docs/work-item artifacts

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- python scripts/ci/check_golden_fixtures.py
- npm.cmd run test:e2e
- npm.cmd run test:e2e:prisma
- npm.cmd run build