### PR TITLE
feat(attendance): add rejection reason traceability

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -63,6 +63,10 @@ Completed:
   - `check_traceability.py` now validates runtime/contract/data-ownership event alignment
   - runtime event names must be represented in contracts and ownership matrix
   - invalid/unknown published event names are blocked by CI
+- WI-0016 attendance rejection reason traceability is implemented:
+  - reject API accepts optional `reason` payload with schema validation
+  - `attendance.rejected` audit/event payload now preserves rejection reason
+  - memory/prisma WI-0001 e2e asserts rejection reason traceability
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -151,6 +155,7 @@ Tasks:
 20. Add Discord-compatible alert webhook path with Slack fallback. (Completed: 2026-02-13)
 21. Add alert webhook regression tests and include them in integration gate. (Completed: 2026-02-13)
 22. Add runtime-contract-ownership event traceability checks to governance gate. (Completed: 2026-02-13)
+23. Add WI-0016 rejection reason traceability in reject API/audit/event and e2e tests. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/specs/attendance/api.yaml
+++ b/specs/attendance/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Attendance API
-  version: 1.1.0
+  version: 1.2.0
 paths:
   /attendance/records:
     post:
@@ -35,7 +35,8 @@ paths:
           description: Approved
   /attendance/records/{recordId}/reject:
     post:
-      summary: Reject attendance record or correction
+      summary: Reject attendance record or correction (optional reason)
+      description: Optional JSON body `{ \"reason\": string }` can be provided for audit/event trace.
       parameters:
         - in: path
           name: recordId

--- a/specs/attendance/contract.yaml
+++ b/specs/attendance/contract.yaml
@@ -1,9 +1,10 @@
 owner: attendance-agent
-version: 1.1.0
+version: 1.2.0
 scope:
   in:
     - attendance record create/update
     - correction approval/rejection flow
+    - rejection reason capture in audit/event payload
     - approved/rejected attendance event publication
   out:
     - payroll tax and deduction
@@ -31,7 +32,7 @@ api:
       description: Approve attendance record or correction.
     - method: POST
       path: /attendance/records/{recordId}/reject
-      description: Reject attendance record or correction.
+      description: Reject attendance record or correction with optional reason payload.
   events:
     published:
       - name: attendance.recorded.v1
@@ -39,7 +40,7 @@ api:
       - name: attendance.approved.v1
         description: Emitted when attendance is approved and payable.
       - name: attendance.rejected.v1
-        description: Emitted when attendance is rejected and excluded from payroll aggregation.
+        description: Emitted when attendance is rejected and excluded from payroll aggregation; includes optional reason.
       - name: attendance.corrected.v1
         description: Emitted when correction is approved.
     consumed:
@@ -74,6 +75,7 @@ test_plan:
   integration:
     - create record to approve flow
     - create record to reject flow
+    - reject flow with reason payload trace
   regression:
     - replay GC-001, GC-002, GC-003, GC-005
   authorization:
@@ -102,10 +104,11 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.1.0 adds non-breaking attendance rejection endpoint and event."
+consumer_impact: "Contract v1.2.0 adds non-breaking optional rejection reason payload for attendance reject flow."
 references:
   - specs/common/time-and-payroll-rules.md
   - work-items/WI-0009-attendance-rejection-flow.md
+  - work-items/WI-0016-attendance-rejection-reason.md
 approval:
   spec_owner: attendance-agent
   qa_owner: qa-agent

--- a/specs/attendance/rfc.md
+++ b/specs/attendance/rfc.md
@@ -7,6 +7,7 @@ Deliver attendance contract and API behavior needed for the first vertical slice
 ## Key Decisions
 
 - Contract-first schema and approval/rejection flow.
+- Optional rejection reason is captured for audit and event traceability.
 - Event publication after approval/rejection to feed payroll aggregation.
 - Time normalization delegated to common SSoT rules.
 

--- a/specs/attendance/test-cases.md
+++ b/specs/attendance/test-cases.md
@@ -9,9 +9,10 @@ Attendance create/update/approval behavior and output consistency for payroll ag
 1. Create attendance record within same business day.
 2. Update attendance before approval.
 3. Approve correction by manager role.
-4. Reject attendance by manager role and verify exclusion from payroll aggregation.
+4. Reject attendance by manager role with optional reason and verify exclusion from payroll aggregation.
 5. Reject unauthorized approval/rejection attempt.
 6. Emit final-state event once (`approved` or `rejected`).
+7. Rejection reason is preserved in audit/event payload when provided.
 
 ## Boundary and Accuracy Cases
 

--- a/src/app/api/attendance/records/[recordId]/reject/route.ts
+++ b/src/app/api/attendance/records/[recordId]/reject/route.ts
@@ -1,3 +1,4 @@
+import { rejectAttendanceSchema } from "@/features/attendance/schemas";
 import { rejectAttendanceRecord } from "@/features/attendance/service";
 import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
 import { isServiceError } from "@/features/shared/service-error";
