### PR TITLE
test(ops): add alert webhook regression tests to integration gate

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -55,6 +55,10 @@ Completed:
   - notifier supports Discord and Slack webhook payloads
   - production workflows read `FLOWHR_ALERT_DISCORD_WEBHOOK` first, then Slack fallback
   - webhook smoke gate validates configured alert channel regardless of provider
+- WI-0014 alert webhook regression tests are implemented:
+  - notifier payload/guard/failure paths covered by `ops-alert-webhook.test.ts`
+  - `test:integration` now includes alert webhook regression test
+  - CI quality gate blocks notifier regression before merge
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -63,7 +67,7 @@ Completed:
 
 Open gaps:
 
-- `FLOWHR_ALERT_DISCORD_WEBHOOK` (or Slack fallback) secret value must be configured in production environment.
+- none blocking for current MVP+ hardening scope
 
 ## 2) Priority Roadmap
 
@@ -141,6 +145,7 @@ Tasks:
 18. Add WI-0010 profile-mode expected version guard for deduction preview. (Completed: 2026-02-13)
 19. Unify Slack failure notifications and add manual alert webhook smoke workflow. (Completed: 2026-02-13)
 20. Add Discord-compatible alert webhook path with Slack fallback. (Completed: 2026-02-13)
+21. Add alert webhook regression tests and include them in integration gate. (Completed: 2026-02-13)
 
 Definition of Done:
 
@@ -174,11 +179,11 @@ Request template:
 ## 5) Inputs Needed From You (Conditional)
 
 1. To proceed with payroll Phase 2:
-   - Provide Discord or Slack webhook for workflow failure alerts (optional but recommended)
+   - no additional mandatory input right now
 
 ## 6) Immediate Next Actions
 
 Without additional input, the next executable step is:
 
 1. observe the next scheduled rollback dry-run result and keep it green,
-2. set `FLOWHR_ALERT_DISCORD_WEBHOOK` (or Slack fallback) in production secrets and re-run `alert-webhook-smoke` to verify delivery.
+2. monitor weekly rollback rehearsal and respond to issue/Discord alerts if any fail.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "tsx scripts/tests/unit.test.ts",
-    "test:integration": "tsx scripts/tests/integration.test.ts && tsx scripts/tests/event-transport-http.test.ts",
+    "test:integration": "tsx scripts/tests/integration.test.ts && tsx scripts/tests/event-transport-http.test.ts && tsx scripts/tests/ops-alert-webhook.test.ts",
     "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile.test.ts",
     "test:e2e:leave": "tsx scripts/tests/e2e-wi0002-leave.test.ts",
     "test:e2e:prisma": "tsx scripts/tests/e2e-wi0001-prisma.test.ts && tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2-prisma.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile-prisma.test.ts",

