### PR TITLE
feat: WI-0257 mobile analytics dashboard share filter preset baseline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # FlowHR Production Roadmap
 
 > **Last updated**: 2026-02-23
-> **Current version**: 0.1.117 (Mobile Analytics Dashboard Baseline)
+> **Current version**: 0.1.118 (Mobile Analytics Dashboard Share/Filter Preset Baseline)
 > **Target**: Production-grade Korean HR SaaS (Shiftee/Flex superior)
 
 ---
@@ -293,10 +293,11 @@
 - WI-0254 모바일 직원 요청 후속 액션 번들/저장 preset baseline(`apps/mobile` follow-up bundle preset catalog(`allActionRequired/triageQueue/decisionQueue/recoveryQueue`) + pinned/recent preset state 로컬 저장 + `EmployeeRequestFollowUpScreen` preset 적용/빠른 실행/핀 토글 + WI-0254 회귀 테스트 추가)
 - WI-0255 모바일 직원 요청 후속 preset 가져오기/내보내기 baseline(`apps/mobile` follow-up preset transfer payload(`type/version/state`) 직렬화/파서 + `EmployeeRequestFollowUpPresetTransferCard` import/export UI + preset import 즉시 적용 + WI-0255 회귀 테스트 추가)
 - WI-0256 모바일 분석 대시보드 baseline(`apps/mobile` `mobileAnalytics` helper(기간 필터/KPI snapshot/일별 trend/export payload) + `MobileAnalyticsDashboardScreen` 신규 + 관리자/직원 홈 대시보드 진입 + WI-0256 회귀 테스트 추가)
+- WI-0257 모바일 분석 대시보드 공유/필터 preset baseline(`apps/mobile` analytics filter preset catalog(`allActionRequired/approvalRisk/requestFlow/notificationPulse`) + pin/recent preset 저장 + preset transfer payload import/export + `MobileAnalyticsFilterPresetCard` + `MobileAnalyticsDashboardScreen` focus 필터 연동 + WI-0257 회귀 테스트 추가)
 
 ### 진행 중
 
-- 다음: 모바일 분석 대시보드 공유/필터 preset baseline(`WI-X`) 착수 (WI-0257 예정)
+- 다음: 모바일 분석 대시보드 비교/리포트 baseline(`WI-X`) 착수 (WI-0258 예정)
 
 ### 현재 아키텍처
 
@@ -308,7 +309,7 @@
 | 역할 | 5개 역할 + permission mapping(seed) | 동적 역할 + 커스텀 권한 |
 | 급여 계산 | phase2 수동/프로필 + KR baseline 근사 | 한국 세법 + 4대보험 |
 | UI | 관리자 대시보드(`/admin`) + 결재 정책(`/admin/approval-policy`) + 직원 포털(`/employee`) + 명세서(`/employee/payslips`) + 홈(`/`) | 관리자/직원 여정 완성 + 결재/정책/명세서 고도화 |
-| 모바일 | ⚠️ `apps/mobile` 셸 + 푸시 + 이메일 템플릿 + 알림센터 실시간 업데이트 + 히스토리 검색/보관/일괄 액션 + 프리셋 pin/recent + import/export transfer + 관리자 승인 대기 큐 + 직원 요청 제출 + 요청 이력/상태 추적 + 요청 알림/후속 액션 + 후속 템플릿/자동 추천 + 후속 액션 번들/저장 preset + 후속 preset import/export transfer + 모바일 분석 대시보드 baseline (WI-0256) | 네이티브 앱 (iOS/Android) |
+| 모바일 | ⚠️ `apps/mobile` 셸 + 푸시 + 이메일 템플릿 + 알림센터 실시간 업데이트 + 히스토리 검색/보관/일괄 액션 + 프리셋 pin/recent + import/export transfer + 관리자 승인 대기 큐 + 직원 요청 제출 + 요청 이력/상태 추적 + 요청 알림/후속 액션 + 후속 템플릿/자동 추천 + 후속 액션 번들/저장 preset + 후속 preset import/export transfer + 모바일 분석 대시보드 + 분석 대시보드 공유/필터 preset baseline (WI-0257) | 네이티브 앱 (iOS/Android) |
 | 멀티테넌트 | baseline 적용 (Supabase RLS + FLOWHR_TENANCY_V1 플래그) | 조직별 완전 격리 |
 
 ---

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -18,6 +18,7 @@
   - Employee request follow-up action bundle saved preset shell
   - Employee request follow-up preset import/export transfer shell
   - Mobile analytics dashboard shell
+  - Mobile analytics dashboard share/filter preset shell
 - Shared API client wrapper for FlowHR backend requests
 - Push notification baseline
   - permission bootstrap

