### PR TITLE
test(ci): add contract governance regression harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
             python scripts/ci/check_contracts.py
           fi
 
+      - name: Contract governance regression tests
+        run: python scripts/ci/test_check_contracts_regression.py
+
       - name: Spec/work-item/runtime traceability checks
         run: python scripts/ci/check_traceability.py
 

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -79,6 +79,10 @@ Completed:
   - changed `api.yaml` now requires sibling `contract.yaml` change in diff checks
   - API-only spec changes are blocked until contract/version update is included
   - versioning policy now documents API/contract coupling enforcement
+- WI-0020 contract governance regression harness is implemented:
+  - `test_check_contracts_regression.py` fixes expected behaviors for governance rules
+  - CI `contract-governance` job runs regression tests after contract lint/version checks
+  - script refactors now fail fast if SemVer/coupling rules regress
 - Golden fixtures (`GC-001` to `GC-006`) are validated in CI and executable tests.
 - Supabase role claim governance script exists (`dry-run`, `apply`, `enforce`).
 - Staging Prisma integration is enabled with schema isolation guardrails.
@@ -171,6 +175,7 @@ Tasks:
 24. Add WI-0017 reject payload validation guard regression coverage. (Completed: 2026-02-13)
 25. Add WI-0018 contract/API version alignment check to contract governance gate. (Completed: 2026-02-13)
 26. Add WI-0019 API/contract coupling check for API-only spec changes. (Completed: 2026-02-13)
+27. Add WI-0020 regression tests for contract governance script rules. (Completed: 2026-02-13)
 
 Definition of Done:
 

