### PR TITLE
feat(scheduling): add schedule delete API (WI-0043)

### DIFF
--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -16,7 +16,7 @@ Exception:
 | People | `Organization`, `Employee` | `organization.created.v1`, `employee.created.v1`, `employee.profile.updated.v1` | Own tables, read-only via API/event projections |
 | RBAC | `Role`, `RolePermission` | none | Read-only by runtime services for authorization resolution; write via RBAC API (admin only) |
 | Attendance | `AttendanceRecord` | `attendance.recorded.v1`, `attendance.corrected.v1`, `attendance.approved.v1`, `attendance.rejected.v1` | Own tables, event projections |
-| Scheduling | `WorkSchedule` | `scheduling.schedule.assigned.v1`, `scheduling.schedule.updated.v1` | Own tables, read-only via API/event projections |
+| Scheduling | `WorkSchedule` | `scheduling.schedule.assigned.v1`, `scheduling.schedule.updated.v1`, `scheduling.schedule.deleted.v1` | Own tables, read-only via API/event projections |
 | Payroll | `PayrollRun` | `payroll.calculated.v1`, `payroll.confirmed.v1`, `payroll.deductions.calculated.v1`, `payroll.deduction_profile.updated.v1` | Own tables, attendance projections only |
 | Leave | `LeaveRequest`, `LeaveApproval`, `LeaveBalanceProjection` | `leave.requested.v1`, `leave.approved.v1`, `leave.rejected.v1`, `leave.canceled.v1`, `leave.accrual.settled.v1` | Own tables, attendance/payroll read-model only |
 | Platform (Shared) | `AuditLog` | none | Read-only for operations and audits |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "tsx scripts/tests/unit.test.ts",
     "test:integration": "tsx scripts/tests/integration.test.ts && tsx scripts/tests/event-transport-http.test.ts && tsx scripts/tests/ops-alert-webhook.test.ts",
-    "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile.test.ts && tsx scripts/tests/e2e-wi0034-people.test.ts && tsx scripts/tests/e2e-wi0037-tenancy.test.ts && tsx scripts/tests/e2e-wi0040-scheduling.test.ts && tsx scripts/tests/e2e-wi0042-scheduling-update.test.ts",
+    "test:e2e": "tsx scripts/tests/e2e-wi0001.test.ts && tsx scripts/tests/e2e-wi0002-leave.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile.test.ts && tsx scripts/tests/e2e-wi0034-people.test.ts && tsx scripts/tests/e2e-wi0037-tenancy.test.ts && tsx scripts/tests/e2e-wi0040-scheduling.test.ts && tsx scripts/tests/e2e-wi0042-scheduling-update.test.ts && tsx scripts/tests/e2e-wi0043-scheduling-delete.test.ts",
     "test:e2e:leave": "tsx scripts/tests/e2e-wi0002-leave.test.ts",
     "test:e2e:prisma": "tsx scripts/tests/e2e-wi0001-prisma.test.ts && tsx scripts/tests/e2e-wi0002-leave-prisma.test.ts && tsx scripts/tests/e2e-wi0005-payroll-phase2-prisma.test.ts && tsx scripts/tests/e2e-wi0006-payroll-deduction-profile-prisma.test.ts",
     "test:e2e:prisma:phase2-flag": "tsx scripts/tests/e2e-wi0005-payroll-phase2-flag-prisma.test.ts",

