### PR TITLE
feat: WI-0225 payroll KR income split item preset dataset

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 ﻿# FlowHR Production Roadmap
 
 > **Last updated**: 2026-02-22
-> **Current version**: 0.1.93 (Payroll KR Split Item Input)
+> **Current version**: 0.1.94 (Payroll KR Split Item Preset)
 > **Target**: Production-grade Korean HR SaaS (Shiftee/Flex superior)
 
 ---
@@ -261,10 +261,11 @@
 - WI-0222 급여 관리자 프리뷰 KR 세액표 프리셋 선택/가이드 UX baseline(`src/components/payroll/PayrollKrPresetGuidePanel.tsx` 신규 + `/admin` 법정공제 프리뷰 preset selector/payload 연동 + locale-aware(`ko`/`en`) 가이드 문구 + WI-0222 회귀 테스트 추가)
 - WI-0223 급여 엔진 KR 과세/비과세 분리 검증 baseline(`statutory_kr_baseline`에 선택 입력 `taxableIncomeKrw` 추가 + `nonTaxableIncomeKrw <= grossPayKrw`, `taxable + nonTaxable = gross` 가드 + `incomeSplitKrw` breakdown + `/admin` 과세소득 입력 연동 + WI-0223 회귀 테스트 추가)
 - WI-0224 급여 엔진 KR 과세/비과세 항목 코드/카테고리 입력 baseline(`taxableIncomeItems`/`nonTaxableIncomeItems` 입력 추가 + 항목 코드 중복/항목합계 정합성 가드 + `incomeSplitItems` breakdown + `/admin` 항목 코드/카테고리/금액 입력 연동 + WI-0224 회귀 테스트 추가)
+- WI-0225 급여 엔진 KR 과세/비과세 항목 프리셋 데이터셋 baseline(`incomeSplitItemPresetId` 입력 추가 + 지원 preset 검증 + preset/manual item 상호배타 가드 + preset 기반 항목 자동 구성 + `/admin` 항목 프리셋 selector/수동입력 비활성화 + WI-0225 회귀 테스트 추가)
 
 ### 진행 중
 
-- 다음: 급여 KR 정밀 계산 고도화(항목 코드 사전/템플릿 preset) 착수 (WI-0225 예정)
+- 다음: 급여 KR 정밀 계산 고도화(다중 항목 입력 테이블 UX) 착수 (WI-0226 예정)
 
 ### 현재 아키텍처
 