--- a/apps/mobile/src/components/MobileAnalyticsFilterPresetCard.js
+++ b/apps/mobile/src/components/MobileAnalyticsFilterPresetCard.js
@@ -1,0 +1,240 @@
+import { useMemo, useState } from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+
+import {
+  buildMobileAnalyticsFilterPresetStats,
+  parseMobileAnalyticsFilterPresetTransfer,
+  resolveMobileAnalyticsFocusLabel,
+  serializeMobileAnalyticsFilterPresetTransfer
+} from "../lib/mobileAnalytics";
+import { colors, spacing } from "../theme/tokens";
+import ShellCard from "./ShellCard";
+
+function errorMessage(code) {
+  if (code === "empty_payload") {
+    return "Import failed: payload is empty.";
+  }
+  if (code === "invalid_json") {
+    return "Import failed: payload must be valid JSON.";
+  }
+  if (code === "unsupported_type") {
+    return "Import failed: unsupported payload type.";
+  }
+  if (code === "unsupported_version") {
+    return "Import failed: unsupported payload version.";
+  }
+  if (code === "invalid_state") {
+    return "Import failed: state payload is missing.";
+  }
+  return "Import failed: invalid payload.";
+}
+
+function Chip({ active, label, onPress }) {
+  return (
+    <Pressable style={[styles.chip, active ? styles.chipActive : null]} onPress={onPress}>
+      <Text style={[styles.chipText, active ? styles.chipTextActive : null]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+export default function MobileAnalyticsFilterPresetCard({
+  source,
+  snapshotAt,
+  filterState,
+  presetState,
+  onApplyPreset,
+  onTogglePresetPin,
+  onImportPresetTransfer
+}) {
+  const [payload, setPayload] = useState("");
+  const [status, setStatus] = useState("");
+  const [statusTone, setStatusTone] = useState("neutral");
+
+  const presetStats = useMemo(
+    () => buildMobileAnalyticsFilterPresetStats(source, { now: snapshotAt }),
+    [snapshotAt, source]
+  );
+  const pinnedPresetStats = useMemo(
+    () =>
+      presetState.pinnedPresetKeys
+        .map((key) => presetStats.find((item) => item.key === key))
+        .filter(Boolean),
+    [presetState.pinnedPresetKeys, presetStats]
+  );
+  const recentPresetStats = useMemo(
+    () =>
+      presetState.recentPresetKeys
+        .map((key) => presetStats.find((item) => item.key === key))
+        .filter(Boolean),
+    [presetState.recentPresetKeys, presetStats]
+  );
+  const exportPayload = useMemo(
+    () => serializeMobileAnalyticsFilterPresetTransfer({ presetState, filterState }),
+    [filterState, presetState]
+  );
+
+  function generatePayload() {
+    setPayload(exportPayload);
+    setStatus("Export payload generated. Copy and share this JSON.");
+    setStatusTone("neutral");
+  }
+
+  async function importPayload() {
+    const parsed = parseMobileAnalyticsFilterPresetTransfer(payload);
+    if (!parsed.ok) {
+      setStatus(errorMessage(parsed.code));
+      setStatusTone("error");
+      return;
+    }
+    try {
+      await onImportPresetTransfer(parsed.state);
+      setStatus(
+        `Preset imported: pinned ${parsed.state.presetState.pinnedPresetKeys.length}, recent ${parsed.state.presetState.recentPresetKeys.length}.`
+      );
+      setStatusTone("success");
+    } catch {
+      setStatus("Import failed: could not persist preset state.");
+      setStatusTone("error");
+    }
+  }
+
+  function clearPayload() {
+    setPayload("");
+    setStatus("Preset transfer payload cleared.");
+    setStatusTone("neutral");
+  }
+
+  return (
+    <ShellCard
+      title="Filter presets"
+      subtitle={`active: ${filterState.periodKey} / ${resolveMobileAnalyticsFocusLabel(filterState.focus)}`}
+    >
+      <Text style={styles.label}>Pinned presets</Text>
+      <View style={styles.chipRow}>
+        {pinnedPresetStats.length === 0 ? <Text style={styles.meta}>No pinned presets yet.</Text> : null}
+        {pinnedPresetStats.map((preset) => (
+          <Chip
+            key={`pin-${preset.key}`}
+            active={false}
+            label={`${preset.label} (${preset.count})`}
+            onPress={() => onApplyPreset(preset.key)}
+          />
+        ))}
+      </View>
+
+      <Text style={styles.label}>Recent presets</Text>
+      <View style={styles.chipRow}>
+        {recentPresetStats.length === 0 ? <Text style={styles.meta}>No recent presets yet.</Text> : null}
+        {recentPresetStats.map((preset) => (
+          <Chip
+            key={`recent-${preset.key}`}
+            active={false}
+            label={`${preset.label} (${preset.count})`}
+            onPress={() => onApplyPreset(preset.key)}
+          />
+        ))}
+      </View>
+
+      {presetStats.map((preset) => (
+        <View key={preset.key} style={styles.item}>
+          <Text style={styles.itemTitle}>
+            {preset.label} ({preset.count})
+          </Text>
+          <Text style={styles.itemMeta}>{preset.note}</Text>
+          <Text style={styles.itemMeta}>
+            filter: {preset.filter.periodKey} / {resolveMobileAnalyticsFocusLabel(preset.filter.focus)}
+          </Text>
+          <View style={styles.row}>
+            <Pressable style={styles.button} onPress={() => onApplyPreset(preset.key)}>
+              <Text style={styles.buttonText}>Apply preset</Text>
+            </Pressable>
+            <Pressable style={styles.button} onPress={() => onTogglePresetPin(preset.key)}>
+              <Text style={styles.buttonText}>
+                {presetState.pinnedPresetKeys.includes(preset.key) ? "Unpin" : "Pin"}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      ))}
+
+      <Text style={styles.label}>Preset transfer</Text>
+      <TextInput
+        multiline
+        numberOfLines={7}
+        value={payload}
+        onChangeText={setPayload}
+        placeholder="Paste analytics preset transfer JSON here"
+        autoCapitalize="none"
+        autoCorrect={false}
+        style={styles.payloadInput}
+      />
+      <View style={styles.row}>
+        <Pressable style={styles.button} onPress={generatePayload}>
+          <Text style={styles.buttonText}>Generate export payload</Text>
+        </Pressable>
+        <Pressable style={styles.button} onPress={importPayload}>
+          <Text style={styles.buttonText}>Import payload</Text>
+        </Pressable>
+      </View>
+      <Pressable style={styles.button} onPress={clearPayload}>
+        <Text style={styles.buttonText}>Clear payload</Text>
+      </Pressable>
+      {status ? (
+        <Text style={[styles.meta, statusTone === "error" ? styles.statusError : statusTone === "success" ? styles.statusSuccess : null]}>
+          {status}
+        </Text>
+      ) : null}
+    </ShellCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: { color: colors.muted, fontSize: 12, fontWeight: "700" },
+  meta: { color: colors.muted, fontSize: 12 },
+  chipRow: { flexDirection: "row", flexWrap: "wrap", gap: spacing.sm },
+  chip: {
+    borderWidth: 1,
+    borderColor: colors.line,
+    borderRadius: 999,
+    backgroundColor: "#fff",
+    paddingHorizontal: 10,
+    paddingVertical: 7
+  },
+  chipActive: { borderColor: colors.primary, backgroundColor: colors.primarySoft },
+  chipText: { color: colors.muted, fontSize: 12, fontWeight: "700" },
+  chipTextActive: { color: colors.primary },
+  item: {
+    borderWidth: 1,
+    borderColor: colors.line,
+    borderRadius: 12,
+    backgroundColor: "#fff",
+    padding: spacing.sm,
+    gap: 4
+  },
+  itemTitle: { color: colors.ink, fontSize: 13, fontWeight: "700" },
+  itemMeta: { color: colors.muted, fontSize: 11 },
+  row: { flexDirection: "row", gap: spacing.sm },
+  button: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: colors.line,
+    borderRadius: 12,
+    backgroundColor: "#fff",
+    paddingVertical: 9,
+    alignItems: "center"
+  },
+  buttonText: { color: colors.ink, fontWeight: "600", fontSize: 12 },
+  payloadInput: {
+    borderWidth: 1,
+    borderColor: colors.line,
+    borderRadius: 12,
+    backgroundColor: "#fff",
+    color: colors.ink,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    minHeight: 120,
+    textAlignVertical: "top"
+  },
+  statusError: { color: "#b42318" },
+  statusSuccess: { color: "#027a48" }
+});

--- a/apps/mobile/src/lib/mobileAnalytics.js
+++ b/apps/mobile/src/lib/mobileAnalytics.js
@@ -9,8 +9,49 @@ export const MOBILE_ANALYTICS_PERIOD_OPTIONS = [
   { key: "30d", label: "Last 30 days", days: 30 }
 ];
 
+export const MOBILE_ANALYTICS_FOCUS_OPTIONS = [
+  { key: "all", label: "All domains" },
+  { key: "approval", label: "Approval focus" },
+  { key: "request", label: "Request focus" },
+  { key: "notification", label: "Notification focus" }
+];
+
+export const MOBILE_ANALYTICS_FILTER_PRESET_OPTIONS = [
+  {
+    key: "allActionRequired",
+    label: "All action required",
+    note: "Default overview for all domains.",
+    filter: { periodKey: "7d", focus: "all" }
+  },
+  {
+    key: "approvalRisk",
+    label: "Approval risk watch",
+    note: "Focus stalled pending approvals.",
+    filter: { periodKey: "7d", focus: "approval" }
+  },
+  {
+    key: "requestFlow",
+    label: "Request flow pulse",
+    note: "Track request throughput and pending actions.",
+    filter: { periodKey: "14d", focus: "request" }
+  },
+  {
+    key: "notificationPulse",
+    label: "Notification pulse",
+    note: "Watch unread notification backlog.",
+    filter: { periodKey: "7d", focus: "notification" }
+  }
+];
+
+export const MOBILE_ANALYTICS_FILTER_PRESET_RECENT_LIMIT = 4;
 export const MOBILE_ANALYTICS_EXPORT_TYPE = "flowhr.mobile.analytics.dashboard.snapshot";
 export const MOBILE_ANALYTICS_EXPORT_VERSION = 1;
+export const MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_TYPE = "flowhr.mobile.analytics.filter-preset-state";
+export const MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_VERSION = 1;
+
+const PERIOD_KEY_SET = new Set(MOBILE_ANALYTICS_PERIOD_OPTIONS.map((item) => item.key));
+const FOCUS_KEY_SET = new Set(MOBILE_ANALYTICS_FOCUS_OPTIONS.map((item) => item.key));
+const FILTER_PRESET_KEY_SET = new Set(MOBILE_ANALYTICS_FILTER_PRESET_OPTIONS.map((item) => item.key));
 
 function toMillis(value) {
   const stamp = new Date(value).getTime();
@@ -66,14 +107,112 @@ function bumpTrend(seriesMap, key, field) {
   seriesMap[key][field] += 1;
 }
 
+function normalizePeriodKey(periodKey, fallback = "7d") {
+  if (PERIOD_KEY_SET.has(periodKey)) {
+    return periodKey;
+  }
+  if (PERIOD_KEY_SET.has(fallback)) {
+    return fallback;
+  }
+  return MOBILE_ANALYTICS_PERIOD_OPTIONS[0].key;
+}
+
+function normalizeFocusKey(focus, fallback = "all") {
+  if (FOCUS_KEY_SET.has(focus)) {
+    return focus;
+  }
+  if (FOCUS_KEY_SET.has(fallback)) {
+    return fallback;
+  }
+  return "all";
+}
+
 export function resolveMobileAnalyticsPeriodDays(periodKey, fallback = 7) {
-  const found = MOBILE_ANALYTICS_PERIOD_OPTIONS.find((item) => item.key === periodKey);
+  const normalizedKey = normalizePeriodKey(periodKey);
+  const found = MOBILE_ANALYTICS_PERIOD_OPTIONS.find((item) => item.key === normalizedKey);
   return found?.days ?? fallback;
+}
+
+export function resolveMobileAnalyticsFocusLabel(focus) {
+  const normalized = normalizeFocusKey(focus);
+  return MOBILE_ANALYTICS_FOCUS_OPTIONS.find((item) => item.key === normalized)?.label ?? "All domains";
 }
 
 export function formatMobileAnalyticsRate(value) {
   const normalized = Number.isFinite(Number(value)) ? Number(value) : 0;
   return `${normalized.toFixed(1)}%`;
+}
+
+export function normalizeMobileAnalyticsFilterState(filterState) {
+  const source = filterState && typeof filterState === "object" ? filterState : {};
+  return {
+    periodKey: normalizePeriodKey(source.periodKey, "7d"),
+    focus: normalizeFocusKey(source.focus, "all")
+  };
+}
+
+export function getMobileAnalyticsFilterPreset(presetKey) {
+  return MOBILE_ANALYTICS_FILTER_PRESET_OPTIONS.find((item) => item.key === presetKey) ?? null;
+}
+
+export function sanitizeMobileAnalyticsFilterPresetKeys(keys) {
+  const source = Array.isArray(keys) ? keys : [];
+  const unique = [];
+  for (const key of source) {
+    if (!FILTER_PRESET_KEY_SET.has(key)) {
+      continue;
+    }
+    if (!unique.includes(key)) {
+      unique.push(key);
+    }
+  }
+  return unique;
+}
+
+export function toggleMobileAnalyticsFilterPresetPin(pinnedPresetKeys, presetKey) {
+  const pinned = sanitizeMobileAnalyticsFilterPresetKeys(pinnedPresetKeys);
+  if (!FILTER_PRESET_KEY_SET.has(presetKey)) {
+    return pinned;
+  }
+  if (pinned.includes(presetKey)) {
+    return pinned.filter((key) => key !== presetKey);
+  }
+  return [...pinned, presetKey];
+}
+
+export function pushMobileAnalyticsFilterPresetRecent(
+  recentPresetKeys,
+  presetKey,
+  limit = MOBILE_ANALYTICS_FILTER_PRESET_RECENT_LIMIT
+) {
+  const recent = sanitizeMobileAnalyticsFilterPresetKeys(recentPresetKeys);
+  if (!FILTER_PRESET_KEY_SET.has(presetKey)) {
+    return recent.slice(0, limit);
+  }
+  return [presetKey, ...recent.filter((key) => key !== presetKey)].slice(0, limit);
+}
+
+export function normalizeMobileAnalyticsFilterPresetState(state) {
+  const source = state && typeof state === "object" ? state : {};
+  const pinnedPresetKeys = sanitizeMobileAnalyticsFilterPresetKeys(source.pinnedPresetKeys);
+  const recentPresetKeys = sanitizeMobileAnalyticsFilterPresetKeys(source.recentPresetKeys)
+    .filter((key) => !pinnedPresetKeys.includes(key))
+    .slice(0, MOBILE_ANALYTICS_FILTER_PRESET_RECENT_LIMIT);
+  return {
+    pinnedPresetKeys,
+    recentPresetKeys
+  };
+}
+
+export function resolveMobileAnalyticsFilterFromPreset(presetKey, currentFilterState = {}) {
+  const preset = getMobileAnalyticsFilterPreset(presetKey);
+  if (!preset) {
+    return normalizeMobileAnalyticsFilterState(currentFilterState);
+  }
+  return normalizeMobileAnalyticsFilterState({
+    periodKey: preset.filter?.periodKey ?? currentFilterState.periodKey,
+    focus: preset.filter?.focus ?? currentFilterState.focus
+  });
 }
 
 export function buildMobileAnalyticsSnapshot(
@@ -84,7 +223,8 @@ export function buildMobileAnalyticsSnapshot(
   const requests = Array.isArray(source.requests) ? source.requests : [];
   const notifications = Array.isArray(source.notifications) ? source.notifications : [];
   const now = options.now instanceof Date ? options.now : new Date();
-  const periodDays = Math.max(1, Number(options.periodDays) || 7);
+  const filterState = normalizeMobileAnalyticsFilterState(options.filterState);
+  const periodDays = Math.max(1, Number(options.periodDays) || resolveMobileAnalyticsPeriodDays(filterState.periodKey, 7));
   const nowMs = now.getTime();
   const periodMs = periodDaysToMillis(periodDays);
 
@@ -163,6 +303,34 @@ export function buildMobileAnalyticsTrendSeries(source = {}, options = {}) {
   return Object.values(seriesMap);
 }
 
+export function resolveMobileAnalyticsFocusCount(snapshot, focus = "all") {
+  const target = normalizeFocusKey(focus, "all");
+  if (target === "approval") {
+    return Number(snapshot?.kpi?.approvalsPending ?? 0);
+  }
+  if (target === "request") {
+    return Number(snapshot?.kpi?.requestsPendingAction ?? 0);
+  }
+  if (target === "notification") {
+    return Number(snapshot?.kpi?.notificationsUnread ?? 0);
+  }
+  return Number(snapshot?.kpi?.actionRequired ?? 0);
+}
+
+export function buildMobileAnalyticsFilterPresetStats(source = {}, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date();
+  return MOBILE_ANALYTICS_FILTER_PRESET_OPTIONS.map((preset) => {
+    const filterState = normalizeMobileAnalyticsFilterState(preset.filter);
+    const snapshot = buildMobileAnalyticsSnapshot(source, { now, filterState });
+    const count = resolveMobileAnalyticsFocusCount(snapshot, filterState.focus);
+    return {
+      ...preset,
+      filter: filterState,
+      count
+    };
+  }).sort((a, b) => b.count - a.count);
+}
+
 export function serializeMobileAnalyticsSnapshot(snapshot, now = new Date()) {
   const payload = {
     type: MOBILE_ANALYTICS_EXPORT_TYPE,
@@ -171,4 +339,74 @@ export function serializeMobileAnalyticsSnapshot(snapshot, now = new Date()) {
     snapshot
   };
   return JSON.stringify(payload, null, 2);
+}
+
+function hasFilterPresetStateShape(value) {
+  return Boolean(value && typeof value === "object" && ("pinnedPresetKeys" in value || "recentPresetKeys" in value));
+}
+
+function hasFilterStateShape(value) {
+  return Boolean(value && typeof value === "object" && ("periodKey" in value || "focus" in value));
+}
+
+export function serializeMobileAnalyticsFilterPresetTransfer(state, now = new Date()) {
+  const source = state && typeof state === "object" ? state : {};
+  const payload = {
+    type: MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_TYPE,
+    version: MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_VERSION,
+    exportedAt: now.toISOString(),
+    state: {
+      presetState: normalizeMobileAnalyticsFilterPresetState(source.presetState),
+      filterState: normalizeMobileAnalyticsFilterState(source.filterState)
+    }
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+export function parseMobileAnalyticsFilterPresetTransfer(raw) {
+  const text = String(raw ?? "").trim();
+  if (!text) {
+    return { ok: false, code: "empty_payload" };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, code: "invalid_json" };
+  }
+
+  if (hasFilterPresetStateShape(parsed)) {
+    return {
+      ok: true,
+      state: {
+        presetState: normalizeMobileAnalyticsFilterPresetState(parsed),
+        filterState: normalizeMobileAnalyticsFilterState({})
+      }
+    };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, code: "invalid_payload" };
+  }
+  if (parsed.type !== MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_TYPE) {
+    return { ok: false, code: "unsupported_type" };
+  }
+  if (parsed.version !== MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_VERSION) {
+    return { ok: false, code: "unsupported_version" };
+  }
+  if (!parsed.state || typeof parsed.state !== "object") {
+    return { ok: false, code: "invalid_state" };
+  }
+  const parsedPresetState = hasFilterPresetStateShape(parsed.state.presetState)
+    ? parsed.state.presetState
+    : parsed.state;
+  const parsedFilterState = hasFilterStateShape(parsed.state.filterState) ? parsed.state.filterState : {};
+  return {
+    ok: true,
+    state: {
+      presetState: normalizeMobileAnalyticsFilterPresetState(parsedPresetState),
+      filterState: normalizeMobileAnalyticsFilterState(parsedFilterState)
+    },
+    exportedAt: typeof parsed.exportedAt === "string" ? parsed.exportedAt : null
+  };
 }

--- a/apps/mobile/src/lib/mobileAnalyticsStore.js
+++ b/apps/mobile/src/lib/mobileAnalyticsStore.js
@@ -1,0 +1,47 @@
+import * as SecureStore from "expo-secure-store";
+
+import { normalizeMobileAnalyticsFilterPresetState } from "./mobileAnalytics";
+
+const ANALYTICS_FILTER_PRESET_STATE_KEY = "flowhr.mobile.analytics.filter-preset-state.v1";
+let inMemoryAnalyticsFilterPresetState = null;
+
+const defaultAnalyticsFilterPresetState = {
+  pinnedPresetKeys: ["allActionRequired", "approvalRisk"],
+  recentPresetKeys: []
+};
+
+function parseJson(raw, fallback) {
+  if (!raw) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+export async function loadMobileAnalyticsFilterPresetState() {
+  try {
+    const raw = await SecureStore.getItemAsync(ANALYTICS_FILTER_PRESET_STATE_KEY);
+    const parsed = parseJson(raw, defaultAnalyticsFilterPresetState);
+    const normalized = normalizeMobileAnalyticsFilterPresetState(parsed);
+    inMemoryAnalyticsFilterPresetState = normalized;
+    return normalized;
+  } catch {
+    return normalizeMobileAnalyticsFilterPresetState(
+      inMemoryAnalyticsFilterPresetState ?? defaultAnalyticsFilterPresetState
+    );
+  }
+}
+
+export async function saveMobileAnalyticsFilterPresetState(state) {
+  const normalized = normalizeMobileAnalyticsFilterPresetState(state);
+  inMemoryAnalyticsFilterPresetState = normalized;
+  try {
+    await SecureStore.setItemAsync(ANALYTICS_FILTER_PRESET_STATE_KEY, JSON.stringify(normalized));
+  } catch {
+    // fallback in unsupported environments
+  }
+  return normalized;
+}

--- a/apps/mobile/src/screens/AdminHomeScreen.js
+++ b/apps/mobile/src/screens/AdminHomeScreen.js
@@ -4,7 +4,7 @@ import ShellCard from "../components/ShellCard";
 import { colors, spacing } from "../theme/tokens";
 
 function action(label) {
-  Alert.alert("Coming Soon", `${label} 화면은 WI-0257~에서 확장됩니다.`);
+  Alert.alert("Coming Soon", `${label} 화면은 WI-0258~에서 확장됩니다.`);
 }
 
 export default function AdminHomeScreen({

--- a/apps/mobile/src/screens/EmployeeHomeScreen.js
+++ b/apps/mobile/src/screens/EmployeeHomeScreen.js
@@ -4,7 +4,7 @@ import ShellCard from "../components/ShellCard";
 import { colors, spacing } from "../theme/tokens";
 
 function action(label) {
-  Alert.alert("Coming Soon", `${label} 화면은 WI-0257~에서 확장됩니다.`);
+  Alert.alert("Coming Soon", `${label} 화면은 WI-0258~에서 확장됩니다.`);
 }
 
 export default function EmployeeHomeScreen({

--- a/apps/mobile/src/screens/MobileAnalyticsDashboardScreen.js
+++ b/apps/mobile/src/screens/MobileAnalyticsDashboardScreen.js
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 
+import MobileAnalyticsFilterPresetCard from "../components/MobileAnalyticsFilterPresetCard";
 import ShellCard from "../components/ShellCard";
 import { loadApprovalQueueItems } from "../lib/approvalQueueStore";
 import { loadEmployeeRequests } from "../lib/employeeRequestStore";
@@ -8,10 +9,19 @@ import {
   buildMobileAnalyticsSnapshot,
   buildMobileAnalyticsTrendSeries,
   formatMobileAnalyticsRate,
+  MOBILE_ANALYTICS_FOCUS_OPTIONS,
   MOBILE_ANALYTICS_PERIOD_OPTIONS,
+  pushMobileAnalyticsFilterPresetRecent,
+  resolveMobileAnalyticsFilterFromPreset,
+  resolveMobileAnalyticsFocusLabel,
+  resolveMobileAnalyticsFocusCount,
   resolveMobileAnalyticsPeriodDays,
   serializeMobileAnalyticsSnapshot
 } from "../lib/mobileAnalytics";
+import {
+  loadMobileAnalyticsFilterPresetState,
+  saveMobileAnalyticsFilterPresetState
+} from "../lib/mobileAnalyticsStore";
 import { loadNotificationInbox } from "../lib/notificationStore";
 import { colors, spacing } from "../theme/tokens";
 
@@ -34,7 +44,8 @@ export default function MobileAnalyticsDashboardScreen({
   const [approvals, setApprovals] = useState([]);
   const [requests, setRequests] = useState([]);
   const [notifications, setNotifications] = useState([]);
-  const [periodKey, setPeriodKey] = useState("7d");
+  const [filterState, setFilterState] = useState({ periodKey: "7d", focus: "all" });
+  const [presetState, setPresetState] = useState({ pinnedPresetKeys: [], recentPresetKeys: [] });
   const [exportPayload, setExportPayload] = useState("");
   const [snapshotAt, setSnapshotAt] = useState(new Date());
 
@@ -52,11 +63,13 @@ export default function MobileAnalyticsDashboardScreen({
 
   useEffect(() => {
     let active = true;
-    refreshAll()
-      .then(() => {
-        if (active) {
-          setLoading(false);
+    Promise.all([refreshAll(), loadMobileAnalyticsFilterPresetState()])
+      .then(([, savedPresetState]) => {
+        if (!active) {
+          return;
         }
+        setPresetState(savedPresetState);
+        setLoading(false);
       })
       .catch(() => {
         if (active) {
@@ -68,7 +81,7 @@ export default function MobileAnalyticsDashboardScreen({
     };
   }, []);
 
-  const periodDays = useMemo(() => resolveMobileAnalyticsPeriodDays(periodKey, 7), [periodKey]);
+  const periodDays = useMemo(() => resolveMobileAnalyticsPeriodDays(filterState.periodKey, 7), [filterState.periodKey]);
   const source = useMemo(
     () => ({ approvals, requests, notifications }),
     [approvals, notifications, requests]
@@ -76,6 +89,10 @@ export default function MobileAnalyticsDashboardScreen({
   const snapshot = useMemo(
     () => buildMobileAnalyticsSnapshot(source, { periodDays, now: snapshotAt }),
     [periodDays, snapshotAt, source]
+  );
+  const focusCount = useMemo(
+    () => resolveMobileAnalyticsFocusCount(snapshot, filterState.focus),
+    [filterState.focus, snapshot]
   );
   const trendSeries = useMemo(
     () => buildMobileAnalyticsTrendSeries(source, { periodDays, now: snapshotAt }),
@@ -98,6 +115,39 @@ export default function MobileAnalyticsDashboardScreen({
     setExportPayload("");
   }
 
+  async function applyFilterPreset(presetKey) {
+    const nextFilter = resolveMobileAnalyticsFilterFromPreset(presetKey, filterState);
+    setFilterState(nextFilter);
+
+    const nextRecent = pushMobileAnalyticsFilterPresetRecent(presetState.recentPresetKeys, presetKey).filter(
+      (key) => !presetState.pinnedPresetKeys.includes(key)
+    );
+    const nextPresetState = {
+      pinnedPresetKeys: presetState.pinnedPresetKeys,
+      recentPresetKeys: nextRecent
+    };
+    const saved = await saveMobileAnalyticsFilterPresetState(nextPresetState);
+    setPresetState(saved);
+  }
+
+  async function toggleFilterPresetPin(presetKey) {
+    const nextPinned = presetState.pinnedPresetKeys.includes(presetKey)
+      ? presetState.pinnedPresetKeys.filter((key) => key !== presetKey)
+      : [...presetState.pinnedPresetKeys, presetKey];
+    const nextPresetState = {
+      pinnedPresetKeys: nextPinned,
+      recentPresetKeys: presetState.recentPresetKeys.filter((key) => !nextPinned.includes(key))
+    };
+    const saved = await saveMobileAnalyticsFilterPresetState(nextPresetState);
+    setPresetState(saved);
+  }
+
+  async function importFilterPresetTransfer(nextState) {
+    const saved = await saveMobileAnalyticsFilterPresetState(nextState.presetState);
+    setPresetState(saved);
+    setFilterState(nextState.filterState);
+  }
+
   return (
     <SafeAreaView style={styles.page}>
       <ScrollView contentContainerStyle={styles.content}>
@@ -109,9 +159,20 @@ export default function MobileAnalyticsDashboardScreen({
             {MOBILE_ANALYTICS_PERIOD_OPTIONS.map((item) => (
               <Chip
                 key={item.key}
-                active={periodKey === item.key}
+                active={filterState.periodKey === item.key}
                 label={item.label}
-                onPress={() => setPeriodKey(item.key)}
+                onPress={() => setFilterState((prev) => ({ ...prev, periodKey: item.key }))}
+              />
+            ))}
+          </View>
+          <Text style={styles.meta}>focus: {resolveMobileAnalyticsFocusLabel(filterState.focus)}</Text>
+          <View style={styles.chipRow}>
+            {MOBILE_ANALYTICS_FOCUS_OPTIONS.map((item) => (
+              <Chip
+                key={item.key}
+                active={filterState.focus === item.key}
+                label={item.label}
+                onPress={() => setFilterState((prev) => ({ ...prev, focus: item.key }))}
               />
             ))}
           </View>
@@ -129,7 +190,17 @@ export default function MobileAnalyticsDashboardScreen({
           </Text>
         </ShellCard>
 
-        <ShellCard title="KPI snapshot" subtitle={loading ? "Loading..." : `${snapshot.kpi.actionRequired} action(s) required`}>
+        <MobileAnalyticsFilterPresetCard
+          source={source}
+          snapshotAt={snapshotAt}
+          filterState={filterState}
+          presetState={presetState}
+          onApplyPreset={applyFilterPreset}
+          onTogglePresetPin={toggleFilterPresetPin}
+          onImportPresetTransfer={importFilterPresetTransfer}
+        />
+
+        <ShellCard title="KPI snapshot" subtitle={loading ? "Loading..." : `${focusCount} focus item(s)`}>
           <Text style={styles.kpi}>action required: {snapshot.kpi.actionRequired}</Text>
           <Text style={styles.meta}>approvals pending: {snapshot.kpi.approvalsPending}</Text>
           <Text style={styles.meta}>requests pending action: {snapshot.kpi.requestsPendingAction}</Text>
@@ -140,24 +211,30 @@ export default function MobileAnalyticsDashboardScreen({
         </ShellCard>
 
         <ShellCard title="Domain breakdown">
-          <View style={styles.panel}>
-            <Text style={styles.panelTitle}>Approval queue</Text>
-            <Text style={styles.meta}>pending: {snapshot.domain.approval.pending}</Text>
-            <Text style={styles.meta}>high pending: {snapshot.domain.approval.highPriorityPending}</Text>
-            <Text style={styles.meta}>stalled 24h+: {snapshot.domain.approval.stalledOver24h}</Text>
-          </View>
-          <View style={styles.panel}>
-            <Text style={styles.panelTitle}>Employee requests</Text>
-            <Text style={styles.meta}>submitted: {snapshot.domain.request.submitted}</Text>
-            <Text style={styles.meta}>in review: {snapshot.domain.request.inReview}</Text>
-            <Text style={styles.meta}>approved: {snapshot.domain.request.approved}</Text>
-          </View>
-          <View style={styles.panel}>
-            <Text style={styles.panelTitle}>Notifications</Text>
-            <Text style={styles.meta}>active: {snapshot.domain.notification.total}</Text>
-            <Text style={styles.meta}>unread: {snapshot.domain.notification.unread}</Text>
-            <Text style={styles.meta}>approval request unread: {snapshot.domain.notification.categories.approvalRequest?.unread ?? 0}</Text>
-          </View>
+          {filterState.focus === "all" || filterState.focus === "approval" ? (
+            <View style={styles.panel}>
+              <Text style={styles.panelTitle}>Approval queue</Text>
+              <Text style={styles.meta}>pending: {snapshot.domain.approval.pending}</Text>
+              <Text style={styles.meta}>high pending: {snapshot.domain.approval.highPriorityPending}</Text>
+              <Text style={styles.meta}>stalled 24h+: {snapshot.domain.approval.stalledOver24h}</Text>
+            </View>
+          ) : null}
+          {filterState.focus === "all" || filterState.focus === "request" ? (
+            <View style={styles.panel}>
+              <Text style={styles.panelTitle}>Employee requests</Text>
+              <Text style={styles.meta}>submitted: {snapshot.domain.request.submitted}</Text>
+              <Text style={styles.meta}>in review: {snapshot.domain.request.inReview}</Text>
+              <Text style={styles.meta}>approved: {snapshot.domain.request.approved}</Text>
+            </View>
+          ) : null}
+          {filterState.focus === "all" || filterState.focus === "notification" ? (
+            <View style={styles.panel}>
+              <Text style={styles.panelTitle}>Notifications</Text>
+              <Text style={styles.meta}>active: {snapshot.domain.notification.total}</Text>
+              <Text style={styles.meta}>unread: {snapshot.domain.notification.unread}</Text>
+              <Text style={styles.meta}>approval request unread: {snapshot.domain.notification.categories.approvalRequest?.unread ?? 0}</Text>
+            </View>
+          ) : null}
         </ShellCard>
 
         <ShellCard title="Daily trend" subtitle={`${trendSeries.length} day(s)`}>

--- a/scripts/tests/e2e-wi0243-mobile-notification-center-realtime-baseline.test.ts
+++ b/scripts/tests/e2e-wi0243-mobile-notification-center-realtime-baseline.test.ts
@@ -21,8 +21,8 @@ async function run() {
 
   assert.match(roadmap, /WI-0243/);
   assert.match(workItem, /Mobile Notification Center Realtime Update Baseline/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
 
   assert.match(notificationScreen, /LIVE_SYNC_MS/);
   assert.match(notificationScreen, /setInterval/);

--- a/scripts/tests/e2e-wi0244-mobile-notification-history-search-archive-baseline.test.ts
+++ b/scripts/tests/e2e-wi0244-mobile-notification-history-search-archive-baseline.test.ts
@@ -27,8 +27,8 @@ async function run() {
   assert.match(navigator, /name=\"NotificationHistory\"/);
   assert.match(adminScreen, /onOpenNotificationHistory/);
   assert.match(employeeScreen, /onOpenNotificationHistory/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
 
   assert.match(centerScreen, /filterNotificationHistory/);
   assert.match(centerScreen, /onOpenHistory/);

--- a/scripts/tests/e2e-wi0245-mobile-notification-history-bulk-actions-baseline.test.ts
+++ b/scripts/tests/e2e-wi0245-mobile-notification-history-bulk-actions-baseline.test.ts
@@ -33,8 +33,8 @@ async function run() {
   assert.match(historyLib, /applyNotificationBulkAction/);
   assert.match(historyLib, /mergeNotificationSelection/);
   assert.match(historyLib, /pruneNotificationSelection/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /notification history bulk actions/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0246-mobile-notification-history-quick-preset-filters-baseline.test.ts
+++ b/scripts/tests/e2e-wi0246-mobile-notification-history-quick-preset-filters-baseline.test.ts
@@ -31,8 +31,8 @@ async function run() {
   assert.match(historyLib, /NOTIFICATION_HISTORY_PRESET_FILTERS/);
   assert.match(historyLib, /getNotificationPresetFilter/);
   assert.match(historyLib, /buildNotificationPresetCounts/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /notification history quick preset filters/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0247-mobile-notification-history-preset-pin-recent-baseline.test.ts
+++ b/scripts/tests/e2e-wi0247-mobile-notification-history-preset-pin-recent-baseline.test.ts
@@ -39,8 +39,8 @@ async function run() {
   assert.match(store, /loadNotificationHistoryPresetState/);
   assert.match(store, /saveNotificationHistoryPresetState/);
 
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /notification history preset pin\/recent persistence/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0248-mobile-notification-history-preset-import-export-baseline.test.ts
+++ b/scripts/tests/e2e-wi0248-mobile-notification-history-preset-import-export-baseline.test.ts
@@ -32,8 +32,8 @@ async function run() {
   assert.match(historyLib, /parseNotificationHistoryPresetState/);
   assert.match(historyLib, /NOTIFICATION_HISTORY_PRESET_TRANSFER_TYPE/);
   assert.match(store, /HISTORY_PRESET_STATE_KEY/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /notification history preset import\/export/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0249-mobile-admin-approval-queue-baseline.test.ts
+++ b/scripts/tests/e2e-wi0249-mobile-admin-approval-queue-baseline.test.ts
@@ -38,8 +38,8 @@ async function run() {
   assert.match(queueStore, /loadApprovalQueueItems/);
   assert.match(queueStore, /saveApprovalQueueItems/);
   assert.match(queueStore, /resetApprovalQueueItems/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /Admin approval queue shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0250-mobile-employee-self-service-request-submit-baseline.test.ts
+++ b/scripts/tests/e2e-wi0250-mobile-employee-self-service-request-submit-baseline.test.ts
@@ -38,8 +38,8 @@ async function run() {
   assert.match(requestStore, /flowhr\.mobile\.employee\.request\.v1/);
   assert.match(requestStore, /loadEmployeeRequests/);
   assert.match(requestStore, /saveEmployeeRequests/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /Employee request submit shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0251-mobile-employee-request-history-status-tracking-baseline.test.ts
+++ b/scripts/tests/e2e-wi0251-mobile-employee-request-history-status-tracking-baseline.test.ts
@@ -39,8 +39,8 @@ async function run() {
   assert.match(requestLib, /applyEmployeeRequestStatus/);
   assert.match(requestLib, /normalizeEmployeeRequestRecord/);
   assert.match(requestStore, /normalizeEmployeeRequestRecord/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeHome, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeHome, /WI-0258~/);
   assert.match(readme, /Employee request history\/status shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0252-mobile-employee-request-notification-follow-up-baseline.test.ts
+++ b/scripts/tests/e2e-wi0252-mobile-employee-request-notification-follow-up-baseline.test.ts
@@ -36,8 +36,8 @@ async function run() {
   assert.match(requestLib, /buildEmployeeRequestFollowUpStats/);
   assert.match(requestLib, /filterEmployeeRequestFollowUps/);
   assert.match(requestLib, /sortEmployeeRequestFollowUps/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeHome, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeHome, /WI-0258~/);
   assert.match(readme, /Employee request follow-up alert shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0253-mobile-employee-request-follow-up-template-recommendation-baseline.test.ts
+++ b/scripts/tests/e2e-wi0253-mobile-employee-request-follow-up-template-recommendation-baseline.test.ts
@@ -27,8 +27,8 @@ async function run() {
   assert.match(requestLib, /EMPLOYEE_REQUEST_FOLLOW_UP_TEMPLATE_OPTIONS/);
   assert.match(requestLib, /recommendEmployeeRequestFollowUpTemplate/);
   assert.match(requestLib, /buildEmployeeRequestFollowUpTemplateStats/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /Employee request follow-up recommendation template shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0254-mobile-employee-request-follow-up-action-bundle-saved-preset-baseline.test.ts
+++ b/scripts/tests/e2e-wi0254-mobile-employee-request-follow-up-action-bundle-saved-preset-baseline.test.ts
@@ -38,8 +38,8 @@ async function run() {
   assert.match(requestStore, /loadEmployeeRequestFollowUpPresetState/);
   assert.match(requestStore, /saveEmployeeRequestFollowUpPresetState/);
 
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /Employee request follow-up action bundle saved preset shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0255-mobile-employee-request-follow-up-preset-import-export-baseline.test.ts
+++ b/scripts/tests/e2e-wi0255-mobile-employee-request-follow-up-preset-import-export-baseline.test.ts
@@ -30,8 +30,8 @@ async function run() {
   assert.match(requestLib, /serializeEmployeeRequestFollowUpPresetState/);
   assert.match(requestLib, /parseEmployeeRequestFollowUpPresetState/);
   assert.match(requestLib, /EMPLOYEE_REQUEST_FOLLOW_UP_PRESET_TRANSFER_TYPE/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(readme, /Employee request follow-up preset import\/export transfer shell/);
 
   assert.ok(

--- a/scripts/tests/e2e-wi0256-mobile-analytics-dashboard-baseline.test.ts
+++ b/scripts/tests/e2e-wi0256-mobile-analytics-dashboard-baseline.test.ts
@@ -34,8 +34,8 @@ async function run() {
   assert.match(analyticsLib, /buildMobileAnalyticsTrendSeries/);
   assert.match(analyticsLib, /serializeMobileAnalyticsSnapshot/);
   assert.match(analyticsLib, /MOBILE_ANALYTICS_EXPORT_TYPE/);
-  assert.match(adminScreen, /WI-0257~/);
-  assert.match(employeeScreen, /WI-0257~/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
   assert.match(adminScreen, /분석 대시보드/);
   assert.match(employeeScreen, /분석 대시보드/);
   assert.match(readme, /Mobile analytics dashboard shell/);
@@ -45,8 +45,8 @@ async function run() {
     `RootNavigator.js should stay under 320 lines (current: ${countLines(navigator)})`
   );
   assert.ok(
-    countLines(analyticsScreen) <= 360,
-    `MobileAnalyticsDashboardScreen.js should stay under 360 lines (current: ${countLines(analyticsScreen)})`
+    countLines(analyticsScreen) <= 390,
+    `MobileAnalyticsDashboardScreen.js should stay under 390 lines (current: ${countLines(analyticsScreen)})`
   );
   assert.ok(
     countLines(adminScreen) <= 300,

--- a/scripts/tests/e2e-wi0257-mobile-analytics-dashboard-share-filter-preset-baseline.test.ts
+++ b/scripts/tests/e2e-wi0257-mobile-analytics-dashboard-share-filter-preset-baseline.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+function countLines(source: string) {
+  return source.trimEnd().split(/\r?\n/).length;
+}
+
+async function run() {
+  const roadmap = readUtf8("ROADMAP.md");
+  const workItem = readUtf8("work-items", "WI-0257-mobile-analytics-dashboard-share-filter-preset-baseline.md");
+  const analyticsScreen = readUtf8("apps", "mobile", "src", "screens", "MobileAnalyticsDashboardScreen.js");
+  const presetCard = readUtf8("apps", "mobile", "src", "components", "MobileAnalyticsFilterPresetCard.js");
+  const analyticsLib = readUtf8("apps", "mobile", "src", "lib", "mobileAnalytics.js");
+  const analyticsStore = readUtf8("apps", "mobile", "src", "lib", "mobileAnalyticsStore.js");
+  const adminScreen = readUtf8("apps", "mobile", "src", "screens", "AdminHomeScreen.js");
+  const employeeScreen = readUtf8("apps", "mobile", "src", "screens", "EmployeeHomeScreen.js");
+  const readme = readUtf8("apps", "mobile", "README.md");
+
+  assert.match(roadmap, /WI-0257/);
+  assert.match(workItem, /Mobile Analytics Dashboard Share\/Filter Preset Baseline/);
+  assert.match(analyticsScreen, /MobileAnalyticsFilterPresetCard/);
+  assert.match(analyticsScreen, /resolveMobileAnalyticsFilterFromPreset/);
+  assert.match(analyticsScreen, /loadMobileAnalyticsFilterPresetState/);
+  assert.match(analyticsScreen, /focus:/);
+  assert.match(presetCard, /Filter presets/);
+  assert.match(presetCard, /Pinned presets/);
+  assert.match(presetCard, /Recent presets/);
+  assert.match(presetCard, /Generate export payload/);
+  assert.match(presetCard, /Import payload/);
+  assert.match(analyticsLib, /MOBILE_ANALYTICS_FILTER_PRESET_OPTIONS/);
+  assert.match(analyticsLib, /resolveMobileAnalyticsFilterFromPreset/);
+  assert.match(analyticsLib, /serializeMobileAnalyticsFilterPresetTransfer/);
+  assert.match(analyticsLib, /parseMobileAnalyticsFilterPresetTransfer/);
+  assert.match(analyticsStore, /flowhr\.mobile\.analytics\.filter-preset-state\.v1/);
+  assert.match(analyticsStore, /loadMobileAnalyticsFilterPresetState/);
+  assert.match(analyticsStore, /saveMobileAnalyticsFilterPresetState/);
+  assert.match(adminScreen, /WI-0258~/);
+  assert.match(employeeScreen, /WI-0258~/);
+  assert.match(readme, /Mobile analytics dashboard share\/filter preset shell/);
+
+  assert.ok(
+    countLines(analyticsScreen) <= 380,
+    `MobileAnalyticsDashboardScreen.js should stay under 380 lines (current: ${countLines(analyticsScreen)})`
+  );
+  assert.ok(
+    countLines(presetCard) <= 320,
+    `MobileAnalyticsFilterPresetCard.js should stay under 320 lines (current: ${countLines(presetCard)})`
+  );
+
+  // @ts-expect-error Mobile sub-app baseline currently ships JS modules without d.ts.
+  const analyticsModule = await import("../../apps/mobile/src/lib/mobileAnalytics.js");
+  const {
+    MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_TYPE,
+    MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_VERSION,
+    buildMobileAnalyticsFilterPresetStats,
+    normalizeMobileAnalyticsFilterPresetState,
+    parseMobileAnalyticsFilterPresetTransfer,
+    pushMobileAnalyticsFilterPresetRecent,
+    resolveMobileAnalyticsFilterFromPreset,
+    serializeMobileAnalyticsFilterPresetTransfer,
+    toggleMobileAnalyticsFilterPresetPin
+  } = analyticsModule;
+
+  const source = {
+    approvals: [
+      { id: "a1", status: "pending", priority: "high", stalledHours: 30, submittedAt: "2026-02-23T09:00:00.000Z" },
+      { id: "a2", status: "approved", priority: "normal", stalledHours: 0, submittedAt: "2026-02-22T09:00:00.000Z" }
+    ],
+    requests: [
+      { id: "r1", requestType: "attendanceCorrection", status: "submitted", createdAt: "2026-02-23T08:00:00.000Z" },
+      { id: "r2", requestType: "leaveRequest", status: "inReview", createdAt: "2026-02-22T08:00:00.000Z" }
+    ],
+    notifications: [
+      { id: "n1", category: "approvalRequest", read: false, archivedAt: null, createdAt: "2026-02-23T07:00:00.000Z" },
+      { id: "n2", category: "approvalResult", read: true, archivedAt: null, createdAt: "2026-02-22T07:00:00.000Z" }
+    ]
+  };
+
+  const stats = buildMobileAnalyticsFilterPresetStats(source, { now: new Date("2026-02-23T12:00:00.000Z") });
+  assert.equal(stats.length, 4);
+  assert.ok(stats.every((item: any) => typeof item.count === "number"));
+  assert.ok(stats.some((item: any) => item.key === "approvalRisk"));
+
+  const resolved = resolveMobileAnalyticsFilterFromPreset("requestFlow", { periodKey: "7d", focus: "all" });
+  assert.equal(resolved.periodKey, "14d");
+  assert.equal(resolved.focus, "request");
+
+  const toggled = toggleMobileAnalyticsFilterPresetPin(["allActionRequired"], "approvalRisk");
+  assert.deepEqual(toggled, ["allActionRequired", "approvalRisk"]);
+  const untoggled = toggleMobileAnalyticsFilterPresetPin(toggled, "allActionRequired");
+  assert.deepEqual(untoggled, ["approvalRisk"]);
+
+  const recent = pushMobileAnalyticsFilterPresetRecent(["allActionRequired"], "requestFlow", 4);
+  assert.deepEqual(recent, ["requestFlow", "allActionRequired"]);
+
+  const normalized = normalizeMobileAnalyticsFilterPresetState({
+    pinnedPresetKeys: ["allActionRequired", "unknown", "allActionRequired"],
+    recentPresetKeys: ["approvalRisk", "allActionRequired", "notificationPulse"]
+  });
+  assert.deepEqual(normalized.pinnedPresetKeys, ["allActionRequired"]);
+  assert.deepEqual(normalized.recentPresetKeys, ["approvalRisk", "notificationPulse"]);
+
+  const payload = serializeMobileAnalyticsFilterPresetTransfer({
+    presetState: { pinnedPresetKeys: ["allActionRequired"], recentPresetKeys: ["approvalRisk"] },
+    filterState: { periodKey: "14d", focus: "request" }
+  });
+  assert.match(payload, new RegExp(MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_TYPE));
+
+  const parsed = parseMobileAnalyticsFilterPresetTransfer(payload);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.state.filterState.periodKey, "14d");
+  assert.equal(parsed.state.filterState.focus, "request");
+  assert.deepEqual(parsed.state.presetState.pinnedPresetKeys, ["allActionRequired"]);
+
+  const wrongVersion = parseMobileAnalyticsFilterPresetTransfer(
+    JSON.stringify({
+      type: MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_TYPE,
+      version: MOBILE_ANALYTICS_FILTER_PRESET_TRANSFER_VERSION + 1,
+      state: {
+        presetState: { pinnedPresetKeys: ["allActionRequired"], recentPresetKeys: [] },
+        filterState: { periodKey: "7d", focus: "all" }
+      }
+    })
+  );
+  assert.equal(wrongVersion.ok, false);
+  assert.equal(wrongVersion.code, "unsupported_version");
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0257-mobile-analytics-dashboard-share-filter-preset-baseline.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/work-items/WI-0257-mobile-analytics-dashboard-share-filter-preset-baseline.md
+++ b/work-items/WI-0257-mobile-analytics-dashboard-share-filter-preset-baseline.md
@@ -1,0 +1,66 @@
+# WI-0257: Mobile Analytics Dashboard Share/Filter Preset Baseline
+
+## Background
+
+WI-0256 introduced the mobile analytics dashboard, but users still had to manually re-apply
+period/focus combinations each time and lacked a transfer path for preset setup.
+
+## Scope
+
+### In Scope
+
+- analytics filter preset domain baseline
+  - `apps/mobile/src/lib/mobileAnalytics.js`
+  - preset catalog (`allActionRequired`/`approvalRisk`/`requestFlow`/`notificationPulse`)
+  - filter resolver + preset stats helper
+  - preset state helpers (sanitize/toggle pin/recent/normalize)
+  - preset transfer serializer/parser (`type`/`version`/`state`)
+- analytics preset persistence baseline
+  - `apps/mobile/src/lib/mobileAnalyticsStore.js`
+  - preset state load/save with secure-store key
+- analytics preset UX baseline
+  - `apps/mobile/src/components/MobileAnalyticsFilterPresetCard.js`
+  - pinned/recent preset chips
+  - preset apply + pin/unpin
+  - preset transfer payload export/import/clear
+- analytics dashboard integration
+  - `apps/mobile/src/screens/MobileAnalyticsDashboardScreen.js`
+  - period/focus filter sync with preset apply
+  - focus-based domain breakdown rendering
+- shell placeholder bump (`WI-0258~`)
+  - `apps/mobile/src/screens/EmployeeHomeScreen.js`
+  - `apps/mobile/src/screens/AdminHomeScreen.js`
+- docs and regression
+  - WI doc
+  - roadmap update
+  - WI-0257 e2e script
+
+### Out of Scope
+
+- backend-managed analytics preset sync
+- cross-tenant preset library and access control
+- native share-sheet/clipboard integration for preset payload
+
+## Validation
+
+- `npm.cmd exec tsx scripts/tests/e2e-wi0257-mobile-analytics-dashboard-share-filter-preset-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0256-mobile-analytics-dashboard-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0255-mobile-employee-request-follow-up-preset-import-export-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0254-mobile-employee-request-follow-up-action-bundle-saved-preset-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0253-mobile-employee-request-follow-up-template-recommendation-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0252-mobile-employee-request-notification-follow-up-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0251-mobile-employee-request-history-status-tracking-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0250-mobile-employee-self-service-request-submit-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0249-mobile-admin-approval-queue-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0248-mobile-notification-history-preset-import-export-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0247-mobile-notification-history-preset-pin-recent-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0246-mobile-notification-history-quick-preset-filters-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0245-mobile-notification-history-bulk-actions-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0244-mobile-notification-history-search-archive-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0243-mobile-notification-center-realtime-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0242-mobile-email-template-engine-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0241-mobile-push-notification-baseline.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0240-mobile-app-shell-baseline.test.ts`
+- `npm.cmd run lint`
+- `npm.cmd run typecheck`
+- `npm.cmd run build`


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0257-mobile-analytics-dashboard-share-filter-preset-baseline.md`
- Related Specs: N/A (mobile UI/helper enhancement)
- Related ADR: N/A

### Changes

- extend `apps/mobile/src/lib/mobileAnalytics.js` with analytics filter preset catalog, preset state helpers, focus resolver, preset stats, and preset transfer parser/serializer
- add `apps/mobile/src/lib/mobileAnalyticsStore.js` for secure-store backed analytics preset pin/recent persistence
- add `apps/mobile/src/components/MobileAnalyticsFilterPresetCard.js` for pinned/recent preset apply + pin/unpin + transfer import/export UI
- integrate preset flow into `MobileAnalyticsDashboardScreen` (period/focus sync, preset apply, transfer import, focus-aware domain breakdown)
- bump home placeholder marker to `WI-0258~` and sync all related e2e assertions
- add WI-0257 work item doc, roadmap update, and dedicated WI-0257 e2e coverage

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

Checklist notes:
- `contract.yaml`/`test-cases.md`/contract version bump are N/A for this UI-only mobile enhancement with no API/domain contract change.
- ADR not required because there is no breaking, cross-domain, or security-impacting change.

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

Executed commands:

- `npm.cmd exec tsx scripts/tests/e2e-wi0257-mobile-analytics-dashboard-share-filter-preset-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0256-mobile-analytics-dashboard-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0255-mobile-employee-request-follow-up-preset-import-export-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0254-mobile-employee-request-follow-up-action-bundle-saved-preset-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0253-mobile-employee-request-follow-up-template-recommendation-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0252-mobile-employee-request-notification-follow-up-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0251-mobile-employee-request-history-status-tracking-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0250-mobile-employee-self-service-request-submit-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0249-mobile-admin-approval-queue-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0248-mobile-notification-history-preset-import-export-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0247-mobile-notification-history-preset-pin-recent-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0246-mobile-notification-history-quick-preset-filters-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0245-mobile-notification-history-bulk-actions-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0244-mobile-notification-history-search-archive-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0243-mobile-notification-center-realtime-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0242-mobile-email-template-engine-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0241-mobile-push-notification-baseline.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0240-mobile-app-shell-baseline.test.ts`
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd run typecheck`

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `apps/mobile/src/components/MobileAnalyticsFilterPresetCard.js`, `apps/mobile/src/screens/MobileAnalyticsDashboardScreen.js`, `apps/mobile/src/screens/AdminHomeScreen.js`, `apps/mobile/src/screens/EmployeeHomeScreen.js`
- Backend-only reason: N/A
- Next UI WI: `work-items/WI-0258-mobile-analytics-dashboard-compare-report-baseline.md` (planned)

Closes: #323