--- a/scripts/tests/e2e-wi0043-scheduling-delete.test.ts
+++ b/scripts/tests/e2e-wi0043-scheduling-delete.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+runtimeEnv.FLOWHR_TENANCY_V1 = "true";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+
+type JsonPayload = Record<string, unknown>;
+
+function actorHeaders(role: string, actorId: string, organizationId?: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId,
+    ...(organizationId ? { "x-actor-organization-id": organizationId } : {})
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson(response: Response) {
+  return (await response.json()) as unknown;
+}
+
+async function run() {
+  const { resetMemoryDataAccess, getMemoryAuditActions } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const { resetRuntimeMemoryDomainEvents, getRuntimeMemoryDomainEvents } = await import(
+    "../../src/features/shared/runtime-domain-event-publisher.ts"
+  );
+
+  const orgRoute = await import("../../src/app/api/people/organizations/route.ts");
+  const employeeRoute = await import("../../src/app/api/people/employees/route.ts");
+  const scheduleRoute = await import("../../src/app/api/scheduling/schedules/route.ts");
+  const scheduleByIdRoute = await import("../../src/app/api/scheduling/schedules/[scheduleId]/route.ts");
+
+  resetMemoryDataAccess();
+  resetRuntimeMemoryDomainEvents();
+
+  const orgAResponse = await orgRoute.POST(
+    jsonRequest("POST", "/api/people/organizations", { name: "OrgA" }, actorHeaders("system", "SYS-1"))
+  );
+  assert.equal(orgAResponse.status, 201);
+  const orgA = (await readJson(orgAResponse)) as { organization: { id: string } };
+
+  const orgBResponse = await orgRoute.POST(
+    jsonRequest("POST", "/api/people/organizations", { name: "OrgB" }, actorHeaders("system", "SYS-1"))
+  );
+  assert.equal(orgBResponse.status, 201);
+  const orgB = (await readJson(orgBResponse)) as { organization: { id: string } };
+
+  const employeeAId = "EMP-A1";
+  const employeeBId = "EMP-B1";
+
+  const employeeACreate = await employeeRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/people/employees",
+      { id: employeeAId, organizationId: orgA.organization.id, name: "A1" },
+      actorHeaders("system", "SYS-1")
+    )
+  );
+  assert.equal(employeeACreate.status, 201);
+
+  const employeeBCreate = await employeeRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/people/employees",
+      { id: employeeBId, organizationId: orgB.organization.id, name: "B1" },
+      actorHeaders("system", "SYS-1")
+    )
+  );
+  assert.equal(employeeBCreate.status, 201);
+
+  const managerOrgAHeaders = actorHeaders("manager", "MGR-A1", orgA.organization.id);
+  const managerOrgBHeaders = actorHeaders("manager", "MGR-B1", orgB.organization.id);
+  const employeeHeadersA = actorHeaders("employee", employeeAId, orgA.organization.id);
+
+  const scheduleAResponse = await scheduleRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/scheduling/schedules",
+      {
+        employeeId: employeeAId,
+        startAt: "2026-02-16T09:00:00+09:00",
+        endAt: "2026-02-16T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      managerOrgAHeaders
+    )
+  );
+  assert.equal(scheduleAResponse.status, 201);
+  const scheduleA = (await readJson(scheduleAResponse)) as { schedule: { id: string } };
+
+  const scheduleBResponse = await scheduleRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/scheduling/schedules",
+      {
+        employeeId: employeeBId,
+        startAt: "2026-02-16T09:00:00+09:00",
+        endAt: "2026-02-16T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      managerOrgBHeaders
+    )
+  );
+  assert.equal(scheduleBResponse.status, 201);
+  const scheduleB = (await readJson(scheduleBResponse)) as { schedule: { id: string } };
+
+  const employeeDeleteDenied = await scheduleByIdRoute.DELETE(
+    new Request(`http://localhost/api/scheduling/schedules/${scheduleA.schedule.id}`, {
+      method: "DELETE",
+      headers: employeeHeadersA
+    }),
+    { params: Promise.resolve({ scheduleId: scheduleA.schedule.id }) }
+  );
+  assert.equal(employeeDeleteDenied.status, 403);
+
+  const crossTenantDeleteDenied = await scheduleByIdRoute.DELETE(
+    new Request(`http://localhost/api/scheduling/schedules/${scheduleB.schedule.id}`, {
+      method: "DELETE",
+      headers: managerOrgAHeaders
+    }),
+    { params: Promise.resolve({ scheduleId: scheduleB.schedule.id }) }
+  );
+  assert.equal(crossTenantDeleteDenied.status, 404);
+
+  const managerDeleteOk = await scheduleByIdRoute.DELETE(
+    new Request(`http://localhost/api/scheduling/schedules/${scheduleA.schedule.id}`, {
+      method: "DELETE",
+      headers: managerOrgAHeaders
+    }),
+    { params: Promise.resolve({ scheduleId: scheduleA.schedule.id }) }
+  );
+  assert.equal(managerDeleteOk.status, 200, "manager can delete schedule within tenant");
+
+  const managerDeleteMissing = await scheduleByIdRoute.DELETE(
+    new Request(`http://localhost/api/scheduling/schedules/${scheduleA.schedule.id}`, {
+      method: "DELETE",
+      headers: managerOrgAHeaders
+    }),
+    { params: Promise.resolve({ scheduleId: scheduleA.schedule.id }) }
+  );
+  assert.equal(managerDeleteMissing.status, 404, "deleting missing schedule should return 404");
+
+  const managerListAfterDelete = await scheduleRoute.GET(
+    new Request(
+      `http://localhost/api/scheduling/schedules?from=2026-02-01T00:00:00+09:00&to=2026-02-28T23:59:59+09:00&employeeId=${employeeAId}`,
+      {
+        method: "GET",
+        headers: managerOrgAHeaders
+      }
+    )
+  );
+  assert.equal(managerListAfterDelete.status, 200);
+  const managerListBody = (await readJson(managerListAfterDelete)) as { schedules: Array<{ id: string }> };
+  assert.equal(managerListBody.schedules.length, 0, "deleted schedule should not appear in list");
+
+  const auditActions = getMemoryAuditActions();
+  const deletedCount = auditActions.filter((action) => action === "scheduling.schedule.deleted").length;
+  assert.equal(deletedCount, 1, "delete audit should be emitted exactly once");
+
+  const eventNames = getRuntimeMemoryDomainEvents().map((event) => event.name);
+  const deletedEventCount = eventNames.filter((name) => name === "scheduling.schedule.deleted.v1").length;
+  assert.equal(deletedEventCount, 1, "delete event should be emitted exactly once");
+
+  console.log("e2e-wi0043-scheduling-delete.test passed");
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+

