### PR TITLE
feat: WI-0227 payroll KR item code autocomplete UX

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 ﻿# FlowHR Production Roadmap
 
 > **Last updated**: 2026-02-22
-> **Current version**: 0.1.95 (Payroll KR Multi-Item Table UX)
+> **Current version**: 0.1.96 (Payroll KR Item Code Autocomplete UX)
 > **Target**: Production-grade Korean HR SaaS (Shiftee/Flex superior)
 
 ---
@@ -263,10 +263,11 @@
 - WI-0224 급여 엔진 KR 과세/비과세 항목 코드/카테고리 입력 baseline(`taxableIncomeItems`/`nonTaxableIncomeItems` 입력 추가 + 항목 코드 중복/항목합계 정합성 가드 + `incomeSplitItems` breakdown + `/admin` 항목 코드/카테고리/금액 입력 연동 + WI-0224 회귀 테스트 추가)
 - WI-0225 급여 엔진 KR 과세/비과세 항목 프리셋 데이터셋 baseline(`incomeSplitItemPresetId` 입력 추가 + 지원 preset 검증 + preset/manual item 상호배타 가드 + preset 기반 항목 자동 구성 + `/admin` 항목 프리셋 selector/수동입력 비활성화 + WI-0225 회귀 테스트 추가)
 - WI-0226 급여 관리자 KR 과세/비과세 다중 항목 입력 테이블 UX baseline(`/admin` 법정공제 프리뷰에서 과세/비과세 항목 다중 행(add/remove) 입력 지원 + 빈 행 제외 payload 변환 + preset 선택 시 수동 테이블 비활성화 + WI-0226 회귀 테스트 추가)
+- WI-0227 급여 관리자 KR 항목 코드 사전 autocomplete UX baseline(`kr-income-split-item-code-dictionary` 추가 + `/admin` 다중 항목 테이블 코드 입력에 datalist 기반 autocomplete + 코드 선택 시 카테고리 자동 채움 + WI-0227 회귀 테스트 추가)
 
 ### 진행 중
 
-- 다음: 급여 KR 정밀 계산 고도화(항목 코드 사전 선택 autocomplete UX) 착수 (WI-0227 예정)
+- 다음: 급여 KR 정밀 계산 고도화(항목 코드 사전 서버 검증 가드) 착수 (WI-0228 예정)
 
 ### 현재 아키텍처
 

