### PR TITLE
docs(plan): clarify alert webhook smoke follow-up

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -176,4 +176,4 @@ Request template:
 Without additional input, the next executable step is:
 
 1. observe the next scheduled rollback dry-run result and keep it green,
-2. connect `FLOWHR_ALERT_SLACK_WEBHOOK` to receive workflow failure alerts.
+2. set `FLOWHR_ALERT_SLACK_WEBHOOK` in production secrets and re-run `alert-webhook-smoke` to verify delivery.


### PR DESCRIPTION
## Summary
- update immediate next action in execution plan
- explicitly require rerunning lert-webhook-smoke after setting FLOWHR_ALERT_SLACK_WEBHOOK

## Validation
- docs-only change