--- a/specs/scheduling/api.yaml
+++ b/specs/scheduling/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Scheduling API
-  version: 0.2.0
+  version: 0.3.0
 paths:
   /scheduling/schedules:
     get:
@@ -66,4 +66,21 @@ paths:
           description: Schedule not found
         "409":
           description: Overlapping schedule exists
+    delete:
+      summary: Delete schedule
+      parameters:
+        - in: path
+          name: scheduleId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+        "401":
+          description: Missing/invalid actor context
+        "403":
+          description: Insufficient permissions
+        "404":
+          description: Schedule not found
 

--- a/specs/scheduling/contract.yaml
+++ b/specs/scheduling/contract.yaml
@@ -1,5 +1,5 @@
 owner: scheduling-agent
-version: 0.2.0
+version: 0.3.0
 scope:
   in:
     - work schedule assignment (planned start/end)
@@ -17,9 +17,9 @@ api:
     - role: employee
       permission: view own schedules only
     - role: manager
-      permission: assign/update schedules and list schedules within tenant (employeeId scoped)
+      permission: assign/update/delete schedules and list schedules within tenant (employeeId scoped)
     - role: admin
-      permission: assign/update schedules and list schedules without org restriction
+      permission: assign/update/delete schedules and list schedules without org restriction
   endpoints:
     - method: GET
       path: /scheduling/schedules
@@ -30,12 +30,17 @@ api:
     - method: PATCH
       path: /scheduling/schedules/{scheduleId}
       description: Update a schedule entry (time/break/holiday/notes); overlap rules apply.
+    - method: DELETE
+      path: /scheduling/schedules/{scheduleId}
+      description: Delete an existing schedule entry.
   events:
     published:
       - name: scheduling.schedule.assigned.v1
         description: Emitted when a schedule entry is created/assigned for an employee.
       - name: scheduling.schedule.updated.v1
         description: Emitted when an existing schedule entry is updated.
+      - name: scheduling.schedule.deleted.v1
+        description: Emitted when an existing schedule entry is deleted.
     consumed: []
 db_changes:
   migrations:
@@ -61,20 +66,23 @@ test_plan:
   integration:
     - manager can create schedule; employee cannot
     - manager can update schedule; employee cannot
+    - manager can delete schedule; employee cannot
     - list schedules enforces role boundaries (employee own-only; manager requires employeeId)
   regression:
     - none
   authorization:
-    - permission boundaries for create/update/list
+    - permission boundaries for create/update/delete/list
   payroll_accuracy:
     - not applicable
 observability:
   audit_events:
     - scheduling.schedule.assigned
     - scheduling.schedule.updated
+    - scheduling.schedule.deleted
   metrics:
     - schedule_assign_count (optional)
     - schedule_update_count (optional)
