### PR TITLE
ops(alert): support Discord webhook with Slack fallback

### DIFF
--- a/.github/workflows/alert-webhook-smoke.yml
+++ b/.github/workflows/alert-webhook-smoke.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       message:
-        description: "Optional custom title for Slack smoke notification"
+        description: "Optional custom title for webhook smoke notification"
         required: false
         type: string
 
@@ -24,8 +24,9 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Send Slack smoke notification
+      - name: Send webhook smoke notification
         env:
+          FLOWHR_ALERT_DISCORD_WEBHOOK: ${{ secrets.FLOWHR_ALERT_DISCORD_WEBHOOK }}
           FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
           FLOWHR_ALERT_REQUIRE_WEBHOOK: "true"
           FLOWHR_ALERT_TITLE: ${{ inputs.message || '[FlowHR] alert-webhook-smoke' }}

--- a/.github/workflows/payroll-phase2-health.yml
+++ b/.github/workflows/payroll-phase2-health.yml
@@ -73,9 +73,10 @@ jobs:
               labels: ["incident", "phase2", "ops"]
             });
 
-      - name: Notify Slack on failure
+      - name: Notify alert webhook on failure
         if: ${{ failure() }}
         env:
+          FLOWHR_ALERT_DISCORD_WEBHOOK: ${{ secrets.FLOWHR_ALERT_DISCORD_WEBHOOK }}
           FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
           FLOWHR_ALERT_TITLE: "[FlowHR] payroll-phase2-health failed"
           FLOWHR_ALERT_WORKFLOW: "payroll-phase2-health"

--- a/.github/workflows/payroll-phase2-rollback.yml
+++ b/.github/workflows/payroll-phase2-rollback.yml
@@ -132,9 +132,10 @@ jobs:
               labels: ["incident", "rollback", "phase2"]
             });
 
-      - name: Notify Slack on failure
+      - name: Notify alert webhook on failure
         if: ${{ failure() }}
         env:
+          FLOWHR_ALERT_DISCORD_WEBHOOK: ${{ secrets.FLOWHR_ALERT_DISCORD_WEBHOOK }}
           FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
           FLOWHR_ALERT_TITLE: "[FlowHR] payroll-phase2-rollback failed"
           FLOWHR_ALERT_WORKFLOW: "payroll-phase2-rollback"

--- a/.github/workflows/production-auth-smoke.yml
+++ b/.github/workflows/production-auth-smoke.yml
@@ -99,9 +99,10 @@ jobs:
               labels: ["incident", "production", "smoke"]
             });
 
-      - name: Notify Slack on failure
+      - name: Notify alert webhook on failure
         if: ${{ failure() }}
         env:
+          FLOWHR_ALERT_DISCORD_WEBHOOK: ${{ secrets.FLOWHR_ALERT_DISCORD_WEBHOOK }}
           FLOWHR_ALERT_SLACK_WEBHOOK: ${{ secrets.FLOWHR_ALERT_SLACK_WEBHOOK }}
           FLOWHR_ALERT_TITLE: "[FlowHR] production-auth-smoke failed"
           FLOWHR_ALERT_WORKFLOW: "production-auth-smoke"

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -48,9 +48,13 @@ Completed:
   - stale profile version requests are blocked with `409`
   - memory/prisma e2e assertions added
 - WI-0011 alert workflow hardening is implemented:
-  - Slack failure notifications unified via `scripts/ops/notify-slack-failure.mjs`
+  - webhook failure notifications unified via `scripts/ops/notify-slack-failure.mjs`
   - production failure workflows switched from inline curl to common notifier
   - manual `alert-webhook-smoke` workflow added for webhook connectivity check
+- WI-0013 alert webhook provider expansion is implemented:
+  - notifier supports Discord and Slack webhook payloads
+  - production workflows read `FLOWHR_ALERT_DISCORD_WEBHOOK` first, then Slack fallback
+  - webhook smoke gate validates configured alert channel regardless of provider
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -59,7 +63,7 @@ Completed:
 
 Open gaps:
 
-- `FLOWHR_ALERT_SLACK_WEBHOOK` secret value is still not configured in production environment.
+- `FLOWHR_ALERT_DISCORD_WEBHOOK` (or Slack fallback) secret value must be configured in production environment.
 
 ## 2) Priority Roadmap
 
@@ -136,6 +140,7 @@ Tasks:
 17. Add WI-0009 attendance rejection flow and payroll exclusion regression coverage. (Completed: 2026-02-13)
 18. Add WI-0010 profile-mode expected version guard for deduction preview. (Completed: 2026-02-13)
 19. Unify Slack failure notifications and add manual alert webhook smoke workflow. (Completed: 2026-02-13)
