### PR TITLE
ops(alert): unify Slack notifier and add webhook smoke workflow

### DIFF
--- a/.github/workflows/alert-webhook-smoke.yml
+++ b/.github/workflows/alert-webhook-smoke.yml
@@ -1,0 +1,36 @@
+name: alert-webhook-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: "Optional custom title for Slack smoke notification"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Send Slack smoke notification
+        env:
+          FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
+          FLOWHR_ALERT_REQUIRE_WEBHOOK: "true"
+          FLOWHR_ALERT_TITLE: ${{ inputs.message || '[FlowHR] alert-webhook-smoke' }}
+          FLOWHR_ALERT_WORKFLOW: "alert-webhook-smoke"
+          FLOWHR_ALERT_RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          FLOWHR_ALERT_REF: ${{ github.ref }}
+          FLOWHR_ALERT_TRIGGER: ${{ github.event_name }}
+        run: node scripts/ops/notify-slack-failure.mjs

--- a/.github/workflows/payroll-phase2-health.yml
+++ b/.github/workflows/payroll-phase2-health.yml
@@ -76,12 +76,10 @@ jobs:
       - name: Notify Slack on failure
         if: ${{ failure() }}
         env:
-          WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
-        run: |
-          if [ -z "$WEBHOOK" ]; then
-            echo "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification."
-            exit 0
-          fi
-          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          payload="{\"text\":\"[FlowHR] payroll-phase2-health failed: ${run_url}\"}"
-          curl -X POST -H "Content-type: application/json" --data "$payload" "$WEBHOOK"
+          FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
+          FLOWHR_ALERT_TITLE: "[FlowHR] payroll-phase2-health failed"
+          FLOWHR_ALERT_WORKFLOW: "payroll-phase2-health"
+          FLOWHR_ALERT_RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          FLOWHR_ALERT_REF: ${{ github.ref }}
+          FLOWHR_ALERT_TRIGGER: ${{ github.event_name }}
+        run: node scripts/ops/notify-slack-failure.mjs

--- a/.github/workflows/payroll-phase2-rollback.yml
+++ b/.github/workflows/payroll-phase2-rollback.yml
@@ -135,12 +135,11 @@ jobs:
       - name: Notify Slack on failure
         if: ${{ failure() }}
         env:
-          WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
-        run: |
-          if [ -z "$WEBHOOK" ]; then
-            echo "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification."
-            exit 0
-          fi
-          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          payload="{\"text\":\"[FlowHR] payroll-phase2-rollback failed: ${run_url}\"}"
-          curl -X POST -H "Content-type: application/json" --data "$payload" "$WEBHOOK"
+          FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
+          FLOWHR_ALERT_TITLE: "[FlowHR] payroll-phase2-rollback failed"
+          FLOWHR_ALERT_WORKFLOW: "payroll-phase2-rollback"
+          FLOWHR_ALERT_RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          FLOWHR_ALERT_REF: ${{ github.ref }}
+          FLOWHR_ALERT_TRIGGER: ${{ github.event_name }}
+          FLOWHR_ALERT_REASON: ${{ steps.mode.outputs.reason }}
+        run: node scripts/ops/notify-slack-failure.mjs

--- a/.github/workflows/production-auth-smoke.yml
+++ b/.github/workflows/production-auth-smoke.yml
@@ -102,12 +102,10 @@ jobs:
       - name: Notify Slack on failure
         if: ${{ failure() }}
         env:
-          WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
-        run: |
-          if [ -z "$WEBHOOK" ]; then
-            echo "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification."
-            exit 0
-          fi
-          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          payload="{\"text\":\"[FlowHR] production-auth-smoke failed: ${run_url}\"}"
-          curl -X POST -H "Content-type: application/json" --data "$payload" "$WEBHOOK"
+          FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
+          FLOWHR_ALERT_TITLE: "[FlowHR] production-auth-smoke failed"
+          FLOWHR_ALERT_WORKFLOW: "production-auth-smoke"
+          FLOWHR_ALERT_RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          FLOWHR_ALERT_REF: ${{ github.ref }}
+          FLOWHR_ALERT_TRIGGER: ${{ github.event_name }}
+        run: node scripts/ops/notify-slack-failure.mjs

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -47,6 +47,10 @@ Completed:
   - profile-mode preview accepts optional `expectedProfileVersion`
   - stale profile version requests are blocked with `409`
   - memory/prisma e2e assertions added
+- WI-0011 alert workflow hardening is implemented:
+  - Slack failure notifications unified via `scripts/ops/notify-slack-failure.mjs`
+  - production failure workflows switched from inline curl to common notifier
+  - manual `alert-webhook-smoke` workflow added for webhook connectivity check
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -55,7 +59,7 @@ Completed:
 
 Open gaps:
 
-- `FLOWHR_ALERT_SLACK_WEBHOOK` is not connected yet (failure alerts are GitHub issue-only right now).
+- `FLOWHR_ALERT_SLACK_WEBHOOK` secret value is still not configured in production environment.
 
 ## 2) Priority Roadmap
 
@@ -131,6 +135,7 @@ Tasks:
 16. Add WI-0008 duplicate transition guard for approval/confirmation flows. (Completed: 2026-02-13)
 17. Add WI-0009 attendance rejection flow and payroll exclusion regression coverage. (Completed: 2026-02-13)
 18. Add WI-0010 profile-mode expected version guard for deduction preview. (Completed: 2026-02-13)
+19. Unify Slack failure notifications and add manual alert webhook smoke workflow. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -83,6 +83,7 @@ Workflow: `.github/workflows/payroll-phase2-health.yml`
   - `payroll.confirmed`
 - Tracks `403` / `409` failure ratios for phase2 preview path.
 - Creates GitHub issue on failure and can notify Slack when `FLOWHR_ALERT_SLACK_WEBHOOK` is configured.
