### PR TITLE
ci(contracts): enforce contract-api version alignment

### DIFF
--- a/contracts/versioning.md
+++ b/contracts/versioning.md
@@ -40,3 +40,5 @@ CI must fail when:
 - `contract.yaml` changes without a version bump.
 - `breaking_changes: true` and MAJOR does not increase.
 - Required contract fields are missing.
+- `contract.yaml` version and sibling `api.yaml` `info.version` do not match.
+- sibling `api.yaml` is missing or `info.version` is not valid SemVer.

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -71,6 +71,10 @@ Completed:
   - reject API invalid JSON and oversized reason paths are covered by memory/prisma e2e
   - invalid reject payloads are asserted as `400` without audit/event side effects
   - attendance contract/test-cases include validation guard expectations
+- WI-0018 contract/API version alignment gate is implemented:
+  - `check_contracts.py` requires sibling `api.yaml` for each domain contract
+  - `api.yaml` `info.version` must follow SemVer
+  - contract/API version mismatch now fails governance gate
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -161,6 +165,7 @@ Tasks:
 22. Add runtime-contract-ownership event traceability checks to governance gate. (Completed: 2026-02-13)
 23. Add WI-0016 rejection reason traceability in reject API/audit/event and e2e tests. (Completed: 2026-02-13)
 24. Add WI-0017 reject payload validation guard regression coverage. (Completed: 2026-02-13)
+25. Add WI-0018 contract/API version alignment check to contract governance gate. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/specs/attendance/api.yaml
+++ b/specs/attendance/api.yaml
@@ -36,7 +36,7 @@ paths:
   /attendance/records/{recordId}/reject:
     post:
       summary: Reject attendance record or correction (optional reason)
-      description: Optional JSON body `{ \"reason\": string }` can be provided for audit/event trace.
+      description: 'Optional JSON body `{"reason": string}` can be provided for audit/event trace.'
       parameters:
         - in: path
           name: recordId

--- a/work-items/WI-0018-contract-api-version-alignment-gate.md
+++ b/work-items/WI-0018-contract-api-version-alignment-gate.md
@@ -1,0 +1,94 @@
+# WI-0018: Contract/API Version Alignment Gate
+
+## Background and Problem
+
+Contract governance validates `contract.yaml` schema and versioning diffs, but it does not enforce alignment with sibling `api.yaml` version.
+This gap can allow inconsistent contract/API version declarations and weaken consumer trust in version signals.
+
+## Scope
+
+### In Scope
+
+- Extend `scripts/ci/check_contracts.py` to require sibling `api.yaml` for each `contract.yaml`.
+- Validate `api.yaml` `info.version` format as SemVer.
+- Fail CI when `contract.yaml` version differs from `api.yaml` version.
+- Record work item and execution-plan completion entry.
+
+### Out of Scope
+
+- OpenAPI schema completeness validation beyond `info.version`.
+- Cross-repo consumer contract compatibility checks.
+- Automatic version bumping logic.
+
+## User Scenarios
+
+1. Developer updates contract version but forgets API version and CI blocks merge.
+2. API version format is invalid and CI fails before review.
+3. Missing sibling `api.yaml` is surfaced immediately as governance error.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: contract and API docs must expose identical semantic versions per domain.
+- Rounding rule: not applicable.
+- Exception handling rule: governance failure blocks merge until version alignment is restored.
+
+## Authorization and Role Matrix
+
+| Action | Orchestrator | Domain Agent | QA Agent | Employee |
+| --- | --- | --- | --- | --- |
+| Update contract governance script | Allow | Allow | Allow | Deny |
+| Merge version-gate changes | Allow | Allow | Allow | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: CI-only guard, no runtime schema impact
+
+## API and Event Changes
+
+- Endpoints: none
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - contract lint catches missing sibling `api.yaml`
+  - contract lint catches invalid `api.yaml` `info.version`
+  - contract lint catches contract/API version mismatch
+- Integration:
+  - run `python scripts/ci/check_contracts.py` against current repo (expected pass)
+- Regression:
+  - existing quality gates remain green
+- Authorization:
+  - not applicable
+- Payroll accuracy:
+  - not applicable
+
+## Observability and Audit Logging
+
+- Audit events:
+  - none
+- Metrics:
+  - CI governance failure count (existing pipeline metrics)
+- Alert conditions:
+  - repeated contract-governance failures on version mismatch
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable.
+- Recovery target time: 15m by reverting script-level validation changes.
+
+## Definition of Ready (DoR)
+
+- [ ] Governance gap is reproducible.
+- [ ] Validation rules are deterministic.
+- [ ] Scope limited to CI/doc alignment.
+
+## Definition of Done (DoD)
+
+- [ ] `check_contracts.py` enforces sibling API version alignment.
+- [ ] Current repository passes updated governance checks.
+- [ ] WI and execution plan are updated.


### PR DESCRIPTION
## Summary
- extend check_contracts.py to require sibling pi.yaml for each domain contract
- validate pi.yaml info.version SemVer and enforce equality with contract.yaml version
- document the new gate in contracts/versioning.md
- add WI-0018 and execution plan progress update

## Validation
- python scripts/ci/check_contracts.py
- python scripts/ci/check_traceability.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test:integration
- npm.cmd run test:golden
- npm.cmd run build

## Linked Work Item
- work-items/WI-0018-contract-api-version-alignment-gate.md