### PR TITLE
feat(scheduling): add schedule update API with overlap guard (WI-0042)

### DIFF
--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -16,7 +16,7 @@ Exception:
 | People | `Organization`, `Employee` | `organization.created.v1`, `employee.created.v1`, `employee.profile.updated.v1` | Own tables, read-only via API/event projections |
 | RBAC | `Role`, `RolePermission` | none | Read-only by runtime services for authorization resolution; write via RBAC API (admin only) |
 | Attendance | `AttendanceRecord` | `attendance.recorded.v1`, `attendance.corrected.v1`, `attendance.approved.v1`, `attendance.rejected.v1` | Own tables, event projections |
-| Scheduling | `WorkSchedule` | `scheduling.schedule.assigned.v1` | Own tables, read-only via API/event projections |
+| Scheduling | `WorkSchedule` | `scheduling.schedule.assigned.v1`, `scheduling.schedule.updated.v1` | Own tables, read-only via API/event projections |
 | Payroll | `PayrollRun` | `payroll.calculated.v1`, `payroll.confirmed.v1`, `payroll.deductions.calculated.v1`, `payroll.deduction_profile.updated.v1` | Own tables, attendance projections only |
 | Leave | `LeaveRequest`, `LeaveApproval`, `LeaveBalanceProjection` | `leave.requested.v1`, `leave.approved.v1`, `leave.rejected.v1`, `leave.canceled.v1`, `leave.accrual.settled.v1` | Own tables, attendance/payroll read-model only |
 | Platform (Shared) | `AuditLog` | none | Read-only for operations and audits |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "tsx scripts/tests/unit.test.ts",
     "test:integration": "tsx scripts/tests/integration.test.ts && tsx scripts/tests/event-transport-http.test.ts && tsx scripts/tests/ops-alert-webhook.test.ts",
-    "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile.test.ts && tsx scripts/tests/e2e-wi0034-people.test.ts && tsx scripts/tests/e2e-wi0037-tenancy.test.ts && tsx scripts/tests/e2e-wi0040-scheduling.test.ts",
+    "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile.test.ts && tsx scripts/tests/e2e-wi0034-people.test.ts && tsx scripts/tests/e2e-wi0037-tenancy.test.ts && tsx scripts/tests/e2e-wi0040-scheduling.test.ts && tsx scripts/tests/e2e-wi0042-scheduling-update.test.ts",
     "test:e2e:leave": "tsx scripts/tests/e2e-wi0002-leave.test.ts",
     "test:e2e:prisma": "tsx scripts/tests/e2e-wi0001-prisma.test.ts && tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2-prisma.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile-prisma.test.ts",
     "test:e2e:prisma:phase2-flag": "tsx scripts/tests/e2e-wi0005-payroll-phase2-flag-prisma.test.ts",

