### PR TITLE
feat(attendance): add aggregates api

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Production rollout: `docs/production-rollout.md`
 
 - Attendance:
   - `GET /api/attendance/records` (query: `from`, `to`, optional `employeeId`, optional `state`)
+  - `GET /api/attendance/aggregates` (query: `from`, `to`, optional `employeeId`)
   - `POST /api/attendance/records`
   - `PATCH /api/attendance/records/{recordId}`
   - `POST /api/attendance/records/{recordId}/approve`

--- a/specs/attendance/api.yaml
+++ b/specs/attendance/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Attendance API
-  version: 1.3.0
+  version: 1.4.0
 paths:
   /attendance/records:
     get:
@@ -38,6 +38,31 @@ paths:
       responses:
         "201":
           description: Created
+  /attendance/aggregates:
+    get:
+      summary: List attendance aggregates by period
+      description: Totals are derived from approved attendance records only and grouped by employee.
+      parameters:
+        - in: query
+          name: from
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: to
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: employeeId
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Aggregates listed
   /attendance/records/{recordId}:
     patch:
       summary: Update attendance record before approval

--- a/specs/attendance/contract.yaml
+++ b/specs/attendance/contract.yaml
@@ -1,9 +1,10 @@
 owner: attendance-agent
-version: 1.3.0
+version: 1.4.0
 scope:
   in:
     - attendance record create/update
     - attendance record list query by period
+    - attendance aggregates query by period
     - correction approval/rejection flow
     - rejection reason capture in audit/event payload
     - approved/rejected attendance event publication
@@ -29,6 +30,9 @@ api:
     - method: GET
       path: /attendance/records
       description: List attendance records filtered by period (from/to) and optional employeeId/state.
+    - method: GET
+      path: /attendance/aggregates
+      description: List attendance aggregates (payable minutes totals) filtered by period (from/to) and optional employeeId.
     - method: POST
       path: /attendance/records
       description: Create attendance record.
@@ -66,6 +70,7 @@ invariants:
   - An approved attendance record cannot be silently overwritten.
   - A rejected attendance record cannot transition directly to approved.
   - Rejected attendance record is excluded from payroll aggregation.
+  - Attendance aggregate totals are derived from approved attendance records only.
   - Attendance timestamps are interpreted in Asia/Seoul.
   - Approved/rejected attendance emits exactly one final state event.
   - Employee attendance list queries are restricted to own employeeId.
@@ -83,6 +88,8 @@ test_plan:
     - correction state transition validation
     - rejection reason schema boundary (max 500 chars)
     - attendance list query parsing and role boundary guards
+    - attendance aggregates query parsing and role boundary guards
+    - attendance aggregates totals are computed from approved records only
   integration:
     - create record to approve flow
     - create record to reject flow
@@ -90,6 +97,7 @@ test_plan:
     - reject flow invalid JSON body returns 400
     - reject flow oversized reason payload returns 400
     - list records by period returns expected rows
+    - list aggregates by period returns expected totals and state counts
     - employee cross-employee list query is blocked with 403
     - manager list query requires employeeId (400)
   regression:
@@ -121,13 +129,14 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.3.0 adds non-breaking attendance record list API (`GET /attendance/records`) with role boundary guards."
+consumer_impact: "Contract v1.4.0 adds non-breaking attendance aggregates API (`GET /attendance/aggregates`) with role boundary guards."
 references:
   - specs/common/time-and-payroll-rules.md
   - work-items/WI-0009-attendance-rejection-flow.md
   - work-items/WI-0016-attendance-rejection-reason.md
   - work-items/WI-0017-attendance-reject-validation-guards.md
   - work-items/WI-0026-attendance-list-api.md
+  - work-items/WI-0031-attendance-aggregates-api.md
 approval:
   spec_owner: attendance-agent
   qa_owner: qa-agent

--- a/specs/attendance/test-cases.md
+++ b/specs/attendance/test-cases.md
@@ -15,6 +15,7 @@ Attendance create/update/approval behavior and output consistency for payroll ag
 7. Rejection reason is preserved in audit/event payload when provided.
 8. Reject API returns `400` for invalid JSON body and oversized reason payload.
 9. List attendance records by period (`from`/`to`) with role boundary guards (employee self-only, manager requires employeeId).
