### PR TITLE
feat: WI-0223 payroll KR taxable/non-taxable split rule

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 ﻿# FlowHR Production Roadmap
 
 > **Last updated**: 2026-02-22
-> **Current version**: 0.1.91 (Payroll KR Preset Admin Preview UX)
+> **Current version**: 0.1.92 (Payroll KR Taxable Split Guard)
 > **Target**: Production-grade Korean HR SaaS (Shiftee/Flex superior)
 
 ---
@@ -259,10 +259,11 @@
 - WI-0220 급여 엔진 KR 정밀 계산 착수 baseline(`POST /payroll/runs/preview-with-deductions` `statutory_kr_baseline`에 `incomeTaxLookupTable`(간이세액표 룩업) + `insuranceRounding`(4대보험 항목별 단위/모드 라운딩) 추가 + payroll spec/rfc 갱신 + WI-0220 회귀 테스트 추가)
 - WI-0221 급여 엔진 KR 세액표 운영 데이터셋/검증 가드 baseline(`statutory_kr_baseline`에 `incomeTaxLookupPresetId` 프리셋 입력 추가 + `incomeTaxBrackets`/`incomeTaxLookupTable`/`incomeTaxLookupPresetId` 상호배타 가드 + 룩업 테이블 단조 세액 검증 + WI-0221 회귀 테스트 추가)
 - WI-0222 급여 관리자 프리뷰 KR 세액표 프리셋 선택/가이드 UX baseline(`src/components/payroll/PayrollKrPresetGuidePanel.tsx` 신규 + `/admin` 법정공제 프리뷰 preset selector/payload 연동 + locale-aware(`ko`/`en`) 가이드 문구 + WI-0222 회귀 테스트 추가)
+- WI-0223 급여 엔진 KR 과세/비과세 분리 검증 baseline(`statutory_kr_baseline`에 선택 입력 `taxableIncomeKrw` 추가 + `nonTaxableIncomeKrw <= grossPayKrw`, `taxable + nonTaxable = gross` 가드 + `incomeSplitKrw` breakdown + `/admin` 과세소득 입력 연동 + WI-0223 회귀 테스트 추가)
 
 ### 진행 중
 
-- 다음: 급여 KR 정밀 계산 고도화(비과세/과세 항목 분리 규칙) 착수 (WI-0223 예정)
+- 다음: 급여 KR 정밀 계산 고도화(과세 분리 항목 코드/카테고리 입력) 착수 (WI-0224 예정)
 
 ### 현재 아키텍처
 