--- a/scripts/tests/e2e-wi0042-scheduling-update.test.ts
+++ b/scripts/tests/e2e-wi0042-scheduling-update.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+runtimeEnv.FLOWHR_TENANCY_V1 = "true";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+
+type JsonPayload = Record<string, unknown>;
+
+function actorHeaders(role: string, actorId: string, organizationId?: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId,
+    ...(organizationId ? { "x-actor-organization-id": organizationId } : {})
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson(response: Response) {
+  return (await response.json()) as unknown;
+}
+
+async function run() {
+  const { resetMemoryDataAccess, getMemoryAuditActions } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const { resetRuntimeMemoryDomainEvents, getRuntimeMemoryDomainEvents } = await import(
+    "../../src/features/shared/runtime-domain-event-publisher.ts"
+  );
+
+  const orgRoute = await import("../../src/app/api/people/organizations/route.ts");
+  const employeeRoute = await import("../../src/app/api/people/employees/route.ts");
+  const scheduleRoute = await import("../../src/app/api/scheduling/schedules/route.ts");
+  const scheduleByIdRoute = await import("../../src/app/api/scheduling/schedules/[scheduleId]/route.ts");
+
+  resetMemoryDataAccess();
+  resetRuntimeMemoryDomainEvents();
+
+  const orgAResponse = await orgRoute.POST(
+    jsonRequest("POST", "/api/people/organizations", { name: "OrgA" }, actorHeaders("system", "SYS-1"))
+  );
+  assert.equal(orgAResponse.status, 201);
+  const orgA = (await readJson(orgAResponse)) as { organization: { id: string } };
+  assert.ok(orgA.organization.id);
+
+  const orgBResponse = await orgRoute.POST(
+    jsonRequest("POST", "/api/people/organizations", { name: "OrgB" }, actorHeaders("system", "SYS-1"))
+  );
+  assert.equal(orgBResponse.status, 201);
+  const orgB = (await readJson(orgBResponse)) as { organization: { id: string } };
+  assert.ok(orgB.organization.id);
+
+  const employeeAId = "EMP-A1";
+  const employeeBId = "EMP-B1";
+
+  const employeeACreate = await employeeRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/people/employees",
+      { id: employeeAId, organizationId: orgA.organization.id, name: "A1" },
+      actorHeaders("system", "SYS-1")
+    )
+  );
+  assert.equal(employeeACreate.status, 201);
+
+  const employeeBCreate = await employeeRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/people/employees",
+      { id: employeeBId, organizationId: orgB.organization.id, name: "B1" },
+      actorHeaders("system", "SYS-1")
+    )
+  );
+  assert.equal(employeeBCreate.status, 201);
+
+  const managerOrgAHeaders = actorHeaders("manager", "MGR-A1", orgA.organization.id);
+  const managerOrgBHeaders = actorHeaders("manager", "MGR-B1", orgB.organization.id);
+
+  const scheduleA1Create = await scheduleRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/scheduling/schedules",
+      {
+        employeeId: employeeAId,
+        startAt: "2026-02-15T09:00:00+09:00",
+        endAt: "2026-02-15T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      managerOrgAHeaders
+    )
+  );
+  assert.equal(scheduleA1Create.status, 201);
+  const scheduleA1 = (await readJson(scheduleA1Create)) as { schedule: { id: string } };
+  assert.ok(scheduleA1.schedule.id);
+
+  const scheduleA2Create = await scheduleRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/scheduling/schedules",
+      {
+        employeeId: employeeAId,
+        startAt: "2026-02-15T18:00:00+09:00",
+        endAt: "2026-02-15T22:00:00+09:00",
+        breakMinutes: 0,
+        isHoliday: false
+      },
+      managerOrgAHeaders
+    )
+  );
+  assert.equal(scheduleA2Create.status, 201);
+
+  const overlapPatchDenied = await scheduleByIdRoute.PATCH(
+    jsonRequest(
+      "PATCH",
+      `/api/scheduling/schedules/${scheduleA1.schedule.id}`,
+      {
+        startAt: "2026-02-15T10:00:00+09:00",
+        endAt: "2026-02-15T19:00:00+09:00"
+      },
+      managerOrgAHeaders
+    ),
+    { params: Promise.resolve({ scheduleId: scheduleA1.schedule.id }) }
+  );
+  assert.equal(overlapPatchDenied.status, 409, "schedule update must reject overlap with another schedule");
+
+  const schedulePatchOk = await scheduleByIdRoute.PATCH(
+    jsonRequest(
+      "PATCH",
+      `/api/scheduling/schedules/${scheduleA1.schedule.id}`,
+      {
+        startAt: "2026-02-15T08:00:00+09:00",
+        endAt: "2026-02-15T18:00:00+09:00",
+        breakMinutes: 30
+      },
+      managerOrgAHeaders
+    ),
+    { params: Promise.resolve({ scheduleId: scheduleA1.schedule.id }) }
+  );
+  assert.equal(schedulePatchOk.status, 200, "manager can patch schedule within tenant");
+  const patchedBody = (await readJson(schedulePatchOk)) as { schedule: { startAt: string; endAt: string; breakMinutes: number } };
+  assert.equal(patchedBody.schedule.breakMinutes, 30);
+  assert.equal(new Date(patchedBody.schedule.startAt).toISOString(), new Date("2026-02-15T08:00:00+09:00").toISOString());
+  assert.equal(new Date(patchedBody.schedule.endAt).toISOString(), new Date("2026-02-15T18:00:00+09:00").toISOString());
+
+  const employeeHeadersA = actorHeaders("employee", employeeAId, orgA.organization.id);
+  const employeePatchDenied = await scheduleByIdRoute.PATCH(
+    jsonRequest(
+      "PATCH",
+      `/api/scheduling/schedules/${scheduleA1.schedule.id}`,
+      { breakMinutes: 0 },
+      employeeHeadersA
+    ),
+    { params: Promise.resolve({ scheduleId: scheduleA1.schedule.id }) }
+  );
+  assert.equal(employeePatchDenied.status, 403, "employee cannot patch schedules");
+
+  const scheduleBCreate = await scheduleRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/scheduling/schedules",
+      {
+        employeeId: employeeBId,
+        startAt: "2026-02-15T09:00:00+09:00",
+        endAt: "2026-02-15T18:00:00+09:00",
+        breakMinutes: 0,
+        isHoliday: false
+      },
+      managerOrgBHeaders
+    )
+  );
+  assert.equal(scheduleBCreate.status, 201);
+  const scheduleB = (await readJson(scheduleBCreate)) as { schedule: { id: string } };
+  assert.ok(scheduleB.schedule.id);
+
+  const crossTenantPatchDenied = await scheduleByIdRoute.PATCH(
+    jsonRequest(
+      "PATCH",
+      `/api/scheduling/schedules/${scheduleB.schedule.id}`,
+      { breakMinutes: 15 },
+      managerOrgAHeaders
+    ),
+    { params: Promise.resolve({ scheduleId: scheduleB.schedule.id }) }
+  );
+  assert.equal(crossTenantPatchDenied.status, 404, "cross-tenant patch must not leak schedule existence");
+
+  const auditActions = getMemoryAuditActions();
+  const assignedCount = auditActions.filter((action) => action === "scheduling.schedule.assigned").length;
+  const updatedCount = auditActions.filter((action) => action === "scheduling.schedule.updated").length;
+  assert.equal(assignedCount, 3);
+  assert.equal(updatedCount, 1);
+
+  const events = getRuntimeMemoryDomainEvents().map((event) => event.name);
+  const assignedEvents = events.filter((name) => name === "scheduling.schedule.assigned.v1").length;
+  const updatedEvents = events.filter((name) => name === "scheduling.schedule.updated.v1").length;
+  assert.equal(assignedEvents, 3);
+  assert.equal(updatedEvents, 1);
+
+  console.log("e2e-wi0042-scheduling-update.test passed");
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/specs/scheduling/api.yaml
+++ b/specs/scheduling/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Scheduling API
-  version: 0.1.1
+  version: 0.2.0
 paths:
   /scheduling/schedules:
     get:
@@ -42,6 +42,28 @@ paths:
           description: Missing/invalid actor context
         "403":
           description: Insufficient permissions
+        "409":
+          description: Overlapping schedule exists
+  /scheduling/schedules/{scheduleId}:
+    patch:
+      summary: Update schedule
+      parameters:
+        - in: path
+          name: scheduleId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated
+        "400":
+          description: Invalid payload
+        "401":
+          description: Missing/invalid actor context
+        "403":
+          description: Insufficient permissions
+        "404":
+          description: Schedule not found
         "409":
           description: Overlapping schedule exists
 

--- a/specs/scheduling/contract.yaml
+++ b/specs/scheduling/contract.yaml
@@ -1,5 +1,5 @@
 owner: scheduling-agent
-version: 0.1.1
+version: 0.2.0
 scope:
   in:
     - work schedule assignment (planned start/end)
@@ -17,9 +17,9 @@ api:
     - role: employee
       permission: view own schedules only
     - role: manager
-      permission: assign and list schedules within tenant (employeeId scoped)
+      permission: assign/update schedules and list schedules within tenant (employeeId scoped)
     - role: admin
-      permission: assign and list schedules without org restriction
+      permission: assign/update schedules and list schedules without org restriction
   endpoints:
     - method: GET
       path: /scheduling/schedules