--- a/scripts/tests/e2e-wi0227-payroll-kr-item-code-autocomplete-ux.test.ts
+++ b/scripts/tests/e2e-wi0227-payroll-kr-item-code-autocomplete-ux.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+
+type JsonPayload = Record<string, unknown>;
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+function actorHeaders(role: string, actorId: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const { memoryDataAccess, resetMemoryDataAccess } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
+  const attendanceApproveRoute = await import(
+    "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
+  );
+  const payrollPreviewWithDeductionsRoute = await import(
+    "../../src/app/api/payroll/runs/preview-with-deductions/route.ts"
+  );
+  const {
+    findPayrollKrIncomeSplitItemCodeDictionaryEntry,
+    listPayrollKrIncomeSplitItemCodeDictionary
+  } = await import("../../src/features/payroll/kr-income-split-item-code-dictionary.ts");
+
+  const payrollContract = readUtf8("specs", "payroll", "contract.yaml");
+  const payrollTestCases = readUtf8("specs", "payroll", "test-cases.md");
+  const payrollRfc = readUtf8("specs", "payroll", "rfc.md");
+  const adminPage = readUtf8("src", "app", "admin", "page.tsx");
+  const tableComponent = readUtf8(
+    "src",
+    "components",
+    "payroll",
+    "PayrollKrIncomeSplitItemsTable.tsx"
+  );
+  const dictionaryModule = readUtf8(
+    "src",
+    "features",
+    "payroll",
+    "kr-income-split-item-code-dictionary.ts"
+  );
+  const workItem = readUtf8("work-items", "WI-0227-payroll-kr-item-code-autocomplete-ux.md");
+
+  assert.match(payrollContract, /WI-0227/i);
+  assert.match(payrollTestCases, /autocomplete/i);
+  assert.match(payrollRfc, /WI-0227/);
+  assert.match(adminPage, /PayrollKrIncomeSplitItemsTable/);
+  assert.match(tableComponent, /list=/);
+  assert.match(tableComponent, /findPayrollKrIncomeSplitItemCodeDictionaryEntry/);
+  assert.match(dictionaryModule, /TX_SALARY/);
+  assert.match(workItem, /autocomplete UX/i);
+
+  const taxableDictionary = listPayrollKrIncomeSplitItemCodeDictionary("taxable");
+  const nonTaxableDictionary = listPayrollKrIncomeSplitItemCodeDictionary("non_taxable");
+  assert.ok(taxableDictionary.length >= 2, "taxable dictionary should include multiple options");
+  assert.ok(nonTaxableDictionary.length >= 2, "non-taxable dictionary should include multiple options");
+  const matchedTaxable = findPayrollKrIncomeSplitItemCodeDictionaryEntry("tx_salary", "taxable");
+  const matchedNonTaxable = findPayrollKrIncomeSplitItemCodeDictionaryEntry("NT_MEAL", "non_taxable");
+  assert.equal(matchedTaxable?.category, "salary");
+  assert.equal(matchedNonTaxable?.category, "allowance");
+
+  resetMemoryDataAccess();
+  runtimeEnv.FLOWHR_PAYROLL_DEDUCTIONS_V1 = "true";
+  runtimeEnv.FLOWHR_PAYROLL_KR_BASELINE_V1 = "true";
+
+  await memoryDataAccess.employees.create({ id: "EMP-3227" });
+
+  const createResponse = await attendanceCreateRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/attendance/records",
+      {
+        employeeId: "EMP-3227",
+        checkInAt: "2026-02-16T09:00:00+09:00",
+        checkOutAt: "2026-02-16T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      actorHeaders("employee", "EMP-3227")
+    )
+  );
+  assert.equal(createResponse.status, 201);
+  const createdBody = await readJson<{ record: { id: string } }>(createResponse);
+
+  const approveResponse = await attendanceApproveRoute.POST(
+    new Request(`http://localhost/api/attendance/records/${createdBody.record.id}/approve`, {
+      method: "POST",
+      headers: actorHeaders("manager", "MGR-3227")
+    }),
+    { params: Promise.resolve({ recordId: createdBody.record.id }) } as RouteContext<{
+      recordId: string;
+    }>
+  );
+  assert.equal(approveResponse.status, 200);
+
+  const successResponse = await payrollPreviewWithDeductionsRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/runs/preview-with-deductions",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId: "EMP-3227",
+        hourlyRateKrw: 12000,
+        deductionMode: "statutory_kr_baseline",
+        statutory: {
+          incomeTaxLookupPresetId: "kr_simple_monthly_v2026_01",
+          taxableIncomeItems: [{ code: "TX_SALARY", category: "salary", amountKrw: 86000 }],
+          nonTaxableIncomeItems: [{ code: "NT_MEAL", category: "allowance", amountKrw: 10000 }]
+        }
+      },
+      actorHeaders("payroll_operator", "PAY-3227")
+    )
+  );
+  assert.equal(successResponse.status, 200, "dictionary-backed code values should remain compatible");
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0227-payroll-kr-item-code-autocomplete-ux.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.30.0
+  version: 1.31.0
 paths:
   /payroll/runs:
     get:
@@ -60,7 +60,7 @@ paths:
   /payroll/runs/preview-with-deductions:
     post:
       summary: Create payroll preview with deduction and tax components (manual/profile/statutory_kr_baseline mode)