+    - schedule_delete_count (optional)
   logs:
     - authorization denied logs for scheduling create/list
 rollout:
@@ -87,12 +95,13 @@ rollback:
   max_recovery_time: 60m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Adds WorkSchedule update API + update event; keeps overlap validation (409) on create/update (no payroll impact in MVP)."
+consumer_impact: "Adds WorkSchedule delete API + delete event; keeps overlap validation (409) on create/update (no payroll impact in MVP)."
 references:
   - specs/common/time-and-payroll-rules.md
   - work-items/WI-0040-scheduling-baseline.md
   - work-items/WI-0041-scheduling-overlap-guard.md
   - work-items/WI-0042-scheduling-update-api.md
+  - work-items/WI-0043-scheduling-delete-api.md
 approval:
   spec_owner: scheduling-agent
   qa_owner: qa-agent

--- a/specs/scheduling/test-cases.md
+++ b/specs/scheduling/test-cases.md
@@ -17,11 +17,15 @@ Work schedule assignment and list behavior with tenant isolation and role bounda
 9. Reject schedule update when it overlaps another schedule for the same employee (409).
 10. Employee cannot update schedules (403).
 11. Cross-tenant schedule update returns 404 (no existence leak).
-12. List schedules by period (`from`/`to`) returns expected rows.
-13. Employee can list only own schedules (403 when querying other employeeId).
-14. Manager list query requires `employeeId` (400).
-15. Emit domain events `scheduling.schedule.assigned.v1` and `scheduling.schedule.updated.v1` on successful create/update.
-16. Append audit logs `scheduling.schedule.assigned` and `scheduling.schedule.updated` with tenant context when available.
+12. Manager deletes a schedule entry (200).
+13. Reject schedule delete when `scheduleId` does not exist (404).
+14. Employee cannot delete schedules (403).
+15. Cross-tenant schedule delete returns 404 (no existence leak).
+16. List schedules by period (`from`/`to`) returns expected rows.
+17. Employee can list only own schedules (403 when querying other employeeId).
+18. Manager list query requires `employeeId` (400).
+19. Emit domain events `scheduling.schedule.assigned.v1`, `scheduling.schedule.updated.v1`, `scheduling.schedule.deleted.v1` on successful actions.
+20. Append audit logs `scheduling.schedule.assigned`, `scheduling.schedule.updated`, `scheduling.schedule.deleted` with tenant context when available.
 
 ## Boundary Cases
 

--- a/src/app/api/scheduling/schedules/[scheduleId]/route.ts
+++ b/src/app/api/scheduling/schedules/[scheduleId]/route.ts
@@ -1,5 +1,5 @@
 import { updateWorkScheduleSchema } from "@/features/scheduling/schemas";
-import { updateWorkSchedule } from "@/features/scheduling/service";
+import { deleteWorkSchedule, updateWorkSchedule } from "@/features/scheduling/service";
 import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
 import { isServiceError } from "@/features/shared/service-error";
 import { readActor } from "@/lib/actor";
@@ -37,6 +37,25 @@ export async function PATCH(request: Request, context: RouteContext) {
         isHoliday: parsed.data.isHoliday,
         notes: parsed.data.notes
       }