+10. List attendance aggregates by period (`from`/`to`) with role boundary guards and verify totals are derived from approved records only.
 
 ## Boundary and Accuracy Cases
 

--- a/src/app/api/attendance/aggregates/route.ts
+++ b/src/app/api/attendance/aggregates/route.ts
@@ -1,0 +1,43 @@
+import { listAttendanceAggregatesQuerySchema } from "@/features/attendance/schemas";
+import { listAttendanceAggregates } from "@/features/attendance/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
+import { readActor } from "@/lib/actor";
+import { fail, ok } from "@/lib/http";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+
+  // `+09:00` in query params is commonly decoded as a space. Normalize to preserve ISO offsets.
+  const normalizeOffset = (value: string | null) => (value ? value.replace(/ /g, "+") : value);
+  const parsed = listAttendanceAggregatesQuerySchema.safeParse({
+    from: normalizeOffset(url.searchParams.get("from")),
+    to: normalizeOffset(url.searchParams.get("to")),
+    employeeId: url.searchParams.get("employeeId") ?? undefined
+  });
+
+  if (!parsed.success) {
+    return fail(400, "invalid query", parsed.error.flatten());
+  }
+
+  try {
+    const aggregates = await listAttendanceAggregates(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      {
+        periodStart: new Date(parsed.data.from),
+        periodEnd: new Date(parsed.data.to),
+        employeeId: parsed.data.employeeId
+      }
+    );
+    return ok({ aggregates });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -336,6 +336,21 @@ export default function HomePage() {
     );
   }
 