@@ -10,13 +11,30 @@ type RouteContext = {
 
 export async function POST(request: Request, context: RouteContext) {
   const { recordId } = await context.params;
+  let reason: string | undefined;
+
+  try {
+    const rawBody = await request.text();
+    if (rawBody.trim().length > 0) {
+      const payload = JSON.parse(rawBody) as unknown;
+      const parsed = rejectAttendanceSchema.safeParse(payload);
+      if (!parsed.success) {
+        return fail(400, "invalid payload", parsed.error.flatten());
+      }
+      reason = parsed.data.reason;
+    }
+  } catch {
+    return fail(400, "invalid JSON body");
+  }
+
   try {
     const record = await rejectAttendanceRecord(
       {
         actor: await readActor(request),
         dataAccess: getRuntimeDataAccess()
       },
-      recordId
+      recordId,
+      reason
     );
     return ok({ record });
   } catch (error) {

--- a/src/features/attendance/schemas.ts
+++ b/src/features/attendance/schemas.ts
@@ -18,3 +18,7 @@ export const updateAttendanceSchema = z.object({
   isHoliday: z.boolean().optional(),
   notes: z.string().max(1000).optional()
 });
+
+export const rejectAttendanceSchema = z.object({
+  reason: z.string().min(1).max(500).optional()
+});

--- a/src/features/attendance/service.ts
+++ b/src/features/attendance/service.ts
@@ -193,7 +193,8 @@ export async function approveAttendanceRecord(
 
 export async function rejectAttendanceRecord(
   context: ServiceContext,
-  recordId: string
+  recordId: string,
+  reason?: string
 ): Promise<AttendanceRecordEntity> {
   if (!context.actor || !hasAnyRole(context.actor, ["admin", "manager"])) {
     throw new ServiceError(403, "rejection requires admin or manager role");
@@ -219,7 +220,8 @@ export async function rejectAttendanceRecord(
     actorRole: context.actor.role,
     actorId: context.actor.id,
     payload: {
-      employeeId: record.employeeId
+      employeeId: record.employeeId,
+      reason: reason ?? null
     }
   });
   await getEventPublisher(context).publish({
@@ -230,7 +232,8 @@ export async function rejectAttendanceRecord(
     actorRole: context.actor.role,
     actorId: context.actor.id,
     payload: {
-      employeeId: record.employeeId
+      employeeId: record.employeeId,
+      reason: reason ?? null
     }
   });
 

--- a/src/features/shared/memory-data-access.ts
+++ b/src/features/shared/memory-data-access.ts
@@ -428,3 +428,11 @@ export function resetMemoryDataAccess() {
 export function getMemoryAuditActions() {
   return state.audit.map((entry) => entry.action);
 }
+
+export function getMemoryAuditEntries() {
+  return state.audit.map((entry) => ({
+    ...entry,
+    payload: entry.payload ? cloneJson(entry.payload) : undefined,
+    createdAt: cloneDate(entry.createdAt)
+  }));
+}

--- a/work-items/WI-0016-attendance-rejection-reason.md
+++ b/work-items/WI-0016-attendance-rejection-reason.md
@@ -1,0 +1,99 @@
+# WI-0016: Attendance Rejection Reason Traceability
+
+## Background and Problem
+
+Attendance rejection currently records only state transition without a structured reason field.
+For audit and dispute handling, operators need optional rejection reason trace in audit logs and domain events.
+
+## Scope
+
+### In Scope
+
+- Add optional `reason` payload to attendance reject endpoint.
+- Persist rejection reason in `attendance.rejected` audit payload.
+- Publish rejection reason in `attendance.rejected.v1` event payload.
+- Extend memory/prisma e2e tests for reason trace assertions.
+
+### Out of Scope
+
+- DB schema change for dedicated rejection reason column.
+- Rejection reason taxonomy/enum standardization.
+- Resubmission workflow for rejected attendance.
+
+## User Scenarios
+
+1. Manager rejects attendance and provides reason for audit.
+2. Payroll/QA can trace rejection reason from audit/event stream when reviewing excluded records.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: payroll aggregation still includes `APPROVED` records only.
+- Rounding rule: not applicable.
+- Exception handling rule: invalid JSON or oversize reason payload returns `400`.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | System |
+| --- | --- | --- | --- | --- |
+| Reject attendance with optional reason | Allow | Allow | Deny | Deny |
+| Read rejection trace from audit logs | Allow | Allow | Deny | Allow (ops only) |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: `AttendanceRecord`, `AuditLog`
+- Migration IDs: none
+- Backward compatibility plan: additive request payload only, no schema change
+
+## API and Event Changes
+
+- Endpoints:
+  - `POST /api/attendance/records/{recordId}/reject` (optional `{ reason }`)
+- Events published:
+  - `attendance.rejected.v1` (payload includes optional `reason`)
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - reject payload schema (`reason` optional, max length check)
+- Integration:
+  - reject request with reason succeeds and returns `REJECTED`
+  - invalid reject JSON payload fails with `400`
+- Regression:
+  - WI-0001 memory/prisma e2e stays green
+- Authorization:
+  - manager/admin only reject path
+- Payroll accuracy:
+  - rejected records remain excluded from payroll preview count
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `attendance.rejected` payload includes `reason` when provided
+- Metrics:
+  - `attendance_rejection_count`
+- Alert conditions:
+  - spike in reject validation errors (`400`)
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable (no migration).
+- Recovery target time: 15m by reverting route/service payload change.
+
+## Definition of Ready (DoR)
+
+- [ ] Requirements are unambiguous and testable.
+- [ ] Domain contract drafted or updated.
+- [ ] Role matrix reviewed by QA.
+- [ ] Data migration impact assessed.
+- [ ] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.


### PR DESCRIPTION
## Summary
- add optional reason payload schema for attendance reject API
- persist reason in attendance.rejected audit/event payloads
- extend WI-0001 memory/prisma e2e assertions for rejection reason traceability
- update attendance contract/api/test-cases and execution plan for WI-0016

## Validation
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test:integration
- npm.cmd run test:golden
- npm.cmd run test:e2e
- npm.cmd run test:e2e:prisma
- npm.cmd run build

## Linked Work Item
- work-items/WI-0016-attendance-rejection-reason.md