+20. Add Discord-compatible alert webhook path with Slack fallback. (Completed: 2026-02-13)
 
 Definition of Done:
 
@@ -169,11 +174,11 @@ Request template:
 ## 5) Inputs Needed From You (Conditional)
 
 1. To proceed with payroll Phase 2:
-   - Provide Slack webhook for workflow failure alerts (optional but recommended)
+   - Provide Discord or Slack webhook for workflow failure alerts (optional but recommended)
 
 ## 6) Immediate Next Actions
 
 Without additional input, the next executable step is:
 
 1. observe the next scheduled rollback dry-run result and keep it green,
-2. set `FLOWHR_ALERT_SLACK_WEBHOOK` in production secrets and re-run `alert-webhook-smoke` to verify delivery.
+2. set `FLOWHR_ALERT_DISCORD_WEBHOOK` (or Slack fallback) in production secrets and re-run `alert-webhook-smoke` to verify delivery.

--- a/docs/production-rollout.md
+++ b/docs/production-rollout.md
@@ -82,8 +82,8 @@ Workflow: `.github/workflows/payroll-phase2-health.yml`
   - `payroll.preview_with_deductions.failed`
   - `payroll.confirmed`
 - Tracks `403` / `409` failure ratios for phase2 preview path.
-- Creates GitHub issue on failure and can notify Slack when `FLOWHR_ALERT_SLACK_WEBHOOK` is configured.
-- Slack notification payload is sent via `scripts/ops/notify-slack-failure.mjs`.
+- Creates GitHub issue on failure and can notify Discord/Slack when webhook secrets are configured.
+- Webhook notification payload is sent via `scripts/ops/notify-slack-failure.mjs` (Discord/Slack auto-detect).
 
 Tunable production environment variables:
 
@@ -108,13 +108,13 @@ Workflow: `.github/workflows/payroll-phase2-rollback.yml`
     - `VERCEL_SCOPE` (default `yh-devs-projects`)
     - `VERCEL_PROJECT_NAME` (default `flowhr`)
 
-## Slack Alert Webhook Smoke Check
+## Alert Webhook Smoke Check
 
 Workflow: `.github/workflows/alert-webhook-smoke.yml`
 
 - Manual trigger only.
-- Fails fast when `FLOWHR_ALERT_SLACK_WEBHOOK` is missing in production environment secrets.
-- Sends one Slack message to validate webhook connectivity and payload format.
+- Fails fast when neither `FLOWHR_ALERT_DISCORD_WEBHOOK` nor `FLOWHR_ALERT_SLACK_WEBHOOK` is configured.
+- Sends one Discord/Slack message to validate webhook connectivity and payload format.
 
 Run command:
 