+    );
+    return ok({ schedule });
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const { scheduleId } = await context.params;
+  try {
+    const schedule = await deleteWorkSchedule(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      scheduleId
     );
     return ok({ schedule });
   } catch (error) {

--- a/src/features/scheduling/service.ts
+++ b/src/features/scheduling/service.ts
@@ -142,7 +142,8 @@ export async function createWorkSchedule(
 
 async function requireEditableSchedule(
   context: ServiceContext,
-  scheduleId: string
+  scheduleId: string,
+  permissionMessage: string
 ): Promise<WorkScheduleEntity> {
   const actor = context.actor;
   if (!actor) {
@@ -155,7 +156,7 @@ async function requireEditableSchedule(
   }
 
   await requireEmployeeWithinTenant(context.dataAccess, context.actor, existing.employeeId);
-  await requirePermission(context, Permissions.schedulingScheduleWriteAny, "schedule update requires permission");
+  await requirePermission(context, Permissions.schedulingScheduleWriteAny, permissionMessage);
 
   return existing;
 }
@@ -165,7 +166,7 @@ export async function updateWorkSchedule(
   scheduleId: string,
   input: UpdateScheduleInput
 ): Promise<WorkScheduleEntity> {
-  const existing = await requireEditableSchedule(context, scheduleId);
+  const existing = await requireEditableSchedule(context, scheduleId, "schedule update requires permission");
   const employee = await requireEmployeeWithinTenant(context.dataAccess, context.actor, existing.employeeId);
 
   const startAt = input.startAt ?? existing.startAt;
@@ -235,6 +236,50 @@ export async function updateWorkSchedule(
   });
 
   return updated;
+}
+
+export async function deleteWorkSchedule(
+  context: ServiceContext,
+  scheduleId: string
+): Promise<WorkScheduleEntity> {
+  const existing = await requireEditableSchedule(context, scheduleId, "schedule delete requires permission");
+  const employee = await requireEmployeeWithinTenant(context.dataAccess, context.actor, existing.employeeId);
+
+  const deleted = await context.dataAccess.scheduling.delete(scheduleId);
+
+  await context.dataAccess.audit.append({
+    action: "scheduling.schedule.deleted",
+    entityType: "WorkSchedule",
+    entityId: deleted.id,
+    organizationId: employee.organizationId,
+    actorRole: context.actor!.role,
+    actorId: context.actor!.id,
+    payload: {
+      scheduleId: deleted.id,
+      employeeId: deleted.employeeId,
+      startAt: deleted.startAt.toISOString(),
+      endAt: deleted.endAt.toISOString(),
+      breakMinutes: deleted.breakMinutes,
+      isHoliday: deleted.isHoliday
+    }
+  });
+  await getEventPublisher(context).publish({
+    name: "scheduling.schedule.deleted.v1",
+    occurredAt: new Date().toISOString(),
+    entityType: "WorkSchedule",
+    entityId: deleted.id,
+    actorRole: context.actor!.role,
+    actorId: context.actor!.id,
+    payload: {
+      employeeId: deleted.employeeId,
+      startAt: deleted.startAt.toISOString(),
+      endAt: deleted.endAt.toISOString(),
+      breakMinutes: deleted.breakMinutes,
+      isHoliday: deleted.isHoliday
+    }
+  });
+
+  return deleted;
 }
 
 export async function listWorkSchedules(

--- a/src/features/shared/data-access.ts
+++ b/src/features/shared/data-access.ts
@@ -291,6 +291,7 @@ export interface SchedulingStore {
   create(input: CreateWorkScheduleInput): Promise<WorkScheduleEntity>;
   findById(id: string): Promise<WorkScheduleEntity | null>;
   update(id: string, input: UpdateWorkScheduleInput): Promise<WorkScheduleEntity>;
+  delete(id: string): Promise<WorkScheduleEntity>;
   listInPeriod(input: {
     periodStart: Date;
     periodEnd: Date;

--- a/src/features/shared/domain-event-publisher.ts
+++ b/src/features/shared/domain-event-publisher.ts
@@ -8,6 +8,7 @@ export const domainEventNames = [
   "attendance.rejected.v1",
   "scheduling.schedule.assigned.v1",
   "scheduling.schedule.updated.v1",
+  "scheduling.schedule.deleted.v1",
   "payroll.calculated.v1",
   "payroll.deductions.calculated.v1",
   "payroll.deduction_profile.updated.v1",

--- a/src/features/shared/memory-data-access.ts
+++ b/src/features/shared/memory-data-access.ts
@@ -503,6 +503,15 @@ export const memoryDataAccess: DataAccess = {
       return cloneWorkSchedule(updated);
     },
 
+    async delete(id: string) {
+      const existing = state.workSchedules.get(id);
+      if (!existing) {
+        throw new Error(`work schedule not found: ${id}`);
+      }
+      state.workSchedules.delete(id);
+      return cloneWorkSchedule(existing);
+    },
+
     async listInPeriod(input) {
       const rows: WorkScheduleEntity[] = [];
       for (const entity of state.workSchedules.values()) {

--- a/src/features/shared/prisma-data-access.ts
+++ b/src/features/shared/prisma-data-access.ts
@@ -488,6 +488,13 @@ const scheduling: SchedulingStore = {
     return toWorkScheduleEntity(record);
   },
 
+  async delete(id: string) {
+    const record = await prisma.workSchedule.delete({
+      where: { id }
+    });
+    return toWorkScheduleEntity(record);
+  },
+
   async listInPeriod(input: {
     periodStart: Date;
     periodEnd: Date;

--- a/work-items/WI-0043-scheduling-delete-api.md
+++ b/work-items/WI-0043-scheduling-delete-api.md
@@ -1,0 +1,104 @@
+# WI-0043: Scheduling Delete API (WorkSchedule DELETE)
+
+## Background and Problem
+
+현재 스케줄은 생성/수정만 가능하고 삭제가 불가능합니다.
+운영 중 잘못 등록된 일정을 제거할 수 없으면 이후 근태/이상 탐지 고도화 단계에서 기준 데이터 품질이 떨어집니다.
+
+## Scope
+
+### In Scope
+
+- `DELETE /scheduling/schedules/{scheduleId}` 추가
+- 권한/테넌트 범위 검증:
+  - manager/admin만 삭제 가능
+  - 타 테넌트 일정 삭제 시 404 (존재 여부 비노출)
+- 감사로그/도메인 이벤트 추가:
+  - audit: `scheduling.schedule.deleted`
+  - event: `scheduling.schedule.deleted.v1`
+- 스펙/계약/테스트케이스/e2e 업데이트
+
+### Out of Scope
+
+- soft delete/복구 기능
+- 일정 대량 삭제
+- 반복/템플릿/로테이션
+
+## User Scenarios
+
+1. 매니저가 잘못 생성한 일정을 삭제한다.
+2. 이미 삭제되었거나 존재하지 않는 일정 삭제 요청은 404를 반환한다.
+3. 다른 테넌트의 일정 삭제 요청은 404로 처리된다.
+
+## Payroll Accuracy and Calculation Rules
+
+- N/A (스케줄은 MVP에서 급여 산정에 직접 영향 없음)
+
+## Authorization and Role Matrix
+
+| Action | Admin | Manager | Employee | System |
+| --- | --- | --- | --- | --- |
+| Delete schedule | Allow | Allow | Deny | N/A |
+| Delete cross-tenant schedule | Allow | Deny(404) | Deny | N/A |
+
+## Data Changes (Tables and Migrations)
+
+- Tables: none
+- Migration IDs: none
+- Backward compatibility plan: additive endpoint + event
+
+## API and Event Changes
+
+- Endpoints:
+  - `DELETE /scheduling/schedules/{scheduleId}` (new)
+- Events published:
+  - `scheduling.schedule.deleted.v1` (new)
+- Events consumed:
+  - none
+
+## Test Plan
+
+- Unit:
+  - schedule delete permission and existence checks
+- Integration:
+  - manager/admin delete success
+  - employee delete denied
+  - cross-tenant delete 404
+- Regression:
+  - WI-0043 e2e에서 create -> delete -> list 검증
+- Authorization:
+  - permission + tenant boundary
+- Payroll accuracy:
+  - N/A
+
+## Observability and Audit Logging
+
+- Audit events:
+  - `scheduling.schedule.deleted`
+- Metrics:
+  - optional: schedule_delete_count (future)
+- Alert conditions:
+  - none
+
+## Rollback Plan
+
+- Feature flag behavior: N/A
+- DB rollback method: N/A
+- Recovery target time: < 30m (route/service revert)
+
+## Definition of Ready (DoR)
+
+- [x] Requirements are unambiguous and testable.
+- [x] Domain contract drafted or updated.
+- [x] Role matrix reviewed by QA.
+- [x] Data migration impact assessed.
+- [x] Risk and rollback drafted.
+
+## Definition of Done (DoD)
+
+- [ ] Implementation matches approved contract.
+- [ ] Required tests pass and coverage is updated.
+- [ ] Audit logs are emitted for sensitive actions.
+- [ ] QA Spec Gate and Code Gate are both passed.
+- [ ] ADR linked when architecture/compatibility changed.
+


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0043-scheduling-delete-api.md`
- Related Specs:
  - `specs/scheduling/contract.yaml`
  - `specs/scheduling/api.yaml`
  - `specs/scheduling/test-cases.md`
- Related ADR:
  - Not required (기존 Scheduling 도메인 API 확장)

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [ ] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):