--- a/scripts/tests/e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test.ts
+++ b/scripts/tests/e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+
+type JsonPayload = Record<string, unknown>;
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+function actorHeaders(role: string, actorId: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const { memoryDataAccess, resetMemoryDataAccess } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
+  const attendanceApproveRoute = await import(
+    "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
+  );
+  const payrollPreviewWithDeductionsRoute = await import(
+    "../../src/app/api/payroll/runs/preview-with-deductions/route.ts"
+  );
+  const { listPayrollKrIncomeSplitItemPresets } = await import(
+    "../../src/features/payroll/kr-income-split-item-presets.ts"
+  );
+
+  const payrollApiSpec = readUtf8("specs", "payroll", "api.yaml");
+  const payrollContract = readUtf8("specs", "payroll", "contract.yaml");
+  const payrollTestCases = readUtf8("specs", "payroll", "test-cases.md");
+  const payrollRfc = readUtf8("specs", "payroll", "rfc.md");
+  const adminPage = readUtf8("src", "app", "admin", "page.tsx");
+  const presetFieldComponent = readUtf8(
+    "src",
+    "components",
+    "payroll",
+    "PayrollKrIncomeSplitItemPresetField.tsx"
+  );
+
+  assert.match(payrollApiSpec, /incomeSplitItemPresetId/);
+  assert.match(payrollContract, /income split item preset/i);
+  assert.match(payrollTestCases, /income split item preset/i);
+  assert.match(payrollRfc, /WI-0225/);
+  assert.match(adminPage, /payrollIncomeSplitItemPresetId/);
+  assert.match(adminPage, /PayrollKrIncomeSplitItemPresetField/);
+  assert.match(presetFieldComponent, /incomeSplitItemPresetId/i);
+
+  const splitItemPresets = listPayrollKrIncomeSplitItemPresets();
+  const defaultPreset = splitItemPresets.find((preset) => preset.id === "kr_income_split_template_v2026_01");
+  assert.ok(defaultPreset, "expected default WI-0225 split item preset to exist");
+
+  resetMemoryDataAccess();
+  runtimeEnv.FLOWHR_PAYROLL_DEDUCTIONS_V1 = "true";
+  runtimeEnv.FLOWHR_PAYROLL_KR_BASELINE_V1 = "true";
+
+  await memoryDataAccess.employees.create({ id: "EMP-3225" });
+
+  const createResponse = await attendanceCreateRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/attendance/records",
+      {
+        employeeId: "EMP-3225",
+        checkInAt: "2026-02-16T09:00:00+09:00",
+        checkOutAt: "2026-02-16T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      actorHeaders("employee", "EMP-3225")
+    )
+  );
+  assert.equal(createResponse.status, 201);
+  const createdBody = await readJson<{ record: { id: string } }>(createResponse);
+
+  const approveResponse = await attendanceApproveRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${createdBody.record.id}/approve`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-3225")
+    }),
+    { params: Promise.resolve({ recordId: createdBody.record.id }) } as RouteContext<{
+      recordId: string;
+    }>
+  );
+  assert.equal(approveResponse.status, 200);
+
+  const presetPreviewResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3225",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          nonTaxableIncomeKrw: 10000,
+          incomeTaxLookupPresetId: "kr_simple_monthly_v2026_01",
+          incomeSplitItemPresetId: "kr_income_split_template_v2026_01"
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3225")
+    )
+  );
+  assert.equal(presetPreviewResponse.status, 200, "preset-based split item input should be accepted");
+  const presetPreviewBody = await readJson<{
+    summary: {
+      deductionBreakdown: {
+        additional: {
+          incomeSplitKrw: { taxableIncomeKrw: number; nonTaxableIncomeKrw: number; taxableSource: string };
+          incomeSplitItems: {
+            taxableIncomeItemTotalKrw: number;
+            nonTaxableIncomeItemTotalKrw: number;
+            taxableIncomeItems: Array<{ code: string; category: string; amountKrw: number }>;
+            nonTaxableIncomeItems: Array<{ code: string; category: string; amountKrw: number }>;
+          };
+          incomeSplitItemPreset: { id: string };
+        };
+      };
+    };
+  }>(presetPreviewResponse);
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitItemPreset.id,
+    "kr_income_split_template_v2026_01"
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitKrw.taxableIncomeKrw,
+    86000
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitKrw.nonTaxableIncomeKrw,
+    10000
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitKrw.taxableSource,
+    "from_income_split_item_preset"
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitItems.taxableIncomeItems[0]?.code,
+    "TX_SALARY"
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitItems.nonTaxableIncomeItems[0]?.code,
+    "NT_MEAL"
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitItems.taxableIncomeItemTotalKrw,
+    86000
+  );
+  assert.equal(
+    presetPreviewBody.summary.deductionBreakdown.additional.incomeSplitItems.nonTaxableIncomeItemTotalKrw,
+    10000
+  );
+
+  const unknownPresetResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3225",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          nonTaxableIncomeKrw: 10000,
+          incomeSplitItemPresetId: "unknown-preset"
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3225")
+    )
+  );
+  assert.equal(unknownPresetResponse.status, 400, "unknown preset id should be rejected");
+  const unknownPresetBody = await readJson<{ error: string }>(unknownPresetResponse);
+  assert.match(unknownPresetBody.error, /incomeSplitItemPresetId is not supported/);
+
+  const conflictPresetResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3225",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          nonTaxableIncomeKrw: 10000,
+          incomeSplitItemPresetId: "kr_income_split_template_v2026_01",
+          taxableIncomeItems: [{ code: "TX_SALARY", category: "salary", amountKrw: 86000 }]
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3225")
+    )
+  );
+  assert.equal(
+    conflictPresetResponse.status,
+    400,
+    "preset and manual split item arrays should be mutually exclusive"
+  );
+  const conflictPresetBody = await readJson<{ error: string }>(conflictPresetResponse);
+  assert.equal(conflictPresetBody.error, "invalid payload");
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.28.0
+  version: 1.29.0
 paths:
   /payroll/runs:
     get:
@@ -60,7 +60,7 @@ paths:
   /payroll/runs/preview-with-deductions:
     post:
       summary: Create payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode)
-      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`. In statutory_kr_baseline mode, baseline KR withholding/social insurance components are derived from configurable rates with optional `incomeTaxBrackets`, `incomeTaxLookupTable`, or `incomeTaxLookupPresetId` (mutually exclusive), insurance cap fields (`nationalPensionCapKrw`, `healthInsuranceCapKrw`, `employmentInsuranceCapKrw`), additive tax-credit fields (`additionalTaxCreditKrw`, `dependentCount`, `dependentTaxCreditPerPersonKrw`), optional split input `taxableIncomeKrw`, optional income split item arrays (`taxableIncomeItems`, `nonTaxableIncomeItems` with `code`/`category`/`amountKrw`), optional insurance rounding rules (`insuranceRounding`), and optional monthly-boundary guard (`requireMonthlyBoundary`). Split guards require `nonTaxableIncomeKrw <= grossPayKrw` and explicit taxable split sum match.
+      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`. In statutory_kr_baseline mode, baseline KR withholding/social insurance components are derived from configurable rates with optional `incomeTaxBrackets`, `incomeTaxLookupTable`, or `incomeTaxLookupPresetId` (mutually exclusive), insurance cap fields (`nationalPensionCapKrw`, `healthInsuranceCapKrw`, `employmentInsuranceCapKrw`), additive tax-credit fields (`additionalTaxCreditKrw`, `dependentCount`, `dependentTaxCreditPerPersonKrw`), optional split input `taxableIncomeKrw`, optional income split item arrays (`taxableIncomeItems`, `nonTaxableIncomeItems` with `code`/`category`/`amountKrw`), optional income split item preset (`incomeSplitItemPresetId`), optional insurance rounding rules (`insuranceRounding`), and optional monthly-boundary guard (`requireMonthlyBoundary`). Split guards require `nonTaxableIncomeKrw <= grossPayKrw` and explicit taxable split sum match; `incomeSplitItemPresetId` cannot be combined with manual income split item arrays.
       responses:
         "200":
           description: Deduction preview generated

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,5 +1,5 @@
 owner: payroll-agent
-version: 1.28.0
+version: 1.29.0
 scope:
   in:
     - gross pay preview from approved attendance aggregates
@@ -16,6 +16,7 @@ scope:
     - KR statutory baseline managed lookup-table preset dataset selection and validation guard
     - KR statutory baseline taxable/non-taxable split validation rule (`taxableIncomeKrw` + `nonTaxableIncomeKrw`)
     - KR statutory baseline income split item code/category input (`taxableIncomeItems`, `nonTaxableIncomeItems`)
+    - KR statutory baseline income split item preset dataset selection (`incomeSplitItemPresetId`)
     - golden fixture regression coverage for statutory KR baseline deduction outputs
     - KR 4-insurance settlement preview with employee/employer contribution deltas and prior-withheld reconciliation
     - payroll withholding settlement and period-close preview/apply workflow for confirmed payroll runs
@@ -64,7 +65,7 @@ api:
       description: Generate payroll gross pay preview for a period.
     - method: POST
       path: /payroll/runs/preview-with-deductions
-      description: Generate payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode with optional progressive tax brackets, simple withholding lookup table or preset dataset ID, contribution caps, additive tax-credit fields, optional taxable/non-taxable split input validation, optional income split item code/category/amount input arrays, configurable insurance rounding, and optional monthly-boundary validation).
+      description: Generate payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode with optional progressive tax brackets, simple withholding lookup table or preset dataset ID, contribution caps, additive tax-credit fields, optional taxable/non-taxable split input validation, optional income split item code/category/amount input arrays, optional income split item preset dataset ID, configurable insurance rounding, and optional monthly-boundary validation).
     - method: POST
       path: /payroll/runs/preview-insurance-settlement
       description: Generate 4-insurance settlement preview with employee/employer contribution breakdown, optional caps, and prior-withheld/prior-paid deltas.
@@ -208,6 +209,8 @@ invariants:
   - In statutory mode, taxableIncomeItems/nonTaxableIncomeItems codes must be unique(case-insensitive) within each list.
   - In statutory mode, when taxableIncomeItems are provided with taxableIncomeKrw, item-total and taxableIncomeKrw must match.
   - In statutory mode, when nonTaxableIncomeItems are provided with nonTaxableIncomeKrw (>0), item-total and nonTaxableIncomeKrw must match.
+  - In statutory mode, when incomeSplitItemPresetId is provided, preset must resolve from known dataset.
+  - In statutory mode, incomeSplitItemPresetId must not be combined with taxableIncomeItems/nonTaxableIncomeItems.
   - Statutory KR baseline mode must keep deduction and net-pay outputs deterministic for same inputs/rates.
   - When incomeTaxBrackets is provided, statutory income tax must be calculated by bracket segments and include open-ended final bracket.
   - When incomeTaxLookupTable is provided, statutory income tax must be selected from first matching lookup row by taxable base, and the lookup table must include open-ended final row.
@@ -276,6 +279,7 @@ risk:
     - Incorrect tax-credit ordering (after/before local income tax) can cause payout mismatch.
     - Taxable/non-taxable split mismatch can cause taxable-base distortion and withholding errors.
     - Income split item code/category mismatch or duplicate codes can break taxable/non-taxable traceability.
+    - Income split item preset drift or invalid preset ID can break code/category trace consistency.
     - Monthly boundary misconfiguration can produce off-cycle payroll previews.
     - Insurance settlement cap/rate misconfiguration can cause employee/employer contribution mismatch.
     - Closing period with unconfirmed runs can cause settlement mismatch.
@@ -294,6 +298,7 @@ test_plan:
     - statutory_kr_baseline lookup-table preset dataset resolution formula
     - statutory_kr_baseline taxable/non-taxable split validation formula
     - statutory_kr_baseline income split item list/total validation formula
+    - statutory_kr_baseline income split item preset resolution and mutual-exclusion validation formula
     - statutory_kr_baseline insurance rounding unit/mode formulas
     - statutory_kr_baseline tax-credit and monthly-boundary formulas
     - insurance settlement contribution, cap, and delta formulas
@@ -332,6 +337,7 @@ test_plan:
     - statutory_kr_baseline resolves managed lookup-table preset ID and rejects unknown preset IDs
     - statutory_kr_baseline validates taxable/non-taxable split guard (`nonTaxableIncomeKrw <= grossPayKrw`, explicit taxable split sum match)
     - statutory_kr_baseline validates income split item list code uniqueness and item-total consistency with split totals
+    - statutory_kr_baseline resolves income split item preset ID and rejects unknown/mutually-exclusive manual item combinations
     - statutory_kr_baseline validates optional monthly-boundary guard in Asia/Seoul
     - preview-insurance-settlement returns employee/employer contributions, capped bases, and prior-withheld/prior-paid deltas
     - preview-insurance-settlement rejects requests when payroll_kr_insurance_settlement_v1 is disabled
@@ -369,6 +375,7 @@ test_plan:
     - statutory_kr_baseline lookup-table preset dataset and validation-guard deterministic replay via WI-0221 e2e
     - statutory_kr_baseline taxable/non-taxable split deterministic replay via WI-0223 e2e
     - statutory_kr_baseline income split item code/category input deterministic replay via WI-0224 e2e
+    - statutory_kr_baseline income split item preset dataset deterministic replay via WI-0225 e2e
     - insurance settlement deterministic replay via WI-0184 e2e
     - close-period deterministic replay via WI-0185 e2e
     - payslip distribution/receipt deterministic replay via WI-0186 e2e
@@ -412,6 +419,7 @@ test_plan:
     - lookup-table preset dataset resolution and malformed lookup-table guard checks
     - taxable/non-taxable split validation and explicit split-sum checks
     - income split item code uniqueness and item-total consistency checks
+    - income split item preset resolution and manual-item mutual-exclusion checks
     - tax-credit and monthly-boundary component checks
     - insurance settlement employee/employer component, cap, and delta deterministic checks
     - close-period withholding/social/net aggregation and settlement-delta checks
@@ -525,7 +533,7 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.28.0 additively extends `statutory_kr_baseline` preview inputs with optional income split item arrays (`taxableIncomeItems`, `nonTaxableIncomeItems`) for code/category/amount traceability and split-total consistency guards, while preserving all existing payroll preview/confirm/profile/statutory preset/split, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
+consumer_impact: "Contract v1.29.0 additively extends `statutory_kr_baseline` preview inputs with optional income split item preset (`incomeSplitItemPresetId`) for managed code/category template application and manual-item mutual-exclusion guard, while preserving all existing payroll preview/confirm/profile/statutory preset/split/item-array, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
 references:
   - specs/common/time-and-payroll-rules.md
   - specs/payroll/phase2-compatibility-matrix.md
@@ -543,6 +551,7 @@ references:
   - work-items/WI-0221-payroll-kr-tax-table-preset-and-validation-guard.md
   - work-items/WI-0223-payroll-kr-taxable-non-taxable-split-rule.md
   - work-items/WI-0224-payroll-kr-income-split-item-code-category-input.md
+  - work-items/WI-0225-payroll-kr-income-split-item-preset-dataset.md
   - work-items/WI-0110-payroll-statutory-golden-regression.md
   - work-items/WI-0184-payroll-insurance-settlement-baseline.md
   - work-items/WI-0185-payroll-withholding-close-period-baseline.md

--- a/specs/payroll/rfc.md
+++ b/specs/payroll/rfc.md
@@ -1,8 +1,8 @@
-# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 + WI-0101 + WI-0105 + WI-0106 + WI-0110 + WI-0220 + WI-0221 + WI-0223 + WI-0224 Contract)
+# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 + WI-0101 + WI-0105 + WI-0106 + WI-0110 + WI-0220 + WI-0221 + WI-0223 + WI-0224 + WI-0225 Contract)
 
 ## Goal
 
-Provide payroll gross pay preview based on attendance aggregates, phase2 deduction/tax expansion, deduction profile auto-calculation mode, and KR statutory baseline deduction mode with progressive/lookup-table/preset/cap/tax-credit/month-boundary/insurance-rounding/taxable-split/item-code options.
+Provide payroll gross pay preview based on attendance aggregates, phase2 deduction/tax expansion, deduction profile auto-calculation mode, and KR statutory baseline deduction mode with progressive/lookup-table/preset/cap/tax-credit/month-boundary/insurance-rounding/taxable-split/item-code/item-preset options.
 
 ## Key Decisions
 
@@ -20,6 +20,7 @@ Provide payroll gross pay preview based on attendance aggregates, phase2 deducti
 - WI-0221 extends statutory baseline with optional managed lookup-table preset ID and stricter lookup-table validation guards while preserving WI-0220 compatibility.
 - WI-0223 extends statutory baseline with optional taxable-income split input (`taxableIncomeKrw`) and explicit taxable/non-taxable sum validation against gross pay.
 - WI-0224 extends statutory baseline with optional taxable/non-taxable income item arrays (`code`/`category`/`amountKrw`) and item-total validation guard integration with split totals.
+- WI-0225 extends statutory baseline with optional income split item preset ID (`incomeSplitItemPresetId`) and server-managed code/category template application guard.
 
 ## Non-Goals
 

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -62,6 +62,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 54. Admin payroll preview exposes lookup-preset selector/guide and forwards selected `incomeTaxLookupPresetId` deterministically.
 55. Validate statutory baseline taxable/non-taxable split rule: reject when `nonTaxableIncomeKrw` exceeds gross pay or when provided `taxableIncomeKrw` does not satisfy `taxable + nonTaxable = gross`.
 56. Validate statutory baseline income split item input (`taxableIncomeItems`, `nonTaxableIncomeItems`) for duplicate-code guard and split-total consistency.
+57. Validate statutory baseline income split item preset input (`incomeSplitItemPresetId`) for supported-preset resolution and mutual exclusivity with manual item arrays.
 
 ## Accuracy Cases
 
@@ -106,6 +107,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 39. Admin payroll preview preset selector/guide wiring remains deterministic for same state/input replay.
 40. Statutory baseline taxable/non-taxable split validation and `incomeSplitKrw` breakdown output remain deterministic for same input replay.
 41. Statutory baseline income split item list/total validation and `incomeSplitItems` breakdown output remain deterministic for same input replay.
+42. Statutory baseline income split item preset resolution and preset-backed `incomeSplitItems` output remain deterministic for same input replay.
 
 ## Regression Linkage
 
@@ -132,6 +134,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 - Admin Preview Preset UX Gate: `/admin` payroll statutory baseline preset selector/guide and payload wiring must remain deterministic and locale-aware (`ko`/`en`).
 - Taxable Split Gate: `taxableIncomeKrw` + `nonTaxableIncomeKrw` split validation against `grossPayKrw` must be deterministic and enforced when explicit taxable split is provided.
 - Income Split Item Gate: `taxableIncomeItems`/`nonTaxableIncomeItems` code-uniqueness and item-total consistency with split totals must be deterministic and validated.
+- Income Split Item Preset Gate: `incomeSplitItemPresetId` resolution and manual-item mutual-exclusion guard must be deterministic and validated.
 - Employee Payslip Gate: employee role can list only their own CONFIRMED payroll runs; other employees and PREVIEWED runs are blocked (403).
 - Insurance Settlement Gate: `POST /payroll/runs/preview-insurance-settlement` remains feature-flagged, permission-guarded, and deterministic under repeated replay.
 - Close-Period Gate: `POST /payroll/runs/close-period` remains feature-flagged, permission-guarded, and blocks apply when unconfirmed runs exist.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/admin-approval/approval-queue-types";
 import { PayrollKrIncomeSplitGuideField } from "@/components/payroll/PayrollKrIncomeSplitGuideField";
 import { PayrollKrIncomeSplitItemFields } from "@/components/payroll/PayrollKrIncomeSplitItemFields";
+import { PayrollKrIncomeSplitItemPresetField } from "@/components/payroll/PayrollKrIncomeSplitItemPresetField";
 import { PayrollKrPresetGuidePanel } from "@/components/payroll/PayrollKrPresetGuidePanel";
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useStickyStringState } from "@/lib/client/useStickyState";
@@ -308,6 +309,7 @@ export default function AdminDashboardPage() {
   const [payrollNonTaxableItemCode, setPayrollNonTaxableItemCode] = useState("");
   const [payrollNonTaxableItemCategory, setPayrollNonTaxableItemCategory] = useState("");
   const [payrollNonTaxableItemAmountKrw, setPayrollNonTaxableItemAmountKrw] = useState("");
+  const [payrollIncomeSplitItemPresetId, setPayrollIncomeSplitItemPresetId] = useState("");
   const [payrollOtherDeductionsKrw, setPayrollOtherDeductionsKrw] = useState("0");
   const [payrollAdditionalTaxCreditKrw, setPayrollAdditionalTaxCreditKrw] = useState("0");
   const [payrollDependentCount, setPayrollDependentCount] = useState("0");
@@ -1056,6 +1058,7 @@ export default function AdminDashboardPage() {
       payrollNonTaxableItemCategory,
       payrollNonTaxableItemAmountKrw
     );
+    const incomeSplitItemPresetId = payrollIncomeSplitItemPresetId.trim();
 
     const basePayload = {
       periodStart: toIso(periodStart),
@@ -1078,8 +1081,15 @@ export default function AdminDashboardPage() {
           payrollTaxableIncomeKrw.trim().length > 0
             ? Math.max(0, Math.trunc(Number(payrollTaxableIncomeKrw) || 0))
             : undefined,
-        taxableIncomeItems: taxableIncomeItem ? [taxableIncomeItem] : undefined,
-        nonTaxableIncomeItems: nonTaxableIncomeItem ? [nonTaxableIncomeItem] : undefined,
+        taxableIncomeItems:
+          incomeSplitItemPresetId.length > 0 ? undefined : taxableIncomeItem ? [taxableIncomeItem] : undefined,
+        nonTaxableIncomeItems:
+          incomeSplitItemPresetId.length > 0
+            ? undefined
+            : nonTaxableIncomeItem
+              ? [nonTaxableIncomeItem]
+              : undefined,
+        incomeSplitItemPresetId: incomeSplitItemPresetId || undefined,
         otherDeductionsKrw: Math.max(0, Number(payrollOtherDeductionsKrw) || 0),
         additionalTaxCreditKrw: Math.max(0, Math.trunc(Number(payrollAdditionalTaxCreditKrw) || 0)),
         dependentCount: Math.max(0, Math.trunc(Number(payrollDependentCount) || 0)),
@@ -1997,6 +2007,12 @@ export default function AdminDashboardPage() {
                   />
                 </div>
                 <div className="full">
+                  <PayrollKrIncomeSplitItemPresetField
+                    selectedPresetId={payrollIncomeSplitItemPresetId}
+                    onPresetChange={setPayrollIncomeSplitItemPresetId}
+                  />
+                </div>
+                <div className="full">
                   <PayrollKrIncomeSplitItemFields
                     taxableCode={payrollTaxableItemCode}
                     onTaxableCodeChange={setPayrollTaxableItemCode}
@@ -2010,6 +2026,7 @@ export default function AdminDashboardPage() {
                     onNonTaxableCategoryChange={setPayrollNonTaxableItemCategory}
                     nonTaxableAmountKrw={payrollNonTaxableItemAmountKrw}
                     onNonTaxableAmountKrwChange={setPayrollNonTaxableItemAmountKrw}
+                    disabled={payrollIncomeSplitItemPresetId.trim().length > 0}
                   />
                 </div>
                 <label>

--- a/src/components/payroll/PayrollKrIncomeSplitItemFields.tsx
+++ b/src/components/payroll/PayrollKrIncomeSplitItemFields.tsx
@@ -16,6 +16,7 @@ type PayrollKrIncomeSplitItemFieldsProps = {
   onNonTaxableCategoryChange: (nextValue: string) => void;
   nonTaxableAmountKrw: string;
   onNonTaxableAmountKrwChange: (nextValue: string) => void;
+  disabled?: boolean;
 };
 
 type IncomeSplitItemCopy = {
@@ -25,6 +26,7 @@ type IncomeSplitItemCopy = {
   categoryLabel: string;
   amountLabel: string;
   guide: string;
+  disabledGuide: string;
 };
 
 const incomeSplitItemCopy: Record<FlowLocale, IncomeSplitItemCopy> = {
@@ -35,7 +37,8 @@ const incomeSplitItemCopy: Record<FlowLocale, IncomeSplitItemCopy> = {
     categoryLabel: "카테고리",
     amountLabel: "금액(KRW)",
     guide:
-      "코드/카테고리/금액 3개를 모두 입력하면 항목 배열에 포함됩니다. 항목 합계는 분리 총액 규칙과 함께 검증됩니다."
+      "코드/카테고리/금액 3개를 모두 입력하면 항목 배열에 포함됩니다. 항목 합계는 분리 총액 규칙과 함께 검증됩니다.",
+    disabledGuide: "항목 프리셋 사용 중에는 수동 항목 입력이 비활성화됩니다."
   },
   en: {
     taxableTitle: "Taxable item (optional)",
@@ -44,7 +47,8 @@ const incomeSplitItemCopy: Record<FlowLocale, IncomeSplitItemCopy> = {
     categoryLabel: "Category",
     amountLabel: "Amount (KRW)",
     guide:
-      "An item is included only when code/category/amount are all provided. Item totals are validated with split totals."
+      "An item is included only when code/category/amount are all provided. Item totals are validated with split totals.",
+    disabledGuide: "Manual item inputs are disabled while an item preset is selected."
   }
 };
 
@@ -60,7 +64,8 @@ export function PayrollKrIncomeSplitItemFields({
   nonTaxableCategory,
   onNonTaxableCategoryChange,
   nonTaxableAmountKrw,
-  onNonTaxableAmountKrwChange
+  onNonTaxableAmountKrwChange,
+  disabled = false
 }: PayrollKrIncomeSplitItemFieldsProps) {
   const { locale } = useI18n();
   const copy = incomeSplitItemCopy[locale];
@@ -68,16 +73,22 @@ export function PayrollKrIncomeSplitItemFields({
   return (
     <div>
       <p className="small muted">{copy.guide}</p>
+      {disabled ? <p className="small muted">{copy.disabledGuide}</p> : null}
       <div className="input-grid compact">
         <label>
           {copy.taxableTitle} {copy.codeLabel}
-          <input value={taxableCode} onChange={(event) => onTaxableCodeChange(event.target.value)} />
+          <input
+            value={taxableCode}
+            onChange={(event) => onTaxableCodeChange(event.target.value)}
+            disabled={disabled}
+          />
         </label>
         <label>
           {copy.taxableTitle} {copy.categoryLabel}
           <input
             value={taxableCategory}
             onChange={(event) => onTaxableCategoryChange(event.target.value)}
+            disabled={disabled}
           />
         </label>
         <label>
@@ -87,6 +98,7 @@ export function PayrollKrIncomeSplitItemFields({
             min={0}
             value={taxableAmountKrw}
             onChange={(event) => onTaxableAmountKrwChange(event.target.value)}
+            disabled={disabled}
           />
         </label>
         <label>
@@ -94,6 +106,7 @@ export function PayrollKrIncomeSplitItemFields({
           <input
             value={nonTaxableCode}
             onChange={(event) => onNonTaxableCodeChange(event.target.value)}
+            disabled={disabled}
           />
         </label>
         <label>
@@ -101,6 +114,7 @@ export function PayrollKrIncomeSplitItemFields({
           <input
             value={nonTaxableCategory}
             onChange={(event) => onNonTaxableCategoryChange(event.target.value)}
+            disabled={disabled}
           />
         </label>
         <label>
@@ -110,6 +124,7 @@ export function PayrollKrIncomeSplitItemFields({
             min={0}
             value={nonTaxableAmountKrw}
             onChange={(event) => onNonTaxableAmountKrwChange(event.target.value)}
+            disabled={disabled}
           />
         </label>
       </div>

--- a/src/components/payroll/PayrollKrIncomeSplitItemPresetField.tsx
+++ b/src/components/payroll/PayrollKrIncomeSplitItemPresetField.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { listPayrollKrIncomeSplitItemPresets } from "@/features/payroll/kr-income-split-item-presets";
+import { type FlowLocale } from "@/lib/i18n/locales";
+import { useI18n } from "@/lib/i18n/provider";
+
+type PayrollKrIncomeSplitItemPresetFieldProps = {
+  selectedPresetId: string;
+  onPresetChange: (nextPresetId: string) => void;
+};
+
+type IncomeSplitItemPresetCopy = {
+  label: string;
+  noneOption: string;
+  payloadGuide: string;
+  conflictGuide: string;
+  selectedPrefix: string;
+  sourceLabel: string;
+  taxableTemplateLabel: string;
+  nonTaxableTemplateLabel: string;
+  notSelected: string;
+};
+
+const incomeSplitItemPresetCopy: Record<FlowLocale, IncomeSplitItemPresetCopy> = {
+  ko: {
+    label: "항목 프리셋",
+    noneOption: "사용 안 함(수동 항목 입력)",
+    payloadGuide:
+      "프리셋을 선택하면 incomeSplitItemPresetId가 전달되고, 서버가 과세/비과세 항목 코드/카테고리를 자동 구성합니다.",
+    conflictGuide:
+      "가드 규칙: incomeSplitItemPresetId와 taxableIncomeItems/nonTaxableIncomeItems는 동시에 사용할 수 없습니다.",
+    selectedPrefix: "선택 프리셋",
+    sourceLabel: "출처",
+    taxableTemplateLabel: "과세 템플릿",
+    nonTaxableTemplateLabel: "비과세 템플릿",
+    notSelected: "현재 항목 프리셋을 사용하지 않습니다."
+  },
+  en: {
+    label: "Income split item preset",
+    noneOption: "Do not use preset (manual item input)",
+    payloadGuide:
+      "When selected, incomeSplitItemPresetId is sent and server-side taxable/non-taxable item code/category templates are applied.",
+    conflictGuide:
+      "Guard rule: incomeSplitItemPresetId cannot be combined with taxableIncomeItems/nonTaxableIncomeItems.",
+    selectedPrefix: "Selected preset",
+    sourceLabel: "source",
+    taxableTemplateLabel: "Taxable template",
+    nonTaxableTemplateLabel: "Non-taxable template",
+    notSelected: "No income split item preset is selected."
+  }
+};
+
+const incomeSplitItemPresets = listPayrollKrIncomeSplitItemPresets();
+
+export function PayrollKrIncomeSplitItemPresetField({
+  selectedPresetId,
+  onPresetChange
+}: PayrollKrIncomeSplitItemPresetFieldProps) {
+  const { locale } = useI18n();
+  const copy = incomeSplitItemPresetCopy[locale];
+  const selectedPreset =
+    incomeSplitItemPresets.find((preset) => preset.id === selectedPresetId.trim()) ?? null;
+
+  return (
+    <div>
+      <label>
+        {copy.label}
+        <select value={selectedPresetId} onChange={(event) => onPresetChange(event.target.value)}>
+          <option value="">{copy.noneOption}</option>
+          {incomeSplitItemPresets.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.label} / {preset.effectiveFrom}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="small">{copy.payloadGuide}</p>
+      <p className="small muted">{copy.conflictGuide}</p>
+      {selectedPreset ? (
+        <p className="small">
+          {copy.selectedPrefix}: <strong>{selectedPreset.id}</strong> / {copy.sourceLabel}:{" "}
+          {selectedPreset.source} / {copy.taxableTemplateLabel}: {selectedPreset.taxableTemplate.code}
+          ({selectedPreset.taxableTemplate.category}) / {copy.nonTaxableTemplateLabel}:{" "}
+          {selectedPreset.nonTaxableTemplate.code}({selectedPreset.nonTaxableTemplate.category})
+        </p>
+      ) : (
+        <p className="small muted">{copy.notSelected}</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/payroll/kr-income-split-item-presets.ts
+++ b/src/features/payroll/kr-income-split-item-presets.ts
@@ -1,0 +1,38 @@
+export type PayrollKrIncomeSplitItemTemplate = {
+  code: string;
+  category: string;
+};
+
+export type PayrollKrIncomeSplitItemPreset = {
+  id: string;
+  label: string;
+  effectiveFrom: string;
+  source: string;
+  taxableTemplate: PayrollKrIncomeSplitItemTemplate;
+  nonTaxableTemplate: PayrollKrIncomeSplitItemTemplate;
+};
+
+const payrollKrIncomeSplitItemPresets: PayrollKrIncomeSplitItemPreset[] = [
+  {
+    id: "kr_income_split_template_v2026_01",
+    label: "KR Income Split Template (2026-01)",
+    effectiveFrom: "2026-01-01",
+    source: "flowhr-curated-operations-dataset",
+    taxableTemplate: {
+      code: "TX_SALARY",
+      category: "salary"
+    },
+    nonTaxableTemplate: {
+      code: "NT_MEAL",
+      category: "allowance"
+    }
+  }
+];
+
+export function getPayrollKrIncomeSplitItemPreset(presetId: string) {
+  return payrollKrIncomeSplitItemPresets.find((preset) => preset.id === presetId) ?? null;
+}
+
+export function listPayrollKrIncomeSplitItemPresets() {
+  return payrollKrIncomeSplitItemPresets.slice();
+}

--- a/src/features/payroll/schemas.ts
+++ b/src/features/payroll/schemas.ts
@@ -57,6 +57,7 @@ const statutoryKrBaselineSchema = z.object({
   taxableIncomeKrw: nonNegativeInteger.optional(),
   taxableIncomeItems: z.array(statutoryIncomeSplitItemSchema).max(20).optional(),
   nonTaxableIncomeItems: z.array(statutoryIncomeSplitItemSchema).max(20).optional(),
+  incomeSplitItemPresetId: z.string().min(1).max(80).optional(),
   incomeTaxBrackets: z.array(statutoryIncomeTaxBracketSchema).min(1).optional(),
   incomeTaxLookupTable: z.array(statutoryIncomeTaxLookupRowSchema).min(1).optional(),
   incomeTaxLookupPresetId: z.string().min(1).max(80).optional(),
@@ -152,6 +153,7 @@ export const previewPayrollWithDeductionsSchema = previewPayrollSchema
       const lookupPresetId = value.statutory?.incomeTaxLookupPresetId;
       const taxableIncomeItems = value.statutory?.taxableIncomeItems;
       const nonTaxableIncomeItems = value.statutory?.nonTaxableIncomeItems;
+      const incomeSplitItemPresetId = value.statutory?.incomeSplitItemPresetId;
       if (brackets && lookupTable) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -171,6 +173,14 @@ export const previewPayrollWithDeductionsSchema = previewPayrollSchema
           code: z.ZodIssueCode.custom,
           path: ["statutory"],
           message: "incomeTaxLookupTable and incomeTaxLookupPresetId are mutually exclusive"
+        });
+      }
+      if (incomeSplitItemPresetId && (taxableIncomeItems || nonTaxableIncomeItems)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["statutory"],
+          message:
+            "incomeSplitItemPresetId and taxableIncomeItems/nonTaxableIncomeItems are mutually exclusive"
         });
       }
       if (brackets) {

--- a/src/features/payroll/service.ts
+++ b/src/features/payroll/service.ts
@@ -20,6 +20,7 @@ import type { DomainEventPublisher } from "@/features/shared/domain-event-publis
 import { getRuntimeDomainEventPublisher } from "@/features/shared/runtime-domain-event-publisher";
 import { ServiceError } from "@/features/shared/service-error";
 import { getPayrollKrIncomeTaxLookupPreset } from "@/features/payroll/kr-income-tax-lookup-presets";
+import { getPayrollKrIncomeSplitItemPreset } from "@/features/payroll/kr-income-split-item-presets";
 
 type PreviewPayrollInput = {
   periodStart: Date;
@@ -60,6 +61,7 @@ type StatutoryKrBaselineDeductions = {
       category: string;
       amountKrw: number;
     }>;
+    incomeSplitItemPresetId?: string;
     incomeTaxBrackets?: Array<{
       upToKrw: number | null;
       rate: number;
@@ -1681,22 +1683,65 @@ export async function previewPayrollWithDeductions(
     const insuranceRoundingRules = normalizeInsuranceRoundingRules(
       input.statutory?.insuranceRounding
     );
-    const taxableIncomeItems = normalizeStatutoryIncomeSplitItems(
+    const requestedTaxableIncomeItems = normalizeStatutoryIncomeSplitItems(
       input.statutory?.taxableIncomeItems,
       "statutory.taxableIncomeItems"
     );
-    const nonTaxableIncomeItems = normalizeStatutoryIncomeSplitItems(
+    const requestedNonTaxableIncomeItems = normalizeStatutoryIncomeSplitItems(
       input.statutory?.nonTaxableIncomeItems,
       "statutory.nonTaxableIncomeItems"
     );
-    const taxableIncomeItemTotalKrw =
-      taxableIncomeItems?.reduce((sum, item) => sum + item.amountKrw, 0) ?? 0;
-    const nonTaxableIncomeItemTotalKrw =
-      nonTaxableIncomeItems?.reduce((sum, item) => sum + item.amountKrw, 0) ?? 0;
+    const incomeSplitItemPresetId = input.statutory?.incomeSplitItemPresetId?.trim() || null;
+    const incomeSplitItemPreset = incomeSplitItemPresetId
+      ? getPayrollKrIncomeSplitItemPreset(incomeSplitItemPresetId)
+      : null;
+    if (incomeSplitItemPresetId && !incomeSplitItemPreset) {
+      throw new ServiceError(
+        400,
+        `statutory.incomeSplitItemPresetId is not supported: ${incomeSplitItemPresetId}`
+      );
+    }
+    if (incomeSplitItemPreset && (requestedTaxableIncomeItems || requestedNonTaxableIncomeItems)) {
+      throw new ServiceError(
+        400,
+        "statutory.incomeSplitItemPresetId and statutory.taxableIncomeItems/nonTaxableIncomeItems are mutually exclusive"
+      );
+    }
     const taxableIncomeKrwInput =
       input.statutory?.taxableIncomeKrw === undefined
         ? null
         : toKrwInteger(input.statutory.taxableIncomeKrw, "statutory.taxableIncomeKrw");
+    if (nonTaxableIncomeKrw > computed.grossPayKrw) {
+      throw new ServiceError(400, "statutory.nonTaxableIncomeKrw cannot exceed grossPayKrw");
+    }
+    const derivedTaxableIncomeKrwFromNumericNonTaxable = computed.grossPayKrw - nonTaxableIncomeKrw;
+    const splitTaxableIncomeKrw =
+      taxableIncomeKrwInput ?? derivedTaxableIncomeKrwFromNumericNonTaxable;
+
+    const taxableIncomeItems = incomeSplitItemPreset
+      ? [
+          {
+            code: incomeSplitItemPreset.taxableTemplate.code,
+            category: incomeSplitItemPreset.taxableTemplate.category,
+            amountKrw: splitTaxableIncomeKrw
+          }
+        ]
+      : requestedTaxableIncomeItems;
+    const nonTaxableIncomeItems = incomeSplitItemPreset
+      ? nonTaxableIncomeKrw > 0
+        ? [
+            {
+              code: incomeSplitItemPreset.nonTaxableTemplate.code,
+              category: incomeSplitItemPreset.nonTaxableTemplate.category,
+              amountKrw: nonTaxableIncomeKrw
+            }
+          ]
+        : []
+      : requestedNonTaxableIncomeItems;
+    const taxableIncomeItemTotalKrw =
+      taxableIncomeItems?.reduce((sum, item) => sum + item.amountKrw, 0) ?? 0;
+    const nonTaxableIncomeItemTotalKrw =
+      nonTaxableIncomeItems?.reduce((sum, item) => sum + item.amountKrw, 0) ?? 0;
 
     if (
       taxableIncomeItems &&
@@ -1724,10 +1769,10 @@ export async function previewPayrollWithDeductions(
       nonTaxableIncomeItems?.length ? nonTaxableIncomeItemTotalKrw : nonTaxableIncomeKrw;
     const effectiveTaxableIncomeKrwInput =
       taxableIncomeKrwInput ?? (taxableIncomeItems?.length ? taxableIncomeItemTotalKrw : null);
-
     if (effectiveNonTaxableIncomeKrw > computed.grossPayKrw) {
       throw new ServiceError(400, "statutory.nonTaxableIncomeKrw cannot exceed grossPayKrw");
     }
+
     const derivedTaxableIncomeKrw = computed.grossPayKrw - effectiveNonTaxableIncomeKrw;
     if (
       effectiveTaxableIncomeKrwInput !== null &&
@@ -1741,11 +1786,15 @@ export async function previewPayrollWithDeductions(
     const taxableBaseKrw = effectiveTaxableIncomeKrwInput ?? derivedTaxableIncomeKrw;
     const taxableSource = taxableIncomeKrwInput !== null
       ? "explicit"
-      : taxableIncomeItems?.length
+      : incomeSplitItemPreset
+        ? "from_income_split_item_preset"
+        : taxableIncomeItems?.length
         ? "from_taxable_income_items"
         : "derived_from_gross_minus_non_taxable";
     const nonTaxableSource = nonTaxableIncomeItems?.length
-      ? "from_non_taxable_income_items"
+      ? incomeSplitItemPreset
+        ? "from_income_split_item_preset"
+        : "from_non_taxable_income_items"
       : "explicit_or_default";
     const taxMethod = incomeTaxLookupTable
       ? incomeTaxLookupPreset
@@ -1847,6 +1896,16 @@ export async function previewPayrollWithDeductions(
         taxableIncomeItemTotalKrw,
         nonTaxableIncomeItemTotalKrw
       },
+      incomeSplitItemPreset: incomeSplitItemPreset
+        ? {
+            id: incomeSplitItemPreset.id,
+            label: incomeSplitItemPreset.label,
+            effectiveFrom: incomeSplitItemPreset.effectiveFrom,
+            source: incomeSplitItemPreset.source,
+            taxableTemplate: incomeSplitItemPreset.taxableTemplate,
+            nonTaxableTemplate: incomeSplitItemPreset.nonTaxableTemplate
+          }
+        : null,
       incomeTaxBrackets: incomeTaxBrackets,
       incomeTaxLookupTable: incomeTaxLookupTable,
       incomeTaxLookupTableChecksum,

--- a/work-items/WI-0225-payroll-kr-income-split-item-preset-dataset.md
+++ b/work-items/WI-0225-payroll-kr-income-split-item-preset-dataset.md
@@ -1,0 +1,40 @@
+# WI-0225: Payroll KR Income Split Item Preset Dataset
+
+## Background
+
+WI-0224에서 과세/비과세 항목 입력(`taxableIncomeItems`, `nonTaxableIncomeItems`)을 추가했지만,
+초기 운영에서는 코드/카테고리 값을 매번 수동 입력해야 해서 입력 일관성이 떨어집니다.
+
+## Scope
+
+### In Scope
+
+- `statutory_kr_baseline` 입력 확장:
+  - `incomeSplitItemPresetId` (선택)
+- 서버 프리셋 데이터셋 추가:
+  - preset ID 기준 과세/비과세 항목 코드/카테고리 템플릿 제공
+  - 분리 총액(`taxableIncomeKrw`, `nonTaxableIncomeKrw`) 기준으로 항목 금액 자동 구성
+- 검증 가드:
+  - 지원하지 않는 `incomeSplitItemPresetId` 거부
+  - `incomeSplitItemPresetId`와 수동 항목 배열(`taxableIncomeItems`, `nonTaxableIncomeItems`) 동시 사용 금지
+- 관리자 급여 프리뷰(`/admin`) UI:
+  - 항목 프리셋 selector 추가
+  - 프리셋 선택 시 수동 항목 입력 비활성화
+- 스펙 문서/테스트 갱신:
+  - `specs/payroll/contract.yaml`, `api.yaml`, `rfc.md`, `test-cases.md`
+  - WI-0225 e2e 회귀 테스트
+
+### Out of Scope
+
+- 프리셋 CRUD(관리자 생성/수정/삭제) 화면
+- 외부 세법 코드 사전 자동 동기화
+- 다중 항목 템플릿(행 단위 복수 자동 생성) 고도화
+
+## Validation
+
+- `npm.cmd exec tsx scripts/tests/e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0224-payroll-kr-income-split-item-code-category-input.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts`
+- `npm.cmd run lint`
+- `npm.cmd run typecheck`
+- `npm.cmd run build`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0225-payroll-kr-income-split-item-preset-dataset.md`
- Related Specs: `specs/payroll/contract.yaml`, `specs/payroll/api.yaml`, `specs/payroll/test-cases.md`, `specs/payroll/rfc.md`
- Related ADR: N/A

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- ADR reason: additive/non-breaking payroll-domain preset dataset enhancement with no cross-domain or security-impacting change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks
- Unit tests: `npm.cmd test`
- Integration tests: `npm.cmd run test:integration`
- Regression checks: `npm.cmd exec tsx scripts/tests/e2e-wi0222-payroll-admin-preset-selector-and-guide.test.ts`, `npm.cmd exec tsx scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts`, `npm.cmd exec tsx scripts/tests/e2e-wi0224-payroll-kr-income-split-item-code-category-input.test.ts`, `npm.cmd exec tsx scripts/tests/e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test.ts`, `npm.cmd run build`
- Lint/typecheck: `npm.cmd run lint`, `npm.cmd run typecheck`
- Migration smoke: `npx prisma validate`, `npx prisma migrate diff --from-empty --to-schema-datamodel prisma/schema.prisma --script`
- Contract governance checks: `python scripts/ci/check_contracts.py`, `python scripts/ci/check_traceability.py`

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/app/admin/page.tsx`, `src/components/payroll/PayrollKrIncomeSplitItemFields.tsx`, `src/components/payroll/PayrollKrIncomeSplitItemPresetField.tsx`
- Backend-only reason: N/A
- Next UI WI: N/A

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):

Closes #259