@@ -27,10 +27,15 @@ api:
     - method: POST
       path: /scheduling/schedules
       description: Create a schedule entry for an employee.
+    - method: PATCH
+      path: /scheduling/schedules/{scheduleId}
+      description: Update a schedule entry (time/break/holiday/notes); overlap rules apply.
   events:
     published:
       - name: scheduling.schedule.assigned.v1
         description: Emitted when a schedule entry is created/assigned for an employee.
+      - name: scheduling.schedule.updated.v1
+        description: Emitted when an existing schedule entry is updated.
     consumed: []
 db_changes:
   migrations:
@@ -55,18 +60,21 @@ test_plan:
     - schedule payload validation boundaries
   integration:
     - manager can create schedule; employee cannot
+    - manager can update schedule; employee cannot
     - list schedules enforces role boundaries (employee own-only; manager requires employeeId)
   regression:
     - none
   authorization:
-    - permission boundaries for create/list
+    - permission boundaries for create/update/list
   payroll_accuracy:
     - not applicable
 observability:
   audit_events:
     - scheduling.schedule.assigned
+    - scheduling.schedule.updated
   metrics:
     - schedule_assign_count (optional)
+    - schedule_update_count (optional)
   logs:
     - authorization denied logs for scheduling create/list
 rollout:
@@ -79,11 +87,12 @@ rollback:
   max_recovery_time: 60m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Adds overlap validation (409) for WorkSchedule create; schedules remain planning-only (no payroll impact in MVP)."
+consumer_impact: "Adds WorkSchedule update API + update event; keeps overlap validation (409) on create/update (no payroll impact in MVP)."
 references:
   - specs/common/time-and-payroll-rules.md
   - work-items/WI-0040-scheduling-baseline.md
   - work-items/WI-0041-scheduling-overlap-guard.md
+  - work-items/WI-0042-scheduling-update-api.md
 approval:
   spec_owner: scheduling-agent
   qa_owner: qa-agent

--- a/specs/scheduling/test-cases.md
+++ b/specs/scheduling/test-cases.md
@@ -11,11 +11,17 @@ Work schedule assignment and list behavior with tenant isolation and role bounda
 3. Reject schedule create when `startAt >= endAt` (400).
 4. Employee cannot create schedules (403).
 5. Reject schedule create when it overlaps an existing schedule for the same employee (409).
-6. List schedules by period (`from`/`to`) returns expected rows.
-7. Employee can list only own schedules (403 when querying other employeeId).
-8. Manager list query requires `employeeId` (400).
-9. Emit domain event `scheduling.schedule.assigned.v1` once per schedule create.
-10. Append audit log `scheduling.schedule.assigned` with tenant context when available.
+6. Manager updates a schedule entry (200).
+7. Reject schedule update when `scheduleId` does not exist (404).
+8. Reject schedule update when `startAt >= endAt` (400).
+9. Reject schedule update when it overlaps another schedule for the same employee (409).
+10. Employee cannot update schedules (403).
+11. Cross-tenant schedule update returns 404 (no existence leak).
+12. List schedules by period (`from`/`to`) returns expected rows.
+13. Employee can list only own schedules (403 when querying other employeeId).
+14. Manager list query requires `employeeId` (400).
+15. Emit domain events `scheduling.schedule.assigned.v1` and `scheduling.schedule.updated.v1` on successful create/update.
+16. Append audit logs `scheduling.schedule.assigned` and `scheduling.schedule.updated` with tenant context when available.
 
 ## Boundary Cases
 