+- Slack notification payload is sent via `scripts/ops/notify-slack-failure.mjs`.
 
 Tunable production environment variables:
 
@@ -106,6 +107,20 @@ Workflow: `.github/workflows/payroll-phase2-rollback.yml`
   - uses production vars:
     - `VERCEL_SCOPE` (default `yh-devs-projects`)
     - `VERCEL_PROJECT_NAME` (default `flowhr`)
+
+## Slack Alert Webhook Smoke Check
+
+Workflow: `.github/workflows/alert-webhook-smoke.yml`
+
+- Manual trigger only.
+- Fails fast when `FLOWHR_ALERT_SLACK_WEBHOOK` is missing in production environment secrets.
+- Sends one Slack message to validate webhook connectivity and payload format.
+
+Run command:
+
+```bash
+gh workflow run alert-webhook-smoke.yml -R yonghyeon-dev/FlowHR
+```
 
 ## Rollback
 

--- a/scripts/ops/notify-slack-failure.mjs
+++ b/scripts/ops/notify-slack-failure.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+function isTruthy(value) {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+async function run() {
+  const webhook = process.env.FLOWHR_ALERT_SLACK_WEBHOOK ?? "";
+  const requireWebhook = isTruthy(process.env.FLOWHR_ALERT_REQUIRE_WEBHOOK);
+
+  if (!webhook) {
+    const message = "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification.";
+    if (requireWebhook) {
+      console.error(message);
+      process.exit(1);
+    }
+    console.log(message);
+    return;
+  }
+
+  const title = process.env.FLOWHR_ALERT_TITLE ?? "[FlowHR] workflow failure";
+  const workflow = process.env.FLOWHR_ALERT_WORKFLOW ?? "unknown-workflow";
+  const runUrl = process.env.FLOWHR_ALERT_RUN_URL ?? "";
+  const ref = process.env.FLOWHR_ALERT_REF ?? "";
+  const trigger = process.env.FLOWHR_ALERT_TRIGGER ?? "";
+  const reason = process.env.FLOWHR_ALERT_REASON ?? "";
+
+  const lines = [title, `- Workflow: ${workflow}`];
+  if (runUrl) {
+    lines.push(`- Run: ${runUrl}`);
+  }
+  if (ref) {
+    lines.push(`- Ref: ${ref}`);
+  }
+  if (trigger) {
+    lines.push(`- Trigger: ${trigger}`);
+  }
+  if (reason) {
+    lines.push(`- Reason: ${reason}`);
+  }
+
+  const payload = JSON.stringify({ text: lines.join("\n") });
+  const response = await fetch(webhook, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: payload
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Slack webhook request failed: ${response.status} ${body}`);
+  }
+
+  console.log("Slack notification sent.");
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/work-items/WI-0011-slack-alert-unification.md
+++ b/work-items/WI-0011-slack-alert-unification.md
@@ -1,0 +1,94 @@
+# WI-0011: Slack Alert Unification and Webhook Smoke Workflow
+
+## Background and Problem
+
+Failure workflows currently embed Slack webhook `curl` logic inline.  
+This duplicates payload construction, makes auditing difficult, and leaves webhook connectivity checks ad hoc.
+
+## Scope
+
+### In Scope
+
+- Add shared Slack notifier script for workflow failure notifications.
+- Replace inline Slack notification steps in production failure workflows.
+- Add manual workflow to smoke-test webhook connectivity.
+
+### Out of Scope
+
+- Slack channel routing by severity.
+- PagerDuty/Opsgenie integration.
+- Automatic secret provisioning.
+
+## User Scenarios
+
+1. Operator receives consistent Slack messages from production failure workflows.
+2. Operator triggers a manual smoke workflow to verify webhook configuration before release windows.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: operational alerting must include workflow/run metadata for traceability.
+- Rounding rule: not applicable.
+- Exception handling rule: missing webhook returns non-fatal skip for failure workflows and hard-fail for smoke workflow.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Payroll Operator | Manager | Employee |
+| --- | --- | --- | --- | --- |
+| Configure production Slack webhook secret | Allow | Deny | Deny | Deny |
+| Trigger alert-webhook-smoke workflow | Allow | Allow | Deny | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: workflow/script-only additive change
+
+## API and Event Changes
+
+- Endpoints: none
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - notifier script truthy parsing and missing webhook behavior
+- Integration:
+  - failure workflows invoke notifier with workflow metadata env
+- Regression:
+  - existing CI quality gates remain green
+- Authorization:
+  - production environment secret remains required for actual webhook send
+- Payroll accuracy:
+  - not applicable
+
+## Observability and Audit Logging
+
+- Audit events:
+  - none (workflow-level operation)
+- Metrics:
+  - failure workflow notification send success/failure from job logs
+- Alert conditions:
+  - webhook smoke workflow failure
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable.
+- Recovery target time: 15m (revert workflow/script changes).
+
+## Definition of Ready (DoR)
+
+- [ ] Requirements are unambiguous and testable.
+- [ ] Domain contract drafted or updated.
+- [ ] Role matrix reviewed by QA.
+- [ ] Data migration impact assessed.
+- [ ] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## Summary
- replace duplicated inline Slack curl blocks with shared scripts/ops/notify-slack-failure.mjs
- wire production failure workflows to use shared notifier payload format
- add manual lert-webhook-smoke workflow for webhook connectivity validation
- sync execution plan/rollout docs and add WI-0011 artifact

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- npm.cmd run build