+  async function listAttendanceAggregates() {
+    const from = toIso(periodStart);
+    const to = toIso(periodEnd);
+    await callApi(
+      "근태 집계 조회",
+      "GET",
+      `/api/attendance/aggregates${buildQuery({
+        from,
+        to,
+        employeeId: attendanceEmployeeId
+      })}`,
+      { role: "payroll_operator", id: payrollActorId }
+    );
+  }
+
   async function listLeaveRequests() {
     const from = toIso(periodStart);
     const to = toIso(periodEnd);
@@ -532,6 +547,9 @@ export default function HomePage() {
           <div className="actions">
             <button className="btn btn-primary" onClick={listAttendanceRecords}>
               출퇴근 조회
+            </button>
+            <button className="btn btn-secondary" onClick={listAttendanceAggregates}>
+              근태 집계 조회
             </button>
             <button className="btn btn-secondary" onClick={listLeaveRequests}>
               휴가 조회

--- a/src/features/attendance/schemas.ts
+++ b/src/features/attendance/schemas.ts
@@ -30,3 +30,9 @@ export const listAttendanceQuerySchema = z.object({
   employeeId: z.string().min(1).optional(),
   state: attendanceState.optional()
 });
+
+export const listAttendanceAggregatesQuerySchema = z.object({
+  from: isoDateTime,
+  to: isoDateTime,
+  employeeId: z.string().min(1).optional()
+});

--- a/work-items/WI-0031-attendance-aggregates-api.md
+++ b/work-items/WI-0031-attendance-aggregates-api.md
@@ -1,0 +1,100 @@
+# WI-0031: Attendance Aggregates API (근태 집계 조회)
+
+## Background and Problem
+
+Payroll preview currently derives payable minutes by reading approved attendance records, but there is no explicit API
+to inspect the underlying attendance aggregation result (regular/overtime/night/holiday totals) per employee.
+The MVP console and future UI need a stable endpoint to validate aggregation outcomes and spot anomalies before payroll.
+
+## Scope
+
+### In Scope
+
+- Add `GET /attendance/aggregates` to return payable-minute totals grouped by employee for a period.
+- Query:
+  - required: `from`, `to` (ISO datetime with offset)
+  - optional: `employeeId`
+- Aggregation rules:
+  - totals are computed from `APPROVED` attendance records only
+  - records without `checkOutAt` do not contribute to totals
+  - rejected records are excluded from totals (but still counted in state counts)
+- Authorization:
+  - `employee`: allow self-only (defaults to actor id when `employeeId` is omitted)
+  - `manager`: allow only with explicit `employeeId`
+  - `admin`, `payroll_operator`: allow (with or without `employeeId`)
+
+### Out of Scope
+
+- Pagination / cursor APIs.
+- Per-day breakdowns and scheduled shift comparison.
+- Org hierarchy based manager scoping (future).
+
+## User Scenarios
+
+1. Employee verifies aggregated payable minutes for their own month before payroll.
+2. Payroll operator aggregates all employees in a period to detect outliers.
+3. Manager checks a specific employee's aggregates after approving records.
+
+## Payroll Accuracy and Calculation Rules
+
+- Source of truth: persisted attendance records in DB.
+- Minute categorization follows `specs/common/time-and-payroll-rules.md` and matches payroll preview behavior.
+- Time zone: `Asia/Seoul`.
+- Workday boundary: `04:00`.
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | Payroll Operator |
+| --- | --- | --- | --- | --- |
+| List attendance aggregates | Allow | Allow (employeeId required) | Allow (self-only) | Allow |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migrations: none (additive API only)
+
+## API and Event Changes
+
+- Endpoints:
+  - `GET /attendance/aggregates`
+- Events published: none
+- Events consumed: none
+
+## Test Plan
+
+- Unit:
+  - query parsing and ISO offset normalization
+  - aggregation totals computed from approved records only
+  - role guard boundaries (employee self-only; manager requires employeeId)
+- Integration:
+  - aggregates include expected totals for approved record
+  - rejected record does not contribute to totals but increases rejected count
+- Regression:
+  - WI-0001 payroll gross pay output remains unchanged (uses same derivation rules)
+
+## Observability and Audit Logging
+
+- Audit events: none (read-only endpoint)
+- Metrics: none for MVP
+- Alert conditions: none for MVP
+
+## Rollback Plan
+
+- Feature flag behavior: not applicable (additive endpoint)
+- Recovery: revert route/service and contract changes
+
+## Definition of Ready (DoR)
+
+- [x] Requirements are unambiguous and testable.
+- [x] Contract + API spec updates prepared.
+- [x] Role matrix reviewed by QA persona.
+- [x] No DB migration required.
+- [x] Rollback plan defined.
+
+## Definition of Done (DoD)
+
+- [ ] Contract/API/test-cases updated with SemVer bump and consumer impact.
+- [ ] Implementation matches contract invariants.
+- [ ] Required unit/e2e tests pass (memory + prisma).
+- [ ] QA Spec Gate and Code Gate are satisfied.
+


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0031-attendance-aggregates-api.md`
- Related Specs:
  - `specs/attendance/contract.yaml`
  - `specs/attendance/api.yaml`
  - `specs/attendance/test-cases.md`
- Related ADR:
  - Not required (additive read-only endpoint, no cross-domain or security-impacting change)

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
  Evidence: `npm test`
- [x] Integration tests
  Evidence: `npm run test:integration`
- [x] Regression checks
  Evidence: `npm run test:e2e`, `npm run test:golden`
- [x] Lint/typecheck
  Evidence: `npm run lint`, `npm run typecheck`
- [x] Migration smoke
  Evidence: N/A (no migration changes in this PR)
- [x] Contract governance checks
  Evidence: `python scripts/ci/check_contracts.py --base origin/main --head HEAD`

## What Changed

- Added `GET /api/attendance/aggregates` (query: `from`, `to`, optional `employeeId`).
- Implemented service aggregation:
  - totals are derived from `APPROVED` records only
  - rejected records do not contribute to totals (but appear in counts)
  - role guard matches attendance list behavior (employee self-only, manager requires employeeId)
- Updated contract + OpenAPI spec + test-cases with SemVer bump (`1.4.0`).
- Extended WI-0001 memory/prisma e2e coverage to assert aggregates correctness.
- Console page: added "근태 집계 조회" button under the list panel for manual verification.

## QA Persona Notes (Evidence)

- Verified role boundaries:
  - employee cannot query other employee aggregates (403)
  - manager requires `employeeId` (400)
  - payroll_operator can list aggregates (200)
- Verified aggregation semantics:
  - totals match payroll derivation rules (`regular/overtime/night/holiday`)
  - totals computed from approved records only