--- a/src/app/api/scheduling/schedules/[scheduleId]/route.ts
+++ b/src/app/api/scheduling/schedules/[scheduleId]/route.ts
@@ -1,0 +1,49 @@
+import { updateWorkScheduleSchema } from "@/features/scheduling/schemas";
+import { updateWorkSchedule } from "@/features/scheduling/service";
+import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
+import { isServiceError } from "@/features/shared/service-error";
+import { readActor } from "@/lib/actor";
+import { fail, ok } from "@/lib/http";
+
+type RouteContext = {
+  params: Promise<{ scheduleId: string }>;
+};
+
+export async function PATCH(request: Request, context: RouteContext) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return fail(400, "invalid JSON body");
+  }
+
+  const parsed = updateWorkScheduleSchema.safeParse(payload);
+  if (!parsed.success) {
+    return fail(400, "invalid payload", parsed.error.flatten());
+  }
+
+  const { scheduleId } = await context.params;
+  try {
+    const schedule = await updateWorkSchedule(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      scheduleId,
+      {
+        startAt: parsed.data.startAt ? new Date(parsed.data.startAt) : undefined,
+        endAt: parsed.data.endAt ? new Date(parsed.data.endAt) : undefined,
+        breakMinutes: parsed.data.breakMinutes,
+        isHoliday: parsed.data.isHoliday,
+        notes: parsed.data.notes
+      }
+    );
+    return ok({ schedule });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
+}
+

--- a/src/features/scheduling/schemas.ts
+++ b/src/features/scheduling/schemas.ts
@@ -11,6 +11,14 @@ export const createWorkScheduleSchema = z.object({
   notes: z.string().max(1000).optional()
 });
 
