### PR TITLE
test(attendance): add reject payload validation regression guards

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -67,6 +67,10 @@ Completed:
   - reject API accepts optional `reason` payload with schema validation
   - `attendance.rejected` audit/event payload now preserves rejection reason
   - memory/prisma WI-0001 e2e asserts rejection reason traceability
+- WI-0017 attendance reject validation guards are implemented:
+  - reject API invalid JSON and oversized reason paths are covered by memory/prisma e2e
+  - invalid reject payloads are asserted as `400` without audit/event side effects
+  - attendance contract/test-cases include validation guard expectations
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -156,6 +160,7 @@ Tasks:
 21. Add alert webhook regression tests and include them in integration gate. (Completed: 2026-02-13)
 22. Add runtime-contract-ownership event traceability checks to governance gate. (Completed: 2026-02-13)
 23. Add WI-0016 rejection reason traceability in reject API/audit/event and e2e tests. (Completed: 2026-02-13)
+24. Add WI-0017 reject payload validation guard regression coverage. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/scripts/tests/e2e-wi0001.test.ts
+++ b/scripts/tests/e2e-wi0001.test.ts
@@ -131,6 +131,40 @@ async function run() {
   };
   assert.equal(rejectedCreateBody.record.state, "PENDING");
 
+  const invalidJsonRejectResponse = await attendanceRejectRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${rejectedCreateBody.record.id}/reject`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-1"),
+      body: "{"
+    }),
+    { params: Promise.resolve({ recordId: rejectedCreateBody.record.id }) } as RouteContext<{
+      recordId: string;
+    }>
+  );
+  assert.equal(invalidJsonRejectResponse.status, 400, "invalid reject JSON should be rejected");
+  const invalidJsonRejectBody = (await readJson(invalidJsonRejectResponse)) as {
+    error: string;
+  };
+  assert.equal(invalidJsonRejectBody.error, "invalid JSON body");
+
+  const invalidPayloadRejectResponse = await attendanceRejectRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${rejectedCreateBody.record.id}/reject`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-1"),
+      body: JSON.stringify({
+        reason: "x".repeat(501)
+      })
+    }),
+    { params: Promise.resolve({ recordId: rejectedCreateBody.record.id }) } as RouteContext<{
+      recordId: string;
+    }>
+  );
+  assert.equal(invalidPayloadRejectResponse.status, 400, "oversized reject reason should be rejected");
+  const invalidPayloadRejectBody = (await readJson(invalidPayloadRejectResponse)) as {
+    error: string;
+  };
+  assert.equal(invalidPayloadRejectBody.error, "invalid payload");
+
   const rejectResponse = await attendanceRejectRoute.POST(
     new Request(`http://localhost/api/attendance/records/${rejectedCreateBody.record.id}/reject`, {
       method: "POST",

--- a/specs/attendance/api.yaml
+++ b/specs/attendance/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Attendance API
-  version: 1.2.0
+  version: 1.2.1
 paths:
   /attendance/records:
     post:
@@ -43,6 +43,20 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 500
       responses:
         "200":
           description: Rejected
+        "400":
+          description: Invalid JSON body or invalid payload

--- a/specs/attendance/contract.yaml
+++ b/specs/attendance/contract.yaml
@@ -1,5 +1,5 @@
 owner: attendance-agent
-version: 1.2.0
+version: 1.2.1
 scope:
   in:
     - attendance record create/update
@@ -72,10 +72,13 @@ test_plan:
   unit:
     - timestamp normalization by timezone
     - correction state transition validation
+    - rejection reason schema boundary (max 500 chars)
   integration:
     - create record to approve flow
     - create record to reject flow
     - reject flow with reason payload trace
+    - reject flow invalid JSON body returns 400
+    - reject flow oversized reason payload returns 400
   regression:
     - replay GC-001, GC-002, GC-003, GC-005
   authorization:
@@ -104,11 +107,12 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.2.0 adds non-breaking optional rejection reason payload for attendance reject flow."
+consumer_impact: "Contract v1.2.1 clarifies non-breaking reject payload validation (`invalid JSON`/`invalid payload` with 400)."
 references:
   - specs/common/time-and-payroll-rules.md
   - work-items/WI-0009-attendance-rejection-flow.md
   - work-items/WI-0016-attendance-rejection-reason.md
+  - work-items/WI-0017-attendance-reject-validation-guards.md
 approval:
   spec_owner: attendance-agent
   qa_owner: qa-agent

--- a/specs/attendance/test-cases.md
+++ b/specs/attendance/test-cases.md
@@ -13,12 +13,14 @@ Attendance create/update/approval behavior and output consistency for payroll ag
 5. Reject unauthorized approval/rejection attempt.
 6. Emit final-state event once (`approved` or `rejected`).
 7. Rejection reason is preserved in audit/event payload when provided.
+8. Reject API returns `400` for invalid JSON body and oversized reason payload.
 
 ## Boundary and Accuracy Cases
 
 1. Overnight shift crossing midnight is mapped using 04:00 workday boundary.
 2. Minute rounding behavior matches common SSoT rules.
 3. Correction after initial approval creates auditable recalculation signal.
+4. Reject reason length `> 500` is blocked and does not create audit/event side effects.
 
 ## Regression Linkage
 

--- a/work-items/WI-0017-attendance-reject-validation-guards.md
+++ b/work-items/WI-0017-attendance-reject-validation-guards.md
@@ -1,0 +1,101 @@
+# WI-0017: Attendance Reject Validation Guard Regression
+
+## Background and Problem
+
+Attendance reject route supports optional reason payload, but invalid input paths were not explicitly fixed by regression tests.
+Without guard coverage, malformed JSON or oversized reason payloads can silently regress and weaken audit quality.
+
+## Scope
+
+### In Scope
+
+- Add WI-0001 memory/prisma e2e assertions for reject payload validation guards.
+- Cover `invalid JSON body` (`400`) behavior for reject route.
+- Cover oversized `reason` payload (`>500`) behavior for reject route.
+- Update attendance contract/test-cases to reflect validation guard expectations.
+
+### Out of Scope
+
+- Reject reason taxonomy standardization.
+- New DB columns for rejection reason.
+- UI-level validation UX changes.
+
+## User Scenarios
+
+1. Manager sends malformed reject payload and API blocks request with `400`.
+2. Manager sends reject reason over max length and API blocks request with `400`.
+3. Valid reject request still succeeds and preserves audit/event reason trace.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: only approved attendance contributes to payroll preview.
+- Rounding rule: not applicable.
+- Exception handling rule: invalid reject payload must not produce final-state audit/event side effects.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | System |
+| --- | --- | --- | --- | --- |
+| Reject attendance with valid payload | Allow | Allow | Deny | Deny |
+| Reject attendance with invalid payload | Blocked (`400`) | Blocked (`400`) | Deny | Deny |
+| Read reject validation failures from logs | Allow | Allow | Deny | Allow (ops only) |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: route validation behavior only, no schema migration
+
+## API and Event Changes
+
+- Endpoints:
+  - `POST /api/attendance/records/{recordId}/reject` (validation guard coverage)
+- Events published:
+  - none added
+  - existing `attendance.rejected.v1` remains unchanged for valid payload
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - reject schema boundary (`reason` max length)
+- Integration:
+  - invalid reject JSON body returns `400`
+  - oversized reject reason returns `400`
+  - valid reject request still returns `REJECTED`
+- Regression:
+  - WI-0001 memory/prisma e2e remains green with added guard assertions
+- Authorization:
+  - manager/admin-only reject path remains enforced
+- Payroll accuracy:
+  - invalid reject payload does not alter source record aggregation behavior
+
+## Observability and Audit Logging
+
+- Audit events:
+  - invalid reject requests do not emit `attendance.rejected`
+- Metrics:
+  - `attendance_reject_validation_error_count` (logical guard metric)
+- Alert conditions:
+  - surge in reject validation `400` errors
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable (no migration).
+- Recovery target time: 15m by reverting e2e/contract guard updates.
+
+## Definition of Ready (DoR)
+
+- [ ] Guard scenarios are defined and reproducible.
+- [ ] Contract/test-case updates are scoped.
+- [ ] QA check items for invalid payload paths are identified.
+- [ ] No migration impact is confirmed.
+
+## Definition of Done (DoD)
+
+- [ ] Memory/prisma e2e include invalid reject payload guard coverage.
+- [ ] Attendance contract/test-cases reflect guard expectations.
+- [ ] All required quality gates pass.
+- [ ] Execution plan is updated with WI-0017 completion.


### PR DESCRIPTION
## Summary
- add WI-0001 memory/prisma e2e coverage for reject invalid JSON and oversized reason payload
- assert reject guard errors return 400 with explicit error messages
- bump attendance contract/api to v1.2.1 with reject payload validation guard expectations
- add WI-0017 and update execution plan

## Validation
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test:integration
- npm.cmd run test:golden
- npm.cmd run test:e2e
- npm.cmd run test:e2e:prisma
- npm.cmd run build

## Linked Work Item
- work-items/WI-0017-attendance-reject-validation-guards.md