--- a/scripts/ci/test_check_contracts_regression.py
+++ b/scripts/ci/test_check_contracts_regression.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import importlib.util
+import pathlib
+import re
+import unittest
+import uuid
+import shutil
+from contextlib import contextmanager
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "ci" / "check_contracts.py"
+
+
+def load_check_contracts_module():
+    spec = importlib.util.spec_from_file_location("check_contracts_module", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load check_contracts.py module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def bump_patch(version: str) -> str:
+    major, minor, patch = version.split(".")
+    return f"{major}.{minor}.{int(patch) + 1}"
+
+
+class CheckContractsRegressionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_check_contracts_module()
+        cls.validator = cls.module.load_schema(ROOT / "contracts" / "contract.schema.json")
+        cls.contract_text = (ROOT / "specs" / "attendance" / "contract.yaml").read_text(encoding="utf-8")
+        cls.api_text = (ROOT / "specs" / "attendance" / "api.yaml").read_text(encoding="utf-8")
+
+        match = re.search(r"(?m)^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$", cls.contract_text)
+        if not match:
+            raise RuntimeError("failed to parse attendance contract version")
+        cls.contract_version = match.group(1)
+
+    def write_contract_and_api(
+        self, temp_root: pathlib.Path, contract_text: str, api_text: str | None
+    ) -> pathlib.Path:
+        domain_dir = temp_root / "specs" / "attendance"
+        domain_dir.mkdir(parents=True, exist_ok=True)
+
+        contract_path = domain_dir / "contract.yaml"
+        contract_path.write_text(contract_text, encoding="utf-8")
+
+        if api_text is not None:
+            (domain_dir / "api.yaml").write_text(api_text, encoding="utf-8")
+
+        return contract_path
+
+    @contextmanager
+    def project_temp_dir(self):
+        temp_root = ROOT / ".tmp-contract-governance-tests" / uuid.uuid4().hex
+        temp_root.mkdir(parents=True, exist_ok=True)
+        try:
+            yield str(temp_root)
+        finally:
+            shutil.rmtree(temp_root, ignore_errors=True)
+
+    def test_lint_contract_file_requires_sibling_api(self):
+        with self.project_temp_dir() as temp_dir:
+            contract_path = self.write_contract_and_api(
+                pathlib.Path(temp_dir), self.contract_text, api_text=None
+            )
+            errors = self.module.lint_contract_file(contract_path, self.validator)
+            self.assertTrue(any("missing sibling api.yaml file" in err for err in errors))
+
+    def test_lint_contract_file_detects_contract_api_version_mismatch(self):
+        mismatched_api_text = re.sub(
+            r"(?m)^(\s*version:\s*)([0-9]+\.[0-9]+\.[0-9]+)\s*$",
+            rf"\g<1>{bump_patch(self.contract_version)}",
+            self.api_text,
+            count=1,
+        )
+
+        with self.project_temp_dir() as temp_dir:
+            contract_path = self.write_contract_and_api(
+                pathlib.Path(temp_dir), self.contract_text, api_text=mismatched_api_text
+            )
+            errors = self.module.lint_contract_file(contract_path, self.validator)
+            self.assertTrue(any("version mismatch with" in err for err in errors))
+
+    def test_check_api_contract_coupling_blocks_api_only_change(self):
+        original_git_show = self.module.git_show
+
+        def fake_git_show(sha: str, path: str):
+            if path != "specs/attendance/api.yaml":
+                return None
+            if sha == "base":
+                return "old"
+            if sha == "head":
+                return "new"
+            return None
+
+        try:
+            self.module.git_show = fake_git_show
+            errors = self.module.check_api_contract_coupling(
+                "base", "head", [], ["specs/attendance/api.yaml"]
+            )
+            self.assertEqual(len(errors), 1)
+            self.assertIn("without sibling contract.yaml change/version bump", errors[0])
+        finally:
+            self.module.git_show = original_git_show
+
+    def test_check_api_contract_coupling_allows_api_change_with_contract_change(self):
+        original_git_show = self.module.git_show
+
+        def fake_git_show(_sha: str, _path: str):
+            return "changed"
+
+        try:
+            self.module.git_show = fake_git_show
+            errors = self.module.check_api_contract_coupling(
+                "base",
+                "head",
+                ["specs/attendance/contract.yaml"],
+                ["specs/attendance/api.yaml"],
+            )
+            self.assertEqual(errors, [])
+        finally:
+            self.module.git_show = original_git_show
+
+    def test_check_versioning_requires_bump(self):
+        original_git_show = self.module.git_show
+        old_contract = "version: 1.2.1\nbreaking_changes: false\n"
+        new_contract = "version: 1.2.1\nbreaking_changes: false\n"
+
+        def fake_git_show(sha: str, _path: str):
+            if sha == "base":
+                return old_contract
+            if sha == "head":
+                return new_contract
+            return None
+
+        try:
+            self.module.git_show = fake_git_show
+            errors = self.module.check_versioning("base", "head", ["specs/attendance/contract.yaml"])
+            self.assertTrue(any("without version bump" in err for err in errors))
+        finally:
+            self.module.git_show = original_git_show
+
+    def test_check_versioning_requires_major_when_breaking(self):
+        original_git_show = self.module.git_show
+        old_contract = "version: 1.2.1\nbreaking_changes: false\n"
+        new_contract = "version: 1.2.2\nbreaking_changes: true\n"
+
+        def fake_git_show(sha: str, _path: str):
+            if sha == "base":
+                return old_contract
+            if sha == "head":
+                return new_contract
+            return None
+
+        try:
+            self.module.git_show = fake_git_show
+            errors = self.module.check_versioning("base", "head", ["specs/attendance/contract.yaml"])
+            self.assertTrue(any("breaking_changes=true requires MAJOR bump" in err for err in errors))
+        finally:
+            self.module.git_show = original_git_show
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/work-items/WI-0020-contract-governance-regression-tests.md
+++ b/work-items/WI-0020-contract-governance-regression-tests.md
@@ -1,0 +1,93 @@
+# WI-0020: Contract Governance Regression Test Harness
+
+## Background and Problem
+
+`check_contracts.py` has expanded rules (SemVer, breaking change major bump, contract/API alignment, API/contract coupling), but these rules were not protected by dedicated regression tests.
+Script refactors could silently weaken governance enforcement if behavior is not fixed by automated tests.
+
+## Scope
+
+### In Scope
+
+- Add Python regression tests for core `check_contracts.py` behaviors.
+- Cover sibling `api.yaml` requirement and version mismatch detection.
+- Cover API-only spec change blocking logic.
+- Cover version bump and breaking change MAJOR bump rules.
+- Run regression tests in `contract-governance` CI job.
+
+### Out of Scope
+
+- OpenAPI semantic diffing by endpoint payload.
+- Consumer SDK compatibility tests.
+- Runtime API behavior changes.
+
+## User Scenarios
+
+1. CI fails immediately if someone breaks API-only coupling logic.
+2. CI fails if script regression stops enforcing SemVer bump rule.
+3. Team can refactor governance code with confidence due to fixed regression suite.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth rule: contract governance scripts are release gates; regressions must fail pre-merge.
+- Rounding rule: not applicable.
+- Exception handling rule: not applicable.
+
+## Authorization and Role Matrix
+
+| Action | Orchestrator | Domain Agent | QA Agent | Employee |
+| --- | --- | --- | --- | --- |
+| Update governance regression tests | Allow | Allow | Allow | Deny |
+| Merge governance gate test changes | Allow | Allow | Allow | Deny |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: CI-only change, no runtime migration impact
+
+## API and Event Changes
+
+- Endpoints: none
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - missing sibling `api.yaml` is detected
+  - contract/API version mismatch is detected
+  - API-only change without contract update is blocked
+  - unchanged contract version after change is blocked
+  - `breaking_changes=true` without MAJOR bump is blocked
+- Integration:
+  - `python scripts/ci/test_check_contracts_regression.py` runs in CI `contract-governance` job
+- Regression:
+  - `python scripts/ci/check_contracts.py` still passes for current repository
+
+## Observability and Audit Logging
+
+- Audit events:
+  - none
+- Metrics:
+  - contract-governance regression test failures (CI)
+- Alert conditions:
+  - repeated failures in contract-governance job
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable.
+- DB rollback method: not applicable.
+- Recovery target time: 15m by reverting regression harness integration.
+
+## Definition of Ready (DoR)
+
+- [ ] Governance rules and expected behavior are documented.
+- [ ] Test fixtures/cases are deterministic.
+- [ ] CI location for execution is confirmed.
+
+## Definition of Done (DoD)
+
+- [ ] Regression test script is added and executable.
+- [ ] CI contract-governance job runs the regression test script.
+- [ ] WI and execution plan reflect completion.


### PR DESCRIPTION
## Summary
- add scripts/ci/test_check_contracts_regression.py to lock critical check_contracts.py behaviors
- cover sibling pi.yaml requirement, contract/api version mismatch, api-only change blocking, and versioning rules
- run regression harness in contract-governance workflow job
- record WI-0020 and execution plan completion

## Validation
- python scripts/ci/test_check_contracts_regression.py
- python scripts/ci/check_contracts.py --base origin/main --head HEAD
- python scripts/ci/check_traceability.py
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run test:integration
- npm.cmd run test:golden
- npm.cmd run build

## Linked Work Item
- work-items/WI-0020-contract-governance-regression-tests.md