+export const updateWorkScheduleSchema = z.object({
+  startAt: isoDateTime.optional(),
+  endAt: isoDateTime.optional(),
+  breakMinutes: z.number().int().min(0).max(300).optional(),
+  isHoliday: z.boolean().optional(),
+  notes: z.string().max(1000).optional()
+});
+
 export const listWorkScheduleQuerySchema = z.object({
   from: isoDateTime,
   to: isoDateTime,

--- a/src/features/scheduling/service.ts
+++ b/src/features/scheduling/service.ts
@@ -1,7 +1,12 @@
 import type { Actor } from "@/lib/actor";
 import { requirePermission, resolveActorPermissions } from "@/lib/permissions";
 import { Permissions } from "@/lib/rbac";
-import type { CreateWorkScheduleInput, DataAccess, WorkScheduleEntity } from "@/features/shared/data-access";
+import type {
+  CreateWorkScheduleInput,
+  DataAccess,
+  UpdateWorkScheduleInput,
+  WorkScheduleEntity
+} from "@/features/shared/data-access";
 import type { DomainEventPublisher } from "@/features/shared/domain-event-publisher";
 import { getRuntimeDomainEventPublisher } from "@/features/shared/runtime-domain-event-publisher";
 import { requireEmployeeWithinTenant, resolveTenantScope } from "@/features/shared/tenant-scope";
@@ -20,6 +25,14 @@ type ListScheduleInput = {
   periodStart: Date;
   periodEnd: Date;
   employeeId?: string;
+};
+
+type UpdateScheduleInput = {
+  startAt?: Date;
+  endAt?: Date;
+  breakMinutes?: number;
+  isHoliday?: boolean;
+  notes?: string;
 };
 
 type ServiceContext = {
@@ -41,6 +54,16 @@ function ensureValidPeriod(periodStart: Date, periodEnd: Date) {
 function toCreateInput(input: CreateScheduleInput): CreateWorkScheduleInput {
   return {
     employeeId: input.employeeId,
+    startAt: input.startAt,
+    endAt: input.endAt,
+    breakMinutes: input.breakMinutes,
+    isHoliday: input.isHoliday,
+    notes: input.notes
+  };
+}
+
+function toUpdateInput(input: UpdateScheduleInput): UpdateWorkScheduleInput {
+  return {
     startAt: input.startAt,
     endAt: input.endAt,
     breakMinutes: input.breakMinutes,
@@ -115,6 +138,103 @@ export async function createWorkSchedule(
   });
 
   return schedule;
+}
+
+async function requireEditableSchedule(
+  context: ServiceContext,
+  scheduleId: string
+): Promise<WorkScheduleEntity> {
+  const actor = context.actor;
+  if (!actor) {
+    throw new ServiceError(401, "missing or invalid actor context");
+  }
+
+  const existing = await context.dataAccess.scheduling.findById(scheduleId);
+  if (!existing) {
+    throw new ServiceError(404, "schedule not found");
+  }
+
+  await requireEmployeeWithinTenant(context.dataAccess, context.actor, existing.employeeId);
+  await requirePermission(context, Permissions.schedulingScheduleWriteAny, "schedule update requires permission");
+
+  return existing;
+}
+
+export async function updateWorkSchedule(
+  context: ServiceContext,
+  scheduleId: string,
+  input: UpdateScheduleInput
+): Promise<WorkScheduleEntity> {
+  const existing = await requireEditableSchedule(context, scheduleId);
+  const employee = await requireEmployeeWithinTenant(context.dataAccess, context.actor, existing.employeeId);
+
+  const startAt = input.startAt ?? existing.startAt;
+  const endAt = input.endAt ?? existing.endAt;
+  if (endAt <= startAt) {
+    throw new ServiceError(400, "endAt must be after startAt");
+  }
+
+  const overlapping = await context.dataAccess.scheduling.listInPeriod({
+    periodStart: startAt,
+    periodEnd: endAt,
+    organizationId: employee.organizationId ?? undefined,
+    employeeId: existing.employeeId
+  });
+  const strictOverlaps = overlapping.filter(
+    (schedule) => schedule.id !== scheduleId && schedule.startAt < endAt && schedule.endAt > startAt
+  );
+  if (strictOverlaps.length > 0) {
+    throw new ServiceError(409, "overlapping schedule exists", {
+      scheduleId,
+      employeeId: existing.employeeId,
+      overlapCount: strictOverlaps.length,
+      overlappingScheduleIds: strictOverlaps.map((schedule) => schedule.id)
+    });
+  }
+
+  const updated = await context.dataAccess.scheduling.update(scheduleId, toUpdateInput(input));
+
+  await context.dataAccess.audit.append({
+    action: "scheduling.schedule.updated",
+    entityType: "WorkSchedule",
+    entityId: updated.id,
+    organizationId: employee.organizationId,
+    actorRole: context.actor!.role,
+    actorId: context.actor!.id,
+    payload: {
+      scheduleId: updated.id,
+      employeeId: updated.employeeId,
+      startAt: updated.startAt.toISOString(),
+      endAt: updated.endAt.toISOString(),
+      breakMinutes: updated.breakMinutes,
+      isHoliday: updated.isHoliday,
+      notes: updated.notes,
+      changed: {
+        startAt: input.startAt ? input.startAt.toISOString() : undefined,
+        endAt: input.endAt ? input.endAt.toISOString() : undefined,
+        breakMinutes: input.breakMinutes,
+        isHoliday: input.isHoliday,
+        notes: input.notes
+      }
+    }
+  });
+  await getEventPublisher(context).publish({
+    name: "scheduling.schedule.updated.v1",
+    occurredAt: new Date().toISOString(),
+    entityType: "WorkSchedule",
+    entityId: updated.id,
+    actorRole: context.actor!.role,
+    actorId: context.actor!.id,
+    payload: {
+      employeeId: updated.employeeId,
+      startAt: updated.startAt.toISOString(),
+      endAt: updated.endAt.toISOString(),
+      breakMinutes: updated.breakMinutes,
+      isHoliday: updated.isHoliday
+    }
+  });
+
+  return updated;
 }
 
 export async function listWorkSchedules(

--- a/src/features/shared/data-access.ts
+++ b/src/features/shared/data-access.ts
@@ -157,6 +157,14 @@ export type CreateWorkScheduleInput = {
   notes?: string;
 };
 
+export type UpdateWorkScheduleInput = {
+  startAt?: Date;
+  endAt?: Date;
+  breakMinutes?: number;
+  isHoliday?: boolean;
+  notes?: string | null;
+};
+
 export type CreatePayrollRunInput = {
   organizationId?: string | null;
   employeeId?: string;
@@ -281,6 +289,8 @@ export interface AttendanceStore {
 
 export interface SchedulingStore {
   create(input: CreateWorkScheduleInput): Promise<WorkScheduleEntity>;
+  findById(id: string): Promise<WorkScheduleEntity | null>;
+  update(id: string, input: UpdateWorkScheduleInput): Promise<WorkScheduleEntity>;
   listInPeriod(input: {
     periodStart: Date;
     periodEnd: Date;

--- a/src/features/shared/domain-event-publisher.ts
+++ b/src/features/shared/domain-event-publisher.ts
@@ -7,6 +7,7 @@ export const domainEventNames = [
   "attendance.approved.v1",
   "attendance.rejected.v1",
   "scheduling.schedule.assigned.v1",
+  "scheduling.schedule.updated.v1",
   "payroll.calculated.v1",
   "payroll.deductions.calculated.v1",
   "payroll.deduction_profile.updated.v1",

--- a/src/features/shared/memory-data-access.ts
+++ b/src/features/shared/memory-data-access.ts
@@ -2,6 +2,7 @@ import type {
   AppendAuditLogInput,
   AttendanceRecordEntity,
   CreateWorkScheduleInput,
+  UpdateWorkScheduleInput,
   CreateEmployeeInput,
   CreateOrganizationInput,
   DataAccess,
@@ -475,6 +476,31 @@ export const memoryDataAccess: DataAccess = {
       };
       state.workSchedules.set(entity.id, entity);
       return cloneWorkSchedule(entity);
+    },
+
+    async findById(id: string) {
+      const entity = state.workSchedules.get(id);
+      return entity ? cloneWorkSchedule(entity) : null;
+    },
+
+    async update(id: string, input: UpdateWorkScheduleInput) {
+      const existing = state.workSchedules.get(id);
+      if (!existing) {
+        throw new Error(`work schedule not found: ${id}`);
+      }
+
+      const updated: WorkScheduleEntity = {
+        ...existing,
+        startAt: input.startAt ? cloneDate(input.startAt) : existing.startAt,
+        endAt: input.endAt ? cloneDate(input.endAt) : existing.endAt,
+        breakMinutes: input.breakMinutes ?? existing.breakMinutes,
+        isHoliday: input.isHoliday ?? existing.isHoliday,
+        notes: input.notes !== undefined ? input.notes : existing.notes,
+        updatedAt: new Date()
+      };
+
+      state.workSchedules.set(id, updated);
+      return cloneWorkSchedule(updated);
     },
 
     async listInPeriod(input) {

--- a/src/features/shared/prisma-data-access.ts
+++ b/src/features/shared/prisma-data-access.ts
@@ -10,6 +10,7 @@ import type {
   CreateOrganizationInput,
   CreatePayrollRunInput,
   CreateWorkScheduleInput,
+  UpdateWorkScheduleInput,
   DataAccess,
   DeductionProfileEntity,
   DeductionProfileStore,
@@ -461,6 +462,27 @@ const scheduling: SchedulingStore = {
         breakMinutes: input.breakMinutes,
         isHoliday: input.isHoliday,
         notes: input.notes ?? null
+      }
+    });
+    return toWorkScheduleEntity(record);
+  },
+
+  async findById(id: string) {
+    const record = await prisma.workSchedule.findUnique({
+      where: { id }
+    });
+    return record ? toWorkScheduleEntity(record) : null;
+  },
+
+  async update(id: string, input: UpdateWorkScheduleInput) {
+    const record = await prisma.workSchedule.update({
+      where: { id },
+      data: {
+        ...(input.startAt ? { startAt: input.startAt } : {}),
+        ...(input.endAt ? { endAt: input.endAt } : {}),
+        ...(input.breakMinutes !== undefined ? { breakMinutes: input.breakMinutes } : {}),
+        ...(input.isHoliday !== undefined ? { isHoliday: input.isHoliday } : {}),
+        ...(input.notes !== undefined ? { notes: input.notes } : {})
       }
     });
     return toWorkScheduleEntity(record);

--- a/work-items/WI-0042-scheduling-update-api.md
+++ b/work-items/WI-0042-scheduling-update-api.md
@@ -1,0 +1,103 @@
+# WI-0042: Scheduling Update API (WorkSchedule PATCH)
+
+## Background and Problem
+
+`WorkSchedule` baseline 생성(할당)만 가능하면 운영 중 정정/변경이 불가능해 실제 사용이 어렵습니다.
+또한 WI-0041에서 추가한 "중복/겹침 방지" 규칙을 수정 경로에도 동일하게 적용해야 데이터 무결성이 유지됩니다.
+
+## Scope
+
+### In Scope
+
+- `PATCH /scheduling/schedules/{scheduleId}` 추가:
+  - 일정의 `startAt/endAt/breakMinutes/isHoliday/notes` 부분 수정 지원
+  - 동일 직원(`employeeId`) 내 시간 겹침(Overlap) 방지 규칙을 업데이트에도 적용 (409)
+- 감사로그/도메인 이벤트 추가:
+  - audit: `scheduling.schedule.updated`
+  - event: `scheduling.schedule.updated.v1`
+- 스펙/계약/테스트케이스 및 e2e 회귀 테스트 추가.
+
+### Out of Scope
+
+- 일정 삭제/취소 API
+- 반복/템플릿/로테이션 스케줄
+- 스케줄 기반 근태 이상 탐지/대시보드
+
+## User Scenarios
+
+1. 매니저가 직원의 일정(09:00~18:00)을 10:00~19:00으로 수정한다.
+2. 매니저가 일정 수정으로 인해 다른 일정과 시간이 겹치면 409로 거절된다.
+3. 테넌트가 다른 직원의 일정 수정은 404로 처리되어 존재 여부가 노출되지 않는다.
+
+## Payroll Accuracy and Calculation Rules
+
+- N/A (스케줄은 MVP에서 급여 산정에 직접 영향 없음)
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | System |
+| --- | --- | --- | --- | --- |
+| Patch schedule | Allow | Allow | Deny | N/A |
+| Patch schedule across tenant | Allow | Deny(404) | Deny | N/A |
+| Patch schedule causing overlap | Allow(409) | Allow(409) | Deny | N/A |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none (behavior/API only)
+- Migration IDs: none
+- Backward compatibility plan: additive endpoint + new event
+
+## API and Event Changes
+
+- Endpoints:
+  - `PATCH /scheduling/schedules/{scheduleId}` (new)
+- Events published:
+  - `scheduling.schedule.updated.v1` (new)
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - update payload validation boundaries
+  - overlap detection on update (exclude self; adjacent allowed)
+- Integration:
+  - manager can patch within tenant, employee cannot
+- Regression:
+  - e2e WI-0042 covers update + overlap rejection + cross-tenant 404
+- Authorization:
+  - tenant + permission boundaries for patch
+- Payroll accuracy:
+  - N/A
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `scheduling.schedule.updated`
+- Metrics:
+  - optional: schedule_update_count (future)
+- Alert conditions:
+  - none
+
+## Rollback Plan
+
+- Feature flag behavior: N/A
+- DB rollback method: N/A
+- Recovery target time: < 30m (revert endpoint + event addition)
+
+## Definition of Ready (DoR)
+
+- [x] Requirements are unambiguous and testable.
+- [x] Domain contract drafted or updated.
+- [x] Role matrix reviewed by QA.
+- [x] Data migration impact assessed.
+- [x] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.
+


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0042-scheduling-update-api.md`
- Related Specs:
  - `specs/scheduling/contract.yaml`
  - `specs/scheduling/api.yaml`
  - `specs/scheduling/test-cases.md`
- Related ADR:
  - Not required (scheduling baseline API 확장 범위)

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [ ] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):