-      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`. In statutory_kr_baseline mode, baseline KR withholding/social insurance components are derived from configurable rates with optional `incomeTaxBrackets`, `incomeTaxLookupTable`, or `incomeTaxLookupPresetId` (mutually exclusive), insurance cap fields (`nationalPensionCapKrw`, `healthInsuranceCapKrw`, `employmentInsuranceCapKrw`), additive tax-credit fields (`additionalTaxCreditKrw`, `dependentCount`, `dependentTaxCreditPerPersonKrw`), optional split input `taxableIncomeKrw`, optional income split item arrays (`taxableIncomeItems`, `nonTaxableIncomeItems` with `code`/`category`/`amountKrw`, multi-row up to 20 entries per list), optional income split item preset (`incomeSplitItemPresetId`), optional insurance rounding rules (`insuranceRounding`), and optional monthly-boundary guard (`requireMonthlyBoundary`). Split guards require `nonTaxableIncomeKrw <= grossPayKrw` and explicit taxable split sum match; `incomeSplitItemPresetId` cannot be combined with manual income split item arrays.
+      description: In profile mode, `expectedProfileVersion` can be provided to reject stale profile usage with `409`. In statutory_kr_baseline mode, baseline KR withholding/social insurance components are derived from configurable rates with optional `incomeTaxBrackets`, `incomeTaxLookupTable`, or `incomeTaxLookupPresetId` (mutually exclusive), insurance cap fields (`nationalPensionCapKrw`, `healthInsuranceCapKrw`, `employmentInsuranceCapKrw`), additive tax-credit fields (`additionalTaxCreditKrw`, `dependentCount`, `dependentTaxCreditPerPersonKrw`), optional split input `taxableIncomeKrw`, optional income split item arrays (`taxableIncomeItems`, `nonTaxableIncomeItems` with `code`/`category`/`amountKrw`, multi-row up to 20 entries per list), optional income split item preset (`incomeSplitItemPresetId`), optional insurance rounding rules (`insuranceRounding`), and optional monthly-boundary guard (`requireMonthlyBoundary`). Split guards require `nonTaxableIncomeKrw <= grossPayKrw` and explicit taxable split sum match; `incomeSplitItemPresetId` cannot be combined with manual income split item arrays. Admin UI may provide dictionary-based code autocomplete while keeping API payload unchanged.
       responses:
         "200":
           description: Deduction preview generated

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,5 +1,5 @@
 owner: payroll-agent
-version: 1.30.0
+version: 1.31.0
 scope:
   in:
     - gross pay preview from approved attendance aggregates
@@ -18,6 +18,7 @@ scope:
     - KR statutory baseline income split item code/category input (`taxableIncomeItems`, `nonTaxableIncomeItems`)
     - KR statutory baseline income split item preset dataset selection (`incomeSplitItemPresetId`)
     - KR statutory baseline admin multi-item input table UX wiring for split item arrays
+    - KR statutory baseline admin item-code dictionary autocomplete UX wiring
     - golden fixture regression coverage for statutory KR baseline deduction outputs
     - KR 4-insurance settlement preview with employee/employer contribution deltas and prior-withheld reconciliation
     - payroll withholding settlement and period-close preview/apply workflow for confirmed payroll runs
@@ -340,6 +341,7 @@ test_plan:
     - statutory_kr_baseline validates income split item list code uniqueness and item-total consistency with split totals
     - statutory_kr_baseline resolves income split item preset ID and rejects unknown/mutually-exclusive manual item combinations
     - admin payroll preview multi-item table UX keeps deterministic split-item array payload wiring
+    - admin payroll preview item-code dictionary autocomplete keeps deterministic code/category payload composition
     - statutory_kr_baseline validates optional monthly-boundary guard in Asia/Seoul
     - preview-insurance-settlement returns employee/employer contributions, capped bases, and prior-withheld/prior-paid deltas
     - preview-insurance-settlement rejects requests when payroll_kr_insurance_settlement_v1 is disabled
@@ -379,6 +381,7 @@ test_plan:
     - statutory_kr_baseline income split item code/category input deterministic replay via WI-0224 e2e
     - statutory_kr_baseline income split item preset dataset deterministic replay via WI-0225 e2e
     - statutory_kr_baseline admin multi-item split input table deterministic replay via WI-0226 e2e
+    - statutory_kr_baseline admin item-code dictionary autocomplete deterministic replay via WI-0227 e2e
     - insurance settlement deterministic replay via WI-0184 e2e
     - close-period deterministic replay via WI-0185 e2e
     - payslip distribution/receipt deterministic replay via WI-0186 e2e
@@ -424,6 +427,7 @@ test_plan:
     - income split item code uniqueness and item-total consistency checks
     - income split item preset resolution and manual-item mutual-exclusion checks
     - multi-item split input table payload composition and row-level validation checks
+    - item-code dictionary autocomplete and category auto-fill payload consistency checks
     - tax-credit and monthly-boundary component checks
     - insurance settlement employee/employer component, cap, and delta deterministic checks
     - close-period withholding/social/net aggregation and settlement-delta checks
@@ -537,7 +541,7 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.30.0 clarifies `statutory_kr_baseline` split-item array usage for admin multi-item table UX (no breaking API change), while preserving all existing payroll preview/confirm/profile/statutory preset/split/item-array, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
+consumer_impact: "Contract v1.31.0 additively documents admin item-code dictionary autocomplete UX for `statutory_kr_baseline` split-item inputs (no breaking API change), while preserving all existing payroll preview/confirm/profile/statutory preset/split/item-array, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
 references:
   - specs/common/time-and-payroll-rules.md
   - specs/payroll/phase2-compatibility-matrix.md
@@ -557,6 +561,7 @@ references:
   - work-items/WI-0224-payroll-kr-income-split-item-code-category-input.md
   - work-items/WI-0225-payroll-kr-income-split-item-preset-dataset.md
   - work-items/WI-0226-payroll-kr-multi-item-input-table-ux.md
+  - work-items/WI-0227-payroll-kr-item-code-autocomplete-ux.md
   - work-items/WI-0110-payroll-statutory-golden-regression.md
   - work-items/WI-0184-payroll-insurance-settlement-baseline.md
   - work-items/WI-0185-payroll-withholding-close-period-baseline.md

--- a/specs/payroll/rfc.md
+++ b/specs/payroll/rfc.md
@@ -1,8 +1,8 @@
-# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 + WI-0101 + WI-0105 + WI-0106 + WI-0110 + WI-0220 + WI-0221 + WI-0223 + WI-0224 + WI-0225 + WI-0226 Contract)
+# Payroll RFC (WI-0001 + WI-0005 + WI-0006 + WI-0010 + WI-0101 + WI-0105 + WI-0106 + WI-0110 + WI-0220 + WI-0221 + WI-0223 + WI-0224 + WI-0225 + WI-0226 + WI-0227 Contract)
 
 ## Goal
 
-Provide payroll gross pay preview based on attendance aggregates, phase2 deduction/tax expansion, deduction profile auto-calculation mode, and KR statutory baseline deduction mode with progressive/lookup-table/preset/cap/tax-credit/month-boundary/insurance-rounding/taxable-split/item-code/item-preset options and admin multi-item input table wiring.
+Provide payroll gross pay preview based on attendance aggregates, phase2 deduction/tax expansion, deduction profile auto-calculation mode, and KR statutory baseline deduction mode with progressive/lookup-table/preset/cap/tax-credit/month-boundary/insurance-rounding/taxable-split/item-code/item-preset options and admin multi-item input table plus code-dictionary autocomplete wiring.
 
 ## Key Decisions
 
@@ -22,6 +22,7 @@ Provide payroll gross pay preview based on attendance aggregates, phase2 deducti
 - WI-0224 extends statutory baseline with optional taxable/non-taxable income item arrays (`code`/`category`/`amountKrw`) and item-total validation guard integration with split totals.
 - WI-0225 extends statutory baseline with optional income split item preset ID (`incomeSplitItemPresetId`) and server-managed code/category template application guard.
 - WI-0226 upgrades admin payroll preview to multi-item split input table UX while preserving WI-0224/0225 split-item contract compatibility.
+- WI-0227 upgrades admin payroll split-item input with dictionary-backed code autocomplete and category auto-fill UX while preserving existing payload contract.
 
 ## Non-Goals
 

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -64,6 +64,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 56. Validate statutory baseline income split item input (`taxableIncomeItems`, `nonTaxableIncomeItems`) for duplicate-code guard and split-total consistency.
 57. Validate statutory baseline income split item preset input (`incomeSplitItemPresetId`) for supported-preset resolution and mutual exclusivity with manual item arrays.
 58. Admin payroll preview multi-item input table wires deterministic multi-row `taxableIncomeItems`/`nonTaxableIncomeItems` payload and preserves row-level validation.
+59. Admin payroll preview split-item table code input supports dictionary autocomplete and category auto-fill while preserving deterministic payload composition.
 
 ## Accuracy Cases
 
@@ -110,6 +111,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 41. Statutory baseline income split item list/total validation and `incomeSplitItems` breakdown output remain deterministic for same input replay.
 42. Statutory baseline income split item preset resolution and preset-backed `incomeSplitItems` output remain deterministic for same input replay.
 43. Admin multi-item split input table payload composition remains deterministic for same UI state/input replay.
+44. Admin item-code dictionary autocomplete and category auto-fill remain deterministic for same UI state/input replay.
 
 ## Regression Linkage
 
@@ -138,6 +140,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 - Income Split Item Gate: `taxableIncomeItems`/`nonTaxableIncomeItems` code-uniqueness and item-total consistency with split totals must be deterministic and validated.
 - Income Split Item Preset Gate: `incomeSplitItemPresetId` resolution and manual-item mutual-exclusion guard must be deterministic and validated.
 - Income Split Item Table UX Gate: `/admin` multi-item split table add/remove row wiring must compose deterministic payload with row-level validation parity.
+- Income Split Item Autocomplete Gate: `/admin` split item code dictionary autocomplete/category auto-fill must preserve deterministic payload wiring.
 - Employee Payslip Gate: employee role can list only their own CONFIRMED payroll runs; other employees and PREVIEWED runs are blocked (403).
 - Insurance Settlement Gate: `POST /payroll/runs/preview-insurance-settlement` remains feature-flagged, permission-guarded, and deterministic under repeated replay.
 - Close-Period Gate: `POST /payroll/runs/close-period` remains feature-flagged, permission-guarded, and blocks apply when unconfirmed runs exist.

--- a/src/components/payroll/PayrollKrIncomeSplitItemsTable.tsx
+++ b/src/components/payroll/PayrollKrIncomeSplitItemsTable.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+  findPayrollKrIncomeSplitItemCodeDictionaryEntry,
+  listPayrollKrIncomeSplitItemCodeDictionary,
+  type PayrollKrIncomeSplitItemCodeDictionaryEntry,
+  type PayrollKrIncomeSplitItemCodeKind
+} from "@/features/payroll/kr-income-split-item-code-dictionary";
 import { type FlowLocale } from "@/lib/i18n/locales";
 import { useI18n } from "@/lib/i18n/provider";
 
@@ -25,6 +31,8 @@ type IncomeSplitItemsTableCopy = {
   codeLabel: string;
   categoryLabel: string;
   amountLabel: string;
+  codeAutocompleteGuide: string;
+  categoryAutofillGuide: string;
   addRowLabel: string;
   removeRowLabel: string;
   rowLabelPrefix: string;
@@ -40,6 +48,8 @@ const incomeSplitItemsTableCopy: Record<FlowLocale, IncomeSplitItemsTableCopy> =
     codeLabel: "코드",
     categoryLabel: "카테고리",
     amountLabel: "금액(KRW)",
+    codeAutocompleteGuide: "코드 입력 시 사전 항목 autocomplete가 제공됩니다.",
+    categoryAutofillGuide: "사전 코드 선택 시 카테고리가 자동으로 채워집니다.",
     addRowLabel: "행 추가",
     removeRowLabel: "행 삭제",
     rowLabelPrefix: "행",
@@ -54,6 +64,8 @@ const incomeSplitItemsTableCopy: Record<FlowLocale, IncomeSplitItemsTableCopy> =
     codeLabel: "Code",
     categoryLabel: "Category",
     amountLabel: "Amount (KRW)",
+    codeAutocompleteGuide: "Code input provides dictionary autocomplete suggestions.",
+    categoryAutofillGuide: "Category is auto-filled when a dictionary code is selected.",
     addRowLabel: "Add row",
     removeRowLabel: "Remove row",
     rowLabelPrefix: "Row",
@@ -106,10 +118,22 @@ type ItemRowsSectionProps = {
   items: PayrollKrIncomeSplitItemDraft[];
   onChange: (nextItems: PayrollKrIncomeSplitItemDraft[]) => void;
   copy: IncomeSplitItemsTableCopy;
+  kind: PayrollKrIncomeSplitItemCodeKind;
+  datalistId: string;
+  codeDictionary: PayrollKrIncomeSplitItemCodeDictionaryEntry[];
   disabled: boolean;
 };
 
-function ItemRowsSection({ title, items, onChange, copy, disabled }: ItemRowsSectionProps) {
+function ItemRowsSection({
+  title,
+  items,
+  onChange,
+  copy,
+  kind,
+  datalistId,
+  codeDictionary,
+  disabled
+}: ItemRowsSectionProps) {
   const safeItems = ensureAtLeastOneRow(items);
 
   return (
@@ -118,54 +142,82 @@ function ItemRowsSection({ title, items, onChange, copy, disabled }: ItemRowsSec
         <strong>{title}</strong> ({copy.rowCountLabel}: {safeItems.length}/{incomeSplitItemRowLimit})
       </p>
       <div className="input-grid compact">
-        {safeItems.map((item, index) => (
-          <div className="full" key={`${title}-${index}`}>
-            <div className="input-grid compact">
-              <label>
-                {copy.rowLabelPrefix} {index + 1} {copy.codeLabel}
-                <input
-                  value={item.code}
-                  onChange={(event) =>
-                    onChange(updateItemAt(safeItems, index, { code: event.target.value }))
-                  }
-                  disabled={disabled}
-                />
-              </label>
-              <label>
-                {copy.rowLabelPrefix} {index + 1} {copy.categoryLabel}
-                <input
-                  value={item.category}
-                  onChange={(event) =>
-                    onChange(updateItemAt(safeItems, index, { category: event.target.value }))
-                  }
-                  disabled={disabled}
-                />
-              </label>
-              <label>
-                {copy.rowLabelPrefix} {index + 1} {copy.amountLabel}
-                <input
-                  type="number"
-                  min={0}
-                  value={item.amountKrw}
-                  onChange={(event) =>
-                    onChange(updateItemAt(safeItems, index, { amountKrw: event.target.value }))
-                  }
-                  disabled={disabled}
-                />
-              </label>
-              <div>
-                <button
-                  type="button"
-                  onClick={() => onChange(removeItemAt(safeItems, index))}
-                  disabled={disabled || safeItems.length <= 1}
-                >
-                  {copy.removeRowLabel}
-                </button>
+        {safeItems.map((item, index) => {
+          const matchedEntry = findPayrollKrIncomeSplitItemCodeDictionaryEntry(item.code, kind);
+          return (
+            <div className="full" key={`${title}-${index}`}>
+              <div className="input-grid compact">
+                <label>
+                  {copy.rowLabelPrefix} {index + 1} {copy.codeLabel}
+                  <input
+                    list={datalistId}
+                    value={item.code}
+                    onChange={(event) => {
+                      const nextCode = event.target.value;
+                      const nextDictionaryEntry = findPayrollKrIncomeSplitItemCodeDictionaryEntry(
+                        nextCode,
+                        kind
+                      );
+                      onChange(
+                        updateItemAt(safeItems, index, {
+                          code: nextCode,
+                          category: nextDictionaryEntry ? nextDictionaryEntry.category : item.category
+                        })
+                      );
+                    }}
+                    disabled={disabled}
+                  />
+                  {matchedEntry ? (
+                    <span className="small muted">
+                      {matchedEntry.label} / {matchedEntry.category}
+                    </span>
+                  ) : null}
+                </label>
+                <label>
+                  {copy.rowLabelPrefix} {index + 1} {copy.categoryLabel}
+                  <input
+                    value={item.category}
+                    onChange={(event) =>
+                      onChange(updateItemAt(safeItems, index, { category: event.target.value }))
+                    }
+                    disabled={disabled}
+                  />
+                </label>
+                <label>
+                  {copy.rowLabelPrefix} {index + 1} {copy.amountLabel}
+                  <input
+                    type="number"
+                    min={0}
+                    value={item.amountKrw}
+                    onChange={(event) =>
+                      onChange(updateItemAt(safeItems, index, { amountKrw: event.target.value }))
+                    }
+                    disabled={disabled}
+                  />
+                </label>
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => onChange(removeItemAt(safeItems, index))}
+                    disabled={disabled || safeItems.length <= 1}
+                  >
+                    {copy.removeRowLabel}
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+      <datalist id={datalistId}>
+        {codeDictionary.map((entry) => (
+          <option
+            key={`${datalistId}-${entry.code}`}
+            value={entry.code}
+            label={`${entry.label} / ${entry.category}`}
+          />
+        ))}
+      </datalist>
       <div>
         <button
           type="button"
@@ -188,16 +240,24 @@ export function PayrollKrIncomeSplitItemsTable({
 }: PayrollKrIncomeSplitItemsTableProps) {
   const { locale } = useI18n();
   const copy = incomeSplitItemsTableCopy[locale];
+  const taxableCodeDictionary = listPayrollKrIncomeSplitItemCodeDictionary("taxable");
+  const nonTaxableCodeDictionary = listPayrollKrIncomeSplitItemCodeDictionary("non_taxable");
 
   return (
     <div>
       <p className="small muted">{copy.guide}</p>
+      <p className="small muted">
+        {copy.codeAutocompleteGuide} {copy.categoryAutofillGuide}
+      </p>
       {disabled ? <p className="small muted">{copy.disabledGuide}</p> : null}
       <ItemRowsSection
         title={copy.taxableTitle}
         items={taxableItems}
         onChange={onTaxableItemsChange}
         copy={copy}
+        kind="taxable"
+        datalistId="payroll-income-split-taxable-code-options"
+        codeDictionary={taxableCodeDictionary}
         disabled={disabled}
       />
       <ItemRowsSection
@@ -205,6 +265,9 @@ export function PayrollKrIncomeSplitItemsTable({
         items={nonTaxableItems}
         onChange={onNonTaxableItemsChange}
         copy={copy}
+        kind="non_taxable"
+        datalistId="payroll-income-split-non-taxable-code-options"
+        codeDictionary={nonTaxableCodeDictionary}
         disabled={disabled}
       />
     </div>

--- a/src/features/payroll/kr-income-split-item-code-dictionary.ts
+++ b/src/features/payroll/kr-income-split-item-code-dictionary.ts
@@ -1,0 +1,77 @@
+export type PayrollKrIncomeSplitItemCodeKind = "taxable" | "non_taxable";
+
+export type PayrollKrIncomeSplitItemCodeDictionaryEntry = {
+  code: string;
+  kind: PayrollKrIncomeSplitItemCodeKind;
+  category: string;
+  label: string;
+};
+
+const payrollKrIncomeSplitItemCodeDictionary: PayrollKrIncomeSplitItemCodeDictionaryEntry[] = [
+  {
+    code: "TX_SALARY",
+    kind: "taxable",
+    category: "salary",
+    label: "Base salary"
+  },
+  {
+    code: "TX_BONUS",
+    kind: "taxable",
+    category: "bonus",
+    label: "Bonus payout"
+  },
+  {
+    code: "TX_ALLOWANCE",
+    kind: "taxable",
+    category: "allowance",
+    label: "Taxable allowance"
+  },
+  {
+    code: "NT_MEAL",
+    kind: "non_taxable",
+    category: "allowance",
+    label: "Meal allowance"
+  },
+  {
+    code: "NT_COMMUTE",
+    kind: "non_taxable",
+    category: "allowance",
+    label: "Commute allowance"
+  },
+  {
+    code: "NT_CHILDCARE",
+    kind: "non_taxable",
+    category: "allowance",
+    label: "Childcare allowance"
+  }
+];
+
+function normalizeCode(value: string) {
+  return value.trim().toUpperCase();
+}
+
+export function listPayrollKrIncomeSplitItemCodeDictionary(
+  kind?: PayrollKrIncomeSplitItemCodeKind
+) {
+  if (!kind) {
+    return payrollKrIncomeSplitItemCodeDictionary.slice();
+  }
+  return payrollKrIncomeSplitItemCodeDictionary.filter((entry) => entry.kind === kind);
+}
+
+export function findPayrollKrIncomeSplitItemCodeDictionaryEntry(
+  code: string,
+  kind?: PayrollKrIncomeSplitItemCodeKind
+) {
+  const normalizedCode = normalizeCode(code);
+  if (!normalizedCode) {
+    return null;
+  }
+  return (
+    payrollKrIncomeSplitItemCodeDictionary.find(
+      (entry) =>
+        normalizeCode(entry.code) === normalizedCode &&
+        (kind === undefined || entry.kind === kind)
+    ) ?? null
+  );
+}

--- a/work-items/WI-0227-payroll-kr-item-code-autocomplete-ux.md
+++ b/work-items/WI-0227-payroll-kr-item-code-autocomplete-ux.md
@@ -1,0 +1,37 @@
+# WI-0227: Payroll KR Item Code Autocomplete UX
+
+## Background
+
+WI-0226에서 `/admin` 다중 항목 입력 테이블을 도입했지만, 코드 입력은 여전히 자유 입력이라
+운영자가 코드 문자열을 기억해야 하고 카테고리 오입력 가능성이 남아 있습니다.
+
+## Scope
+
+### In Scope
+
+- 과세/비과세 항목 코드 사전 데이터셋 추가
+  - 코드, 기본 카테고리, 라벨 제공
+- `/admin` 다중 항목 테이블에 코드 `autocomplete` 적용
+  - 코드 입력에 사전 기반 suggestion 제공
+  - 사전 코드 선택 시 카테고리 자동 채움
+  - 카테고리 수동 수정은 유지
+- API/서버 계약은 유지(입력 스키마 변경 없음)
+- 스펙/로드맵/회귀 테스트 갱신
+  - `specs/payroll/{contract.yaml,api.yaml,test-cases.md,rfc.md}`
+  - `scripts/tests/e2e-wi0227-payroll-kr-item-code-autocomplete-ux.test.ts`
+
+### Out of Scope
+
+- 서버 측 코드 사전 강제 검증
+- 코드 사전 CRUD 관리자 화면
+- 외부 코드 체계(Hometax/NTS) 자동 동기화
+
+## Validation
+
+- `npm.cmd exec tsx scripts/tests/e2e-wi0227-payroll-kr-item-code-autocomplete-ux.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0226-payroll-kr-multi-item-input-table-ux.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0224-payroll-kr-income-split-item-code-category-input.test.ts`
+- `npm.cmd run lint`
+- `npm.cmd run typecheck`
+- `npm.cmd run build`


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0227-payroll-kr-item-code-autocomplete-ux.md`
- Related Specs: `specs/payroll/api.yaml`, `specs/payroll/contract.yaml`, `specs/payroll/rfc.md`, `specs/payroll/test-cases.md`
- Related ADR: N/A (UI-only additive enhancement)
- Closes #263

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
Reason: UI-only additive autocomplete wiring in existing admin payroll table; no breaking/cross-domain/security-impacting contract change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
  - `npm.cmd run test`