--- a/scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts
+++ b/scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+
+type JsonPayload = Record<string, unknown>;
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+function actorHeaders(role: string, actorId: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const { memoryDataAccess, resetMemoryDataAccess } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
+  const attendanceApproveRoute = await import(
+    "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
+  );
+  const payrollPreviewWithDeductionsRoute = await import(
+    "../../src/app/api/payroll/runs/preview-with-deductions/route.ts"
+  );
+
+  const payrollApiSpec = readUtf8("specs", "payroll", "api.yaml");
+  const payrollContract = readUtf8("specs", "payroll", "contract.yaml");
+  const payrollTestCases = readUtf8("specs", "payroll", "test-cases.md");
+  const payrollRfc = readUtf8("specs", "payroll", "rfc.md");
+  const adminPage = readUtf8("src", "app", "admin", "page.tsx");
+  const splitGuideComponent = readUtf8(
+    "src",
+    "components",
+    "payroll",
+    "PayrollKrIncomeSplitGuideField.tsx"
+  );
+
+  assert.match(payrollApiSpec, /taxableIncomeKrw/);
+  assert.match(payrollContract, /taxableIncomeKrw/);
+  assert.match(payrollContract, /nonTaxableIncomeKrw must not exceed grossPayKrw/);
+  assert.match(payrollTestCases, /taxable\/non-taxable split rule/);
+  assert.match(payrollRfc, /WI-0223/);
+  assert.match(adminPage, /payrollTaxableIncomeKrw/);
+  assert.match(adminPage, /PayrollKrIncomeSplitGuideField/);
+  assert.match(
+    splitGuideComponent,
+    /taxable \+ non-taxable must equal grossPayKrw/i,
+    "split guide copy should explain sum-validation rule"
+  );
+
+  resetMemoryDataAccess();
+  runtimeEnv.FLOWHR_PAYROLL_DEDUCTIONS_V1 = "true";
+  runtimeEnv.FLOWHR_PAYROLL_KR_BASELINE_V1 = "true";
+
+  await memoryDataAccess.employees.create({ id: "EMP-3223" });
+
+  const createResponse = await attendanceCreateRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/attendance/records",
+      {
+        employeeId: "EMP-3223",
+        checkInAt: "2026-02-15T09:00:00+09:00",
+        checkOutAt: "2026-02-15T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      actorHeaders("employee", "EMP-3223")
+    )
+  );
+  assert.equal(createResponse.status, 201);
+  const createdBody = await readJson<{ record: { id: string } }>(createResponse);
+
+  const approveResponse = await attendanceApproveRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${createdBody.record.id}/approve`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-3223")
+    }),
+    { params: Promise.resolve({ recordId: createdBody.record.id }) } as RouteContext<{
+      recordId: string;
+    }>
+  );
+  assert.equal(approveResponse.status, 200);
+
+  const successResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3223",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          nonTaxableIncomeKrw: 10000,
+          taxableIncomeKrw: 86000,
+          incomeTaxLookupPresetId: "kr_simple_monthly_v2026_01"
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3223")
+    )
+  );
+  assert.equal(successResponse.status, 200, "valid split should be accepted");
+  const successBody = await readJson<{
+    summary: {
+      grossPayKrw: number;
+      deductionBreakdown: {
+        additional: {
+          taxableBaseKrw: number;
+          incomeSplitKrw: {
+            grossPayKrw: number;
+            taxableIncomeKrw: number;
+            nonTaxableIncomeKrw: number;
+            taxableSource: string;
+            validated: boolean;
+          };
+        };
+      };
+    };
+  }>(successResponse);
+
+  assert.equal(successBody.summary.grossPayKrw, 96000);
+  assert.equal(successBody.summary.deductionBreakdown.additional.taxableBaseKrw, 86000);
+  assert.deepEqual(successBody.summary.deductionBreakdown.additional.incomeSplitKrw, {
+    grossPayKrw: 96000,
+    taxableIncomeKrw: 86000,
+    nonTaxableIncomeKrw: 10000,
+    taxableSource: "explicit",
+    validated: true
+  });
+
+  const splitMismatchResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3223",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          nonTaxableIncomeKrw: 10000,
+          taxableIncomeKrw: 85000
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3223")
+    )
+  );
+  assert.equal(splitMismatchResponse.status, 400, "mismatched split sum should be rejected");
+  const splitMismatchBody = await readJson<{ error: string }>(splitMismatchResponse);
+  assert.match(
+    splitMismatchBody.error,
+    /taxableIncomeKrw plus statutory\.nonTaxableIncomeKrw must equal grossPayKrw/
+  );
+
+  const nonTaxableExceedResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3223",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          nonTaxableIncomeKrw: 120000
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3223")
+    )
+  );
+  assert.equal(nonTaxableExceedResponse.status, 400, "non-taxable above gross should be rejected");
+  const nonTaxableExceedBody = await readJson<{ error: string }>(nonTaxableExceedResponse);
+  assert.match(nonTaxableExceedBody.error, /nonTaxableIncomeKrw cannot exceed grossPayKrw/);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.26.0
+  version: 1.27.0
 paths:
   /payroll/runs:
     get:
@@ -60,7 +60,7 @@ paths:
   /payroll/runs/preview-with-deductions:
     post:
       summary: Create payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode)
-      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`. In statutory_kr_baseline mode, baseline KR withholding/social insurance components are derived from configurable rates with optional `incomeTaxBrackets`, `incomeTaxLookupTable`, or `incomeTaxLookupPresetId` (mutually exclusive), insurance cap fields (`nationalPensionCapKrw`, `healthInsuranceCapKrw`, `employmentInsuranceCapKrw`), additive tax-credit fields (`additionalTaxCreditKrw`, `dependentCount`, `dependentTaxCreditPerPersonKrw`), optional insurance rounding rules (`insuranceRounding`), and optional monthly-boundary guard (`requireMonthlyBoundary`).
+      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`. In statutory_kr_baseline mode, baseline KR withholding/social insurance components are derived from configurable rates with optional `incomeTaxBrackets`, `incomeTaxLookupTable`, or `incomeTaxLookupPresetId` (mutually exclusive), insurance cap fields (`nationalPensionCapKrw`, `healthInsuranceCapKrw`, `employmentInsuranceCapKrw`), additive tax-credit fields (`additionalTaxCreditKrw`, `dependentCount`, `dependentTaxCreditPerPersonKrw`), optional split input `taxableIncomeKrw`, optional insurance rounding rules (`insuranceRounding`), and optional monthly-boundary guard (`requireMonthlyBoundary`). When `taxableIncomeKrw` is provided, `taxableIncomeKrw + nonTaxableIncomeKrw` must equal `grossPayKrw`.
       responses:
         "200":
           description: Deduction preview generated

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,5 +1,5 @@
 owner: payroll-agent
-version: 1.26.0
+version: 1.27.0
 scope:
   in:
     - gross pay preview from approved attendance aggregates
@@ -14,6 +14,7 @@ scope:
     - KR statutory baseline additive tax-credit inputs and optional monthly-boundary validation (Asia/Seoul)
     - KR statutory baseline simple withholding lookup-table input and configurable insurance rounding rules
     - KR statutory baseline managed lookup-table preset dataset selection and validation guard
+    - KR statutory baseline taxable/non-taxable split validation rule (`taxableIncomeKrw` + `nonTaxableIncomeKrw`)
     - golden fixture regression coverage for statutory KR baseline deduction outputs
     - KR 4-insurance settlement preview with employee/employer contribution deltas and prior-withheld reconciliation
     - payroll withholding settlement and period-close preview/apply workflow for confirmed payroll runs
@@ -62,7 +63,7 @@ api:
       description: Generate payroll gross pay preview for a period.
     - method: POST
       path: /payroll/runs/preview-with-deductions
-      description: Generate payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode with optional progressive tax brackets, simple withholding lookup table or preset dataset ID, contribution caps, additive tax-credit fields, configurable insurance rounding, and optional monthly-boundary validation).
+      description: Generate payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode with optional progressive tax brackets, simple withholding lookup table or preset dataset ID, contribution caps, additive tax-credit fields, optional taxable/non-taxable split input validation, configurable insurance rounding, and optional monthly-boundary validation).
     - method: POST
       path: /payroll/runs/preview-insurance-settlement
       description: Generate 4-insurance settlement preview with employee/employer contribution breakdown, optional caps, and prior-withheld/prior-paid deltas.
@@ -200,7 +201,9 @@ invariants:
   - Net pay equals gross pay minus total deductions when phase2 fields are populated.
   - Profile-mode preview must persist profile ID and version trace.
   - Profile-mode preview rejects request when expected profile version mismatches current profile version.
-  - Statutory KR baseline mode must derive taxable base as max(grossPayKrw - nonTaxableIncomeKrw, 0).
+  - Statutory KR baseline mode must derive taxable base as grossPayKrw - nonTaxableIncomeKrw with explicit split guards.
+  - In statutory mode, nonTaxableIncomeKrw must not exceed grossPayKrw.
+  - In statutory mode, when taxableIncomeKrw is provided, taxableIncomeKrw + nonTaxableIncomeKrw must equal grossPayKrw.
   - Statutory KR baseline mode must keep deduction and net-pay outputs deterministic for same inputs/rates.
   - When incomeTaxBrackets is provided, statutory income tax must be calculated by bracket segments and include open-ended final bracket.
   - When incomeTaxLookupTable is provided, statutory income tax must be selected from first matching lookup row by taxable base, and the lookup table must include open-ended final row.
@@ -267,6 +270,7 @@ risk:
     - Stale deduction profile version can produce incorrect net pay.
     - Statutory baseline rates are approximation-only and require policy/legal review before production default.
     - Incorrect tax-credit ordering (after/before local income tax) can cause payout mismatch.
+    - Taxable/non-taxable split mismatch can cause taxable-base distortion and withholding errors.
     - Monthly boundary misconfiguration can produce off-cycle payroll previews.
     - Insurance settlement cap/rate misconfiguration can cause employee/employer contribution mismatch.
     - Closing period with unconfirmed runs can cause settlement mismatch.
@@ -283,6 +287,7 @@ test_plan:
     - statutory_kr_baseline progressive bracket and contribution-cap formulas
     - statutory_kr_baseline simple withholding lookup-table selection formula
     - statutory_kr_baseline lookup-table preset dataset resolution formula
+    - statutory_kr_baseline taxable/non-taxable split validation formula
     - statutory_kr_baseline insurance rounding unit/mode formulas
     - statutory_kr_baseline tax-credit and monthly-boundary formulas
     - insurance settlement contribution, cap, and delta formulas
@@ -319,6 +324,7 @@ test_plan:
     - statutory_kr_baseline validates progressive bracket ordering/open-ended final bracket
     - statutory_kr_baseline validates lookup-table ordering/open-ended final row, monotonic tax values, and mutual exclusivity with brackets/preset
     - statutory_kr_baseline resolves managed lookup-table preset ID and rejects unknown preset IDs
+    - statutory_kr_baseline validates taxable/non-taxable split guard (`nonTaxableIncomeKrw <= grossPayKrw`, explicit taxable split sum match)
     - statutory_kr_baseline validates optional monthly-boundary guard in Asia/Seoul
     - preview-insurance-settlement returns employee/employer contributions, capped bases, and prior-withheld/prior-paid deltas
     - preview-insurance-settlement rejects requests when payroll_kr_insurance_settlement_v1 is disabled
@@ -354,6 +360,7 @@ test_plan:
     - statutory_kr_baseline tax-credit/boundary deterministic replay via WI-0106 e2e
     - statutory_kr_baseline simple lookup-table + insurance rounding deterministic replay via WI-0220 e2e
     - statutory_kr_baseline lookup-table preset dataset and validation-guard deterministic replay via WI-0221 e2e
+    - statutory_kr_baseline taxable/non-taxable split deterministic replay via WI-0223 e2e
     - insurance settlement deterministic replay via WI-0184 e2e
     - close-period deterministic replay via WI-0185 e2e
     - payslip distribution/receipt deterministic replay via WI-0186 e2e
@@ -395,6 +402,7 @@ test_plan:
     - progressive bracket and insurance-cap component checks
     - lookup-table income-tax selection and insurance rounding-rule component checks
     - lookup-table preset dataset resolution and malformed lookup-table guard checks
+    - taxable/non-taxable split validation and explicit split-sum checks
     - tax-credit and monthly-boundary component checks
     - insurance settlement employee/employer component, cap, and delta deterministic checks
     - close-period withholding/social/net aggregation and settlement-delta checks
@@ -508,7 +516,7 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.26.0 additively extends `statutory_kr_baseline` preview inputs with optional managed lookup-table preset selection (`incomeTaxLookupPresetId`) and stricter lookup-table validation guards, while preserving all existing payroll preview/confirm/profile, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
+consumer_impact: "Contract v1.27.0 additively extends `statutory_kr_baseline` preview inputs with optional explicit taxable-income split input (`taxableIncomeKrw`) and taxable/non-taxable sum validation guard, while preserving all existing payroll preview/confirm/profile/statutory preset, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
 references:
   - specs/common/time-and-payroll-rules.md
   - specs/payroll/phase2-compatibility-matrix.md
@@ -524,6 +532,7 @@ references:
   - work-items/WI-0106-payroll-tax-credit-month-boundary.md
   - work-items/WI-0220-payroll-kr-precision-simple-tax-table-and-insurance-rounding.md
   - work-items/WI-0221-payroll-kr-tax-table-preset-and-validation-guard.md
+  - work-items/WI-0223-payroll-kr-taxable-non-taxable-split-rule.md
   - work-items/WI-0110-payroll-statutory-golden-regression.md
   - work-items/WI-0184-payroll-insurance-settlement-baseline.md
   - work-items/WI-0185-payroll-withholding-close-period-baseline.md

--- a/specs/payroll/rfc.md
+++ b/specs/payroll/rfc.md
@@ -1,8 +1,8 @@
-# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 + WI-0101 + WI-0105 + WI-0106 + WI-0110 + WI-0220 + WI-0221 Contract)
+# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 + WI-0101 + WI-0105 + WI-0106 + WI-0110 + WI-0220 + WI-0221 + WI-0223 Contract)
 
 ## Goal
 
-Provide payroll gross pay preview based on attendance aggregates, phase2 deduction/tax expansion, deduction profile auto-calculation mode, and KR statutory baseline deduction mode with progressive/lookup-table/preset/cap/tax-credit/month-boundary/insurance-rounding options.
+Provide payroll gross pay preview based on attendance aggregates, phase2 deduction/tax expansion, deduction profile auto-calculation mode, and KR statutory baseline deduction mode with progressive/lookup-table/preset/cap/tax-credit/month-boundary/insurance-rounding/taxable-split options.
 
 ## Key Decisions
 
@@ -18,6 +18,7 @@ Provide payroll gross pay preview based on attendance aggregates, phase2 deducti
 - WI-0110 extends golden fixture regression coverage to include statutory deterministic cases (GC-007/GC-008).
 - WI-0220 extends statutory baseline with optional simple withholding lookup-table and insurance rounding rules while preserving WI-0106 compatibility.
 - WI-0221 extends statutory baseline with optional managed lookup-table preset ID and stricter lookup-table validation guards while preserving WI-0220 compatibility.
+- WI-0223 extends statutory baseline with optional taxable-income split input (`taxableIncomeKrw`) and explicit taxable/non-taxable sum validation against gross pay.
 
 ## Non-Goals
 

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -60,6 +60,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 52. Reject statutory baseline preview when `incomeTaxLookupPresetId` is mixed with `incomeTaxBrackets` or `incomeTaxLookupTable`.
 53. Reject statutory baseline preview when lookup-table rows contain non-monotonic `taxKrw` values.
 54. Admin payroll preview exposes lookup-preset selector/guide and forwards selected `incomeTaxLookupPresetId` deterministically.
+55. Validate statutory baseline taxable/non-taxable split rule: reject when `nonTaxableIncomeKrw` exceeds gross pay or when provided `taxableIncomeKrw` does not satisfy `taxable + nonTaxable = gross`.
 
 ## Accuracy Cases
 
@@ -102,6 +103,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 37. Statutory baseline preset mode resolves to deterministic lookup rows for same preset ID and taxable base.
 38. Statutory baseline lookup-table validation guard rejects malformed non-monotonic tax rows deterministically.
 39. Admin payroll preview preset selector/guide wiring remains deterministic for same state/input replay.
+40. Statutory baseline taxable/non-taxable split validation and `incomeSplitKrw` breakdown output remain deterministic for same input replay.
 
 ## Regression Linkage
 
@@ -126,6 +128,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 - Lookup/Rounding Gate: `incomeTaxLookupTable` selection and `insuranceRounding` unit/mode checks must be deterministic and validated.
 - Preset/Validation Gate: `incomeTaxLookupPresetId` resolution and lookup-table monotonic-tax validation must be deterministic and validated.
 - Admin Preview Preset UX Gate: `/admin` payroll statutory baseline preset selector/guide and payload wiring must remain deterministic and locale-aware (`ko`/`en`).
+- Taxable Split Gate: `taxableIncomeKrw` + `nonTaxableIncomeKrw` split validation against `grossPayKrw` must be deterministic and enforced when explicit taxable split is provided.
 - Employee Payslip Gate: employee role can list only their own CONFIRMED payroll runs; other employees and PREVIEWED runs are blocked (403).
 - Insurance Settlement Gate: `POST /payroll/runs/preview-insurance-settlement` remains feature-flagged, permission-guarded, and deterministic under repeated replay.
 - Close-Period Gate: `POST /payroll/runs/close-period` remains feature-flagged, permission-guarded, and blocks apply when unconfirmed runs exist.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -25,6 +25,7 @@ import {
   type QueueSearchSortRow,
   type QueueSearchSortScope
 } from "@/components/admin-approval/approval-queue-types";
+import { PayrollKrIncomeSplitGuideField } from "@/components/payroll/PayrollKrIncomeSplitGuideField";
 import { PayrollKrPresetGuidePanel } from "@/components/payroll/PayrollKrPresetGuidePanel";
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useStickyStringState } from "@/lib/client/useStickyState";
@@ -299,6 +300,7 @@ export default function AdminDashboardPage() {
     "gross"
   );
   const [payrollNonTaxableIncomeKrw, setPayrollNonTaxableIncomeKrw] = useState("0");
+  const [payrollTaxableIncomeKrw, setPayrollTaxableIncomeKrw] = useState("");
   const [payrollOtherDeductionsKrw, setPayrollOtherDeductionsKrw] = useState("0");
   const [payrollAdditionalTaxCreditKrw, setPayrollAdditionalTaxCreditKrw] = useState("0");
   const [payrollDependentCount, setPayrollDependentCount] = useState("0");
@@ -1038,6 +1040,10 @@ export default function AdminDashboardPage() {
       deductionMode: "statutory_kr_baseline" as const,
       statutory: {
         nonTaxableIncomeKrw: Math.max(0, Number(payrollNonTaxableIncomeKrw) || 0),
+        taxableIncomeKrw:
+          payrollTaxableIncomeKrw.trim().length > 0
+            ? Math.max(0, Math.trunc(Number(payrollTaxableIncomeKrw) || 0))
+            : undefined,
         otherDeductionsKrw: Math.max(0, Number(payrollOtherDeductionsKrw) || 0),
         additionalTaxCreditKrw: Math.max(0, Math.trunc(Number(payrollAdditionalTaxCreditKrw) || 0)),
         dependentCount: Math.max(0, Math.trunc(Number(payrollDependentCount) || 0)),
@@ -1948,6 +1954,12 @@ export default function AdminDashboardPage() {
                     onChange={(event) => setPayrollNonTaxableIncomeKrw(event.target.value)}
                   />
                 </label>
+                <div className="full">
+                  <PayrollKrIncomeSplitGuideField
+                    taxableIncomeKrw={payrollTaxableIncomeKrw}
+                    onTaxableIncomeKrwChange={setPayrollTaxableIncomeKrw}
+                  />
+                </div>
                 <label>
                   기타 공제(KRW)
                   <input

--- a/src/components/payroll/PayrollKrIncomeSplitGuideField.tsx
+++ b/src/components/payroll/PayrollKrIncomeSplitGuideField.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { type FlowLocale } from "@/lib/i18n/locales";
+import { useI18n } from "@/lib/i18n/provider";
+
+type PayrollKrIncomeSplitGuideFieldProps = {
+  taxableIncomeKrw: string;
+  onTaxableIncomeKrwChange: (nextValue: string) => void;
+};
+
+type IncomeSplitGuideCopy = {
+  label: string;
+  guide: string;
+};
+
+const incomeSplitGuideCopy: Record<FlowLocale, IncomeSplitGuideCopy> = {
+  ko: {
+    label: "과세 소득(KRW, 선택)",
+    guide:
+      "입력 시 과세 + 비과세 = 총지급(grossPayKrw) 분리 규칙을 검증합니다. 비워두면 과세 소득은 자동 계산됩니다."
+  },
+  en: {
+    label: "Taxable income (KRW, optional)",
+    guide:
+      "When set, taxable + non-taxable must equal grossPayKrw. If omitted, taxable income is derived automatically."
+  }
+};
+
+export function PayrollKrIncomeSplitGuideField({
+  taxableIncomeKrw,
+  onTaxableIncomeKrwChange
+}: PayrollKrIncomeSplitGuideFieldProps) {
+  const { locale } = useI18n();
+  const copy = incomeSplitGuideCopy[locale];
+
+  return (
+    <div>
+      <label>
+        {copy.label}
+        <input
+          type="number"
+          min={0}
+          value={taxableIncomeKrw}
+          onChange={(event) => onTaxableIncomeKrwChange(event.target.value)}
+        />
+      </label>
+      <p className="small muted">{copy.guide}</p>
+    </div>
+  );
+}

--- a/src/features/payroll/schemas.ts
+++ b/src/features/payroll/schemas.ts
@@ -48,6 +48,7 @@ const statutoryInsuranceRoundingSchema = z.object({
 
 const statutoryKrBaselineSchema = z.object({
   nonTaxableIncomeKrw: nonNegativeInteger.default(0),
+  taxableIncomeKrw: nonNegativeInteger.optional(),
   incomeTaxBrackets: z.array(statutoryIncomeTaxBracketSchema).min(1).optional(),
   incomeTaxLookupTable: z.array(statutoryIncomeTaxLookupRowSchema).min(1).optional(),
   incomeTaxLookupPresetId: z.string().min(1).max(80).optional(),

--- a/src/features/payroll/service.ts
+++ b/src/features/payroll/service.ts
@@ -49,6 +49,7 @@ type StatutoryKrBaselineDeductions = {
   deductionMode: "statutory_kr_baseline";
   statutory?: {
     nonTaxableIncomeKrw: number;
+    taxableIncomeKrw?: number;
     incomeTaxBrackets?: Array<{
       upToKrw: number | null;
       rate: number;
@@ -1629,8 +1630,26 @@ export async function previewPayrollWithDeductions(
     const insuranceRoundingRules = normalizeInsuranceRoundingRules(
       input.statutory?.insuranceRounding
     );
-
-    const taxableBaseKrw = Math.max(computed.grossPayKrw - nonTaxableIncomeKrw, 0);
+    const taxableIncomeKrwInput =
+      input.statutory?.taxableIncomeKrw === undefined
+        ? null
+        : toKrwInteger(input.statutory.taxableIncomeKrw, "statutory.taxableIncomeKrw");
+    if (nonTaxableIncomeKrw > computed.grossPayKrw) {
+      throw new ServiceError(400, "statutory.nonTaxableIncomeKrw cannot exceed grossPayKrw");
+    }
+    const derivedTaxableIncomeKrw = computed.grossPayKrw - nonTaxableIncomeKrw;
+    if (
+      taxableIncomeKrwInput !== null &&
+      taxableIncomeKrwInput + nonTaxableIncomeKrw !== computed.grossPayKrw
+    ) {
+      throw new ServiceError(
+        400,
+        "statutory.taxableIncomeKrw plus statutory.nonTaxableIncomeKrw must equal grossPayKrw"
+      );
+    }
+    const taxableBaseKrw = taxableIncomeKrwInput ?? derivedTaxableIncomeKrw;
+    const taxableSource =
+      taxableIncomeKrwInput === null ? "derived_from_gross_minus_non_taxable" : "explicit";
     const taxMethod = incomeTaxLookupTable
       ? incomeTaxLookupPreset
         ? "simple_lookup_table_preset"
@@ -1717,6 +1736,13 @@ export async function previewPayrollWithDeductions(
       statutoryModel: "kr_baseline_v1",
       taxMethod,
       taxableBaseKrw,
+      incomeSplitKrw: {
+        grossPayKrw: computed.grossPayKrw,
+        nonTaxableIncomeKrw,
+        taxableIncomeKrw: taxableBaseKrw,
+        taxableSource,
+        validated: true
+      },
       incomeTaxBrackets: incomeTaxBrackets,
       incomeTaxLookupTable: incomeTaxLookupTable,
       incomeTaxLookupTableChecksum,

--- a/work-items/WI-0223-payroll-kr-taxable-non-taxable-split-rule.md
+++ b/work-items/WI-0223-payroll-kr-taxable-non-taxable-split-rule.md
@@ -1,0 +1,38 @@
+# WI-0223: Payroll KR Taxable/Non-Taxable Split Rule
+
+## Background
+
+현재 `statutory_kr_baseline` 모드는 `nonTaxableIncomeKrw`만 받아 과세표준을 계산합니다.
+운영 입력 관점에서는 과세/비과세 분리값 검증 규칙이 없어, 총지급 대비 분리 입력 정합성을
+명시적으로 보장하기 어렵습니다.
+
+## Scope
+
+### In Scope
+
+- `statutory_kr_baseline` 입력 확장:
+  - `taxableIncomeKrw` (선택)
+- 서비스 규칙 추가:
+  - `nonTaxableIncomeKrw`는 `grossPayKrw`를 초과할 수 없음
+  - `taxableIncomeKrw`가 제공된 경우 `taxableIncomeKrw + nonTaxableIncomeKrw = grossPayKrw` 강제
+  - 분리 검증 결과(`incomeSplitKrw`)를 deduction breakdown에 기록
+- 관리자 급여 프리뷰(`/admin`)에 과세 소득 선택 입력 추가
+- 스펙 문서 갱신:
+  - `specs/payroll/contract.yaml`
+  - `specs/payroll/api.yaml`
+  - `specs/payroll/test-cases.md`
+  - `specs/payroll/rfc.md`
+- WI-0223 e2e 테스트 추가
+
+### Out of Scope
+
+- 신규 세액표/세법 엔진 정책 추가
+- 연말정산 재설계
+- ops 스케줄러/워크플로 확장
+
+## Validation
+
+- `npm.cmd exec tsx scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0221-payroll-kr-tax-table-preset-and-validation-guard.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0222-payroll-admin-preset-selector-and-guide.test.ts`
+- `npm.cmd run build`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0223-payroll-kr-taxable-non-taxable-split-rule.md`
- Related Specs: `specs/payroll/contract.yaml`, `specs/payroll/api.yaml`, `specs/payroll/test-cases.md`, `specs/payroll/rfc.md`
- Related ADR: N/A (additive payroll statutory rule hardening within existing domain)
- Related Issue: #255

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
Reason: additive/non-breaking statutory payroll input validation and UI wiring only.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/app/admin/page.tsx`, `src/components/payroll/PayrollKrIncomeSplitGuideField.tsx`
- Backend-only reason:
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):

## Validation

- `npm.cmd exec tsx scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0222-payroll-admin-preset-selector-and-guide.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0221-payroll-kr-tax-table-preset-and-validation-guard.test.ts`
- `npm.cmd run build`