--- a/scripts/ops/notify-slack-failure.mjs
+++ b/scripts/ops/notify-slack-failure.mjs
@@ -8,12 +8,55 @@ function isTruthy(value) {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+function normalize(value) {
+  return (value ?? "").trim();
+}
+
+function resolveWebhook() {
+  const direct = normalize(process.env.FLOWHR_ALERT_WEBHOOK_URL);
+  if (direct) {
+    return { url: direct, source: "FLOWHR_ALERT_WEBHOOK_URL" };
+  }
+
+  const discord = normalize(process.env.FLOWHR_ALERT_DISCORD_WEBHOOK);
+  if (discord) {
+    return { url: discord, source: "FLOWHR_ALERT_DISCORD_WEBHOOK" };
+  }
+
+  const slack = normalize(process.env.FLOWHR_ALERT_SLACK_WEBHOOK);
+  if (slack) {
+    return { url: slack, source: "FLOWHR_ALERT_SLACK_WEBHOOK" };
+  }
+
+  return null;
+}
+
+function resolveProvider(webhookUrl) {
+  const configured = normalize(process.env.FLOWHR_ALERT_WEBHOOK_PROVIDER).toLowerCase();
+  if (configured === "discord" || configured === "slack") {
+    return configured;
+  }
+
+  if (
+    webhookUrl.includes("discord.com/api/webhooks/") ||
+    webhookUrl.includes("discordapp.com/api/webhooks/")
+  ) {
+    return "discord";
+  }
+  if (webhookUrl.includes("hooks.slack.com/services/")) {
+    return "slack";
+  }
+
+  return "slack";
+}
+
 async function run() {
-  const webhook = process.env.FLOWHR_ALERT_SLACK_WEBHOOK ?? "";
+  const webhook = resolveWebhook();
   const requireWebhook = isTruthy(process.env.FLOWHR_ALERT_REQUIRE_WEBHOOK);
 
   if (!webhook) {
-    const message = "FLOWHR_ALERT_SLACK_WEBHOOK not configured; skip Slack notification.";
+    const message =
+      "Alert webhook not configured; set FLOWHR_ALERT_DISCORD_WEBHOOK, FLOWHR_ALERT_SLACK_WEBHOOK, or FLOWHR_ALERT_WEBHOOK_URL.";
     if (requireWebhook) {
       console.error(message);
       process.exit(1);
@@ -21,6 +64,7 @@ async function run() {
     console.log(message);
     return;
   }
+  const provider = resolveProvider(webhook.url);
 
   const title = process.env.FLOWHR_ALERT_TITLE ?? "[FlowHR] workflow failure";
   const workflow = process.env.FLOWHR_ALERT_WORKFLOW ?? "unknown-workflow";
@@ -42,9 +86,14 @@ async function run() {
   if (reason) {
     lines.push(`- Reason: ${reason}`);
   }
+  const message = lines.join("\n");
 
-  const payload = JSON.stringify({ text: lines.join("\n") });
-  const response = await fetch(webhook, {
+  const payload =
+    provider === "discord"
+      ? JSON.stringify({ content: message })
+      : JSON.stringify({ text: message });
+
+  const response = await fetch(webhook.url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: payload
@@ -52,10 +101,10 @@ async function run() {
 
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(`Slack webhook request failed: ${response.status} ${body}`);
+    throw new Error(`${provider} webhook request failed: ${response.status} ${body}`);
   }
 
-  console.log("Slack notification sent.");
+  console.log(`Alert notification sent via ${provider} (${webhook.source}).`);
 }
 
 run().catch((error) => {

--- a/work-items/WI-0013-discord-alert-webhook-support.md
+++ b/work-items/WI-0013-discord-alert-webhook-support.md
@@ -1,0 +1,97 @@
+# WI-0013: Discord Alert Webhook Support with Slack Fallback
+
+## Background and Problem
+
+Current failure-alert pipeline is wired for Slack-oriented payloads and secret naming.
+The operator requested Discord webhook as the primary alert channel.
+
+## Scope
+
+### In Scope
+
+- Extend alert notifier to support Discord webhook payload format.
+- Keep Slack compatibility for existing environments.
+- Update failure workflows and webhook smoke workflow to use Discord-first secret resolution.
+
+### Out of Scope
+
+- Multi-channel fan-out (send to both Discord and Slack simultaneously).
+- Provider-specific message templates by severity.
+- Alert acknowledgement workflows.
+
+## User Scenarios
+
+1. Operator configures Discord webhook and receives workflow failure notifications.
+2. Existing Slack setup continues to work without code changes.
+3. Webhook smoke workflow fails when no alert webhook is configured.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: alerts must include workflow name and run URL for traceability.
+- Rounding rule: not applicable.
+- Exception handling rule: missing webhook is non-fatal for failure hooks, fatal for smoke workflow.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Payroll Operator | Manager | Employee |
+| --- | --- | --- | --- | --- |
+| Configure production alert webhook secret | Allow | Deny | Deny | Deny |
+| Trigger `alert-webhook-smoke` workflow | Allow | Allow | Deny | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: additive workflow/script update only
+
+## API and Event Changes
+
+- Endpoints: none
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - webhook provider auto-detection (discord/slack)
+  - missing webhook guard behavior (`requireWebhook=true/false`)
+- Integration:
+  - failure workflows pass provider secrets to notifier
+  - smoke workflow enforces webhook presence
+- Regression:
+  - CI quality gates remain green
+- Authorization:
+  - production secret write remains admin-only
+- Payroll accuracy:
+  - not applicable
+
+## Observability and Audit Logging
+
+- Audit events:
+  - none (workflow layer)
+- Metrics:
+  - workflow notification success/failure logs
+- Alert conditions:
+  - `alert-webhook-smoke` failure
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable.
+- Recovery target time: 15m by reverting workflow/script changes.
+
+## Definition of Ready (DoR)
+
+- [ ] Requirements are unambiguous and testable.
+- [ ] Domain contract drafted or updated.
+- [ ] Role matrix reviewed by QA.
+- [ ] Data migration impact assessed.
+- [ ] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## Summary
- extend alert notifier to support Discord payloads with webhook auto-detection
- keep Slack compatibility as fallback path
- update production failure workflows and webhook smoke workflow to pass Discord secret
- add WI-0013 and update rollout/execution docs

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- python scripts/ci/check_traceability.py
- python scripts/ci/check_contracts.py
- npm.cmd run build