- [x] Integration tests
  - `npm.cmd run test:integration`
- [x] Regression checks
  - `npm.cmd exec tsx scripts/tests/e2e-wi0223-payroll-kr-taxable-non-taxable-split-rule.test.ts`
  - `npm.cmd exec tsx scripts/tests/e2e-wi0224-payroll-kr-income-split-item-code-category-input.test.ts`
  - `npm.cmd exec tsx scripts/tests/e2e-wi0225-payroll-kr-income-split-item-preset-dataset.test.ts`
  - `npm.cmd exec tsx scripts/tests/e2e-wi0226-payroll-kr-multi-item-input-table-ux.test.ts`
  - `npm.cmd exec tsx scripts/tests/e2e-wi0227-payroll-kr-item-code-autocomplete-ux.test.ts`
- [x] Lint/typecheck
  - `npm.cmd run lint`
  - `npm.cmd run typecheck`
- [x] Migration smoke
  - `npm.cmd run prisma:validate`
- [x] Contract governance checks
  - `python scripts/ci/check_contracts.py`
  - `python scripts/ci/check_traceability.py`

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/payroll/PayrollKrIncomeSplitItemsTable.tsx`
- Backend-only reason: N/A
- Next UI WI: WI-0228 (server-side dictionary validation guard for payload parity)

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID: N/A
- Approval:
  - Human approver: N/A
  - Co-sign approver (Orchestrator or QA): N/A
- Change scope: N/A
- Risk assessment: N/A
- Rollback plan: Revert PR if needed.
- Customer impact: N/A
- Temporary mitigation: N/A
- RCA due date (<= 48h after merge): N/A
