### PR TITLE
ci(contracts): require contract update for api spec changes

### DIFF
--- a/contracts/versioning.md
+++ b/contracts/versioning.md
@@ -42,3 +42,4 @@ CI must fail when:
 - Required contract fields are missing.
 - `contract.yaml` version and sibling `api.yaml` `info.version` do not match.
 - sibling `api.yaml` is missing or `info.version` is not valid SemVer.
+- `api.yaml` changes without sibling `contract.yaml` change/version bump.

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -75,6 +75,10 @@ Completed:
   - `check_contracts.py` requires sibling `api.yaml` for each domain contract
   - `api.yaml` `info.version` must follow SemVer
   - contract/API version mismatch now fails governance gate
+- WI-0019 API/contract coupling gate is implemented:
+  - changed `api.yaml` now requires sibling `contract.yaml` change in diff checks
+  - API-only spec changes are blocked until contract/version update is included
+  - versioning policy now documents API/contract coupling enforcement
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -166,6 +170,7 @@ Tasks:
 23. Add WI-0016 rejection reason traceability in reject API/audit/event and e2e tests. (Completed: 2026-02-13)
 24. Add WI-0017 reject payload validation guard regression coverage. (Completed: 2026-02-13)
 25. Add WI-0018 contract/API version alignment check to contract governance gate. (Completed: 2026-02-13)
+26. Add WI-0019 API/contract coupling check for API-only spec changes. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/work-items/WI-0019-api-contract-coupling-gate.md
+++ b/work-items/WI-0019-api-contract-coupling-gate.md
@@ -1,0 +1,93 @@
+# WI-0019: API/Contract Coupling Gate
+
+## Background and Problem
+
+Even with version alignment checks, `api.yaml` can still be edited alone in a PR without a sibling `contract.yaml` version bump.
+This allows undocumented API changes to bypass contract version governance intent.
+
+## Scope
+
+### In Scope
+
+- Extend contract governance diff checks so changed `api.yaml` requires sibling `contract.yaml` change.
+- Fail CI when `api.yaml` changed but same-domain `contract.yaml` did not change.
+- Document the new rule in versioning policy.
+- Add WI and execution-plan completion entries.
+
+### Out of Scope
+
+- OpenAPI semantic diff classification.
+- Automatic version bump suggestion bot.
+- Runtime API behavior changes.
+
+## User Scenarios
+
+1. Developer edits `specs/attendance/api.yaml` but forgets contract update and CI fails.
+2. Developer updates API + contract together and CI passes.
+3. Reviewer can rely on CI to enforce contract-first discipline for API spec changes.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: API surface changes must be reflected in same-domain contract revision.
+- Rounding rule: not applicable.
+- Exception handling rule: API-only spec change is blocked until contract/version updates are included.
+
+## Authorization and Role Matrix
+
+| Action | Orchestrator | Domain Agent | QA Agent | Employee |
+| --- | --- | --- | --- | --- |
+| Update governance check scripts | Allow | Allow | Allow | Deny |
+| Merge API contract-coupling policy changes | Allow | Allow | Allow | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: CI guard only, no runtime schema changes
+
+## API and Event Changes
+
+- Endpoints: none
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - changed `api.yaml` without changed sibling `contract.yaml` fails
+  - changed `api.yaml` with changed sibling `contract.yaml` passes coupling check
+- Integration:
+  - `python scripts/ci/check_contracts.py` passes on current repository
+- Regression:
+  - existing governance checks continue to pass
+- Authorization:
+  - not applicable
+- Payroll accuracy:
+  - not applicable
+
+## Observability and Audit Logging
+
+- Audit events:
+  - none
+- Metrics:
+  - contract-governance failure count for API-only changes
+- Alert conditions:
+  - repeated API-only governance failures
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable.
+- Recovery target time: 15m by reverting coupling rule.
+
+## Definition of Ready (DoR)
+
+- [ ] API-only governance gap is reproducible.
+- [ ] Coupling rule has deterministic domain mapping.
+- [ ] Scope constrained to CI policy.
+
+## Definition of Done (DoD)
+
+- [ ] `check_contracts.py` blocks API-only spec changes without sibling contract update.
+- [ ] Versioning policy reflects the new coupling rule.
+- [ ] WI and execution plan are updated.


### PR DESCRIPTION
## Summary
- extend contract governance diff checks with API/contract coupling enforcement
- fail when pi.yaml changes without sibling contract.yaml change/version bump
- document the coupling rule in contracts/versioning.md
- add WI-0019 and execution plan progress update

## Validation
- python scripts/ci/check_contracts.py --base origin/main --head HEAD
- python scripts/ci/check_traceability.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test:integration
- npm.cmd run test:golden
- npm.cmd run build

## Linked Work Item
- work-items/WI-0019-api-contract-coupling-gate.md