--- a/scripts/tests/ops-alert-webhook.test.ts
+++ b/scripts/tests/ops-alert-webhook.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import http from "node:http";
+import path from "node:path";
+
+type CommandResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+type CapturedRequest = {
+  method: string;
+  body: string;
+};
+
+const notifierScriptPath = path.resolve(process.cwd(), "scripts", "ops", "notify-slack-failure.mjs");
+
+async function runNotifier(env: Record<string, string | undefined>): Promise<CommandResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [notifierScriptPath], {
+      env: {
+        ...process.env,
+        ...env
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({
+        code,
+        stdout,
+        stderr
+      });
+    });
+  });
+}
+
+async function startWebhookServer(responseStatus = 200, responseBody = "ok") {
+  const capturedRequests: CapturedRequest[] = [];
+
+  const server = http.createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) {
+      chunks.push(Buffer.from(chunk));
+    }
+    capturedRequests.push({
+      method: request.method ?? "UNKNOWN",
+      body: Buffer.concat(chunks).toString("utf8")
+    });
+    response.statusCode = responseStatus;
+    response.end(responseBody);
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to acquire test webhook server address");
+  }
+
+  return {
+    webhookUrl: `http://127.0.0.1:${address.port}/webhook`,
+    capturedRequests,
+    async close() {
+      server.close();
+      await once(server, "close");
+    }
+  };
+}
+
+async function testMissingWebhookAllowsPass() {
+  const result = await runNotifier({
+    FLOWHR_ALERT_WEBHOOK_URL: "",
+    FLOWHR_ALERT_DISCORD_WEBHOOK: "",
+    FLOWHR_ALERT_SLACK_WEBHOOK: "",
+    FLOWHR_ALERT_REQUIRE_WEBHOOK: "false"
+  });
+  assert.equal(result.code, 0, "missing webhook should be non-fatal when require flag is false");
+  assert.match(result.stdout, /Alert webhook not configured/, "stdout should describe missing webhook");
+}
+
+async function testMissingWebhookFailsWhenRequired() {
+  const result = await runNotifier({
+    FLOWHR_ALERT_WEBHOOK_URL: "",
+    FLOWHR_ALERT_DISCORD_WEBHOOK: "",
+    FLOWHR_ALERT_SLACK_WEBHOOK: "",
+    FLOWHR_ALERT_REQUIRE_WEBHOOK: "true"
+  });
+  assert.equal(result.code, 1, "missing webhook should fail when require flag is true");
+  assert.match(result.stderr, /Alert webhook not configured/, "stderr should describe missing webhook");
+}
+
+async function testDiscordPayloadShape() {
+  const server = await startWebhookServer();
+  try {
+    const result = await runNotifier({
+      FLOWHR_ALERT_WEBHOOK_URL: server.webhookUrl,
+      FLOWHR_ALERT_WEBHOOK_PROVIDER: "discord",
+      FLOWHR_ALERT_TITLE: "[FlowHR] discord test",
+      FLOWHR_ALERT_WORKFLOW: "ops-alert-webhook-test",
+      FLOWHR_ALERT_RUN_URL: "https://example.com/run/discord",
+      FLOWHR_ALERT_REF: "refs/heads/main",
+      FLOWHR_ALERT_TRIGGER: "workflow_dispatch"
+    });
+
+    assert.equal(result.code, 0, "discord webhook send should succeed");
+    assert.match(result.stdout, /sent via discord/i);
+    assert.equal(server.capturedRequests.length, 1, "discord webhook should receive exactly one request");
+
+    const payload = JSON.parse(server.capturedRequests[0].body) as Record<string, unknown>;
+    assert.equal(typeof payload.content, "string", "discord payload should use content field");
+    assert.equal(payload.text, undefined, "discord payload should not include slack text field");
+    assert.match(String(payload.content), /\[FlowHR\] discord test/);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testSlackPayloadShape() {
+  const server = await startWebhookServer();
+  try {
+    const result = await runNotifier({
+      FLOWHR_ALERT_WEBHOOK_URL: server.webhookUrl,
+      FLOWHR_ALERT_WEBHOOK_PROVIDER: "slack",
+      FLOWHR_ALERT_TITLE: "[FlowHR] slack test",
+      FLOWHR_ALERT_WORKFLOW: "ops-alert-webhook-test",
+      FLOWHR_ALERT_RUN_URL: "https://example.com/run/slack",
+      FLOWHR_ALERT_REF: "refs/heads/main",
+      FLOWHR_ALERT_TRIGGER: "workflow_dispatch"
+    });
+
+    assert.equal(result.code, 0, "slack webhook send should succeed");
+    assert.match(result.stdout, /sent via slack/i);
+    assert.equal(server.capturedRequests.length, 1, "slack webhook should receive exactly one request");
+
+    const payload = JSON.parse(server.capturedRequests[0].body) as Record<string, unknown>;
+    assert.equal(typeof payload.text, "string", "slack payload should use text field");
+    assert.equal(payload.content, undefined, "slack payload should not include discord content field");
+    assert.match(String(payload.text), /\[FlowHR\] slack test/);
+  } finally {
+    await server.close();
+  }
+}
+
+async function testWebhookFailurePropagatesExitCode() {
+  const server = await startWebhookServer(500, "internal-error");
+  try {
+    const result = await runNotifier({
+      FLOWHR_ALERT_WEBHOOK_URL: server.webhookUrl,
+      FLOWHR_ALERT_WEBHOOK_PROVIDER: "discord",
+      FLOWHR_ALERT_TITLE: "[FlowHR] failure test",
+      FLOWHR_ALERT_WORKFLOW: "ops-alert-webhook-test"
+    });
+
+    assert.equal(result.code, 1, "non-2xx webhook response should fail");
+    assert.match(result.stderr, /webhook request failed/i);
+    assert.equal(server.capturedRequests.length, 1, "failed webhook call should still send one request");
+  } finally {
+    await server.close();
+  }
+}
+
+async function run() {
+  await testMissingWebhookAllowsPass();
+  await testMissingWebhookFailsWhenRequired();
+  await testDiscordPayloadShape();
+  await testSlackPayloadShape();
+  await testWebhookFailurePropagatesExitCode();
+}
+
+run()
+  .then(() => {
+    console.log("ops-alert-webhook.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/work-items/WI-0014-alert-webhook-regression-tests.md
+++ b/work-items/WI-0014-alert-webhook-regression-tests.md
@@ -1,0 +1,97 @@
+# WI-0014: Alert Webhook Regression Tests in CI
+
+## Background and Problem
+
+Alert webhook logic now supports Discord and Slack payloads, but CI does not directly test payload shape and failure handling.
+Without dedicated regression tests, provider-specific changes can break production alerts silently.
+
+## Scope
+
+### In Scope
+
+- Add alert webhook regression tests for notifier script behavior.
+- Validate Discord payload shape, Slack payload shape, missing webhook guard, and non-2xx failure handling.
+- Include alert webhook tests in `test:integration` so `quality-gates` blocks regressions.
+
+### Out of Scope
+
+- External webhook endpoint integration tests.
+- Alert message formatting by domain severity.
+- Multi-channel fan-out policy.
+
+## User Scenarios
+
+1. Developer changes notifier code and CI catches payload regression before merge.
+2. Operator can trust that Discord/Slack alert path remains functional after refactor.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: operational alerts must remain deterministic and machine-validated in CI.
+- Rounding rule: not applicable.
+- Exception handling rule: notifier exits with code `1` for required-webhook-missing or webhook non-2xx.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Payroll Operator | Manager | Employee |
+| --- | --- | --- | --- | --- |
+| Modify alert notifier script/tests | Allow | Allow | Deny | Deny |
+| Merge CI gate changes | Allow | Allow | Deny | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: script/test-only additive change
+
+## API and Event Changes
+
+- Endpoints: none
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - missing webhook with `FLOWHR_ALERT_REQUIRE_WEBHOOK=false` returns success
+  - missing webhook with `FLOWHR_ALERT_REQUIRE_WEBHOOK=true` returns failure
+- Integration:
+  - local HTTP server captures Discord `content` payload
+  - local HTTP server captures Slack `text` payload
+  - non-2xx webhook response returns failure
+- Regression:
+  - `npm run test:integration` includes alert webhook tests
+- Authorization:
+  - no auth surface change
+- Payroll accuracy:
+  - not applicable
+
+## Observability and Audit Logging
+
+- Audit events:
+  - none
+- Metrics:
+  - CI pass/fail for `test:integration`
+- Alert conditions:
+  - `quality-gates` failure on notifier regression
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable.
+- Recovery target time: 15m by reverting script/test integration.
+
+## Definition of Ready (DoR)
+
+- [ ] Requirements are unambiguous and testable.
+- [ ] Domain contract drafted or updated.
+- [ ] Role matrix reviewed by QA.
+- [ ] Data migration impact assessed.
+- [ ] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## Summary
- add scripts/tests/ops-alert-webhook.test.ts for notifier regression coverage
- validate missing-webhook guard, discord/slack payload shape, and non-2xx failure path
- include alert webhook regression test in 
pm run test:integration
- add WI-0014 artifact and sync execution plan progress

## Validation
- npm.cmd run lint
- npm.cmd run typecheck
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- npm.cmd run test:integration
- npm.cmd run build