### PR TITLE
feat: WI-0274 year-end withholding receipt document download

### DIFF
--- a/scripts/tests/e2e-wi0274-payroll-year-end-withholding-receipt-document-download.test.ts
+++ b/scripts/tests/e2e-wi0274-payroll-year-end-withholding-receipt-document-download.test.ts
@@ -1,0 +1,194 @@
+﻿import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+
+function readUtf8(...parts: string[]) {
+  return fs.readFileSync(path.resolve(process.cwd(), ...parts), "utf8");
+}
+
+function actorHeaders(role: string, actorId: string, organizationId?: string) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId
+  };
+  if (organizationId) {
+    headers["x-actor-organization-id"] = organizationId;
+  }
+  return headers;
+}
+
+function jsonRequest(method: string, urlPath: string, payload: unknown, headers: Record<string, string>) {
+  return new Request(`http://localhost${urlPath}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+function getRequest(urlPath: string, headers: Record<string, string>) {
+  return new Request(`http://localhost${urlPath}`, {
+    method: "GET",
+    headers
+  });
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+async function run() {
+  const { memoryDataAccess, resetMemoryDataAccess } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const withholdingReceiptRoute = await import(
+    "../../src/app/api/payroll/year-end/withholding-receipts/route.ts"
+  );
+
+  resetMemoryDataAccess();
+  runtimeEnv.FLOWHR_PAYROLL_YEAR_END_V1 = "true";
+
+  const payrollApiSpec = readUtf8("specs", "payroll", "api.yaml");
+  const payrollContract = readUtf8("specs", "payroll", "contract.yaml");
+  const payrollTestCases = readUtf8("specs", "payroll", "test-cases.md");
+  assert.match(payrollApiSpec, /Get issued withholding receipt document/i);
+  assert.match(payrollContract, /issued withholding receipt document read\/download workflow/i);
+  assert.match(payrollTestCases, /issued withholding receipt document/i);
+
+  const organization = await memoryDataAccess.organizations.create({
+    name: "Org Payroll Withholding Document"
+  });
+  await memoryDataAccess.employees.create({
+    id: "EMP-WDOC-1001",
+    organizationId: organization.id,
+    name: "Withholding Document Employee"
+  });
+  await memoryDataAccess.employees.create({
+    id: "EMP-WDOC-2002",
+    organizationId: organization.id,
+    name: "Other Employee"
+  });
+
+  const yearStart = new Date("2026-01-01T00:00:00+09:00");
+  const yearEnd = new Date("2026-12-31T23:59:59+09:00");
+  const runRecord = await memoryDataAccess.payroll.create({
+    organizationId: organization.id,
+    employeeId: "EMP-WDOC-1001",
+    periodStart: yearStart,
+    periodEnd: yearEnd,
+    grossPayKrw: 3_200_000,
+    withholdingTaxKrw: 120_000,
+    socialInsuranceKrw: 150_000,
+    otherDeductionsKrw: 20_000,
+    totalDeductionsKrw: 290_000,
+    netPayKrw: 2_910_000,
+    sourceRecordCount: 1
+  });
+
+  await memoryDataAccess.payroll.update(runRecord.id, {
+    state: "CONFIRMED",
+    confirmedAt: new Date("2026-12-31T09:00:00+09:00"),
+    confirmedBy: "PAY-WDOC-1001",
+    payslipDistributedAt: new Date("2026-12-31T09:10:00+09:00"),
+    payslipDistributedBy: "PAY-WDOC-1001",
+    payslipReceiptConfirmedAt: new Date("2026-12-31T09:20:00+09:00"),
+    payslipReceiptConfirmedBy: "EMP-WDOC-1001"
+  });
+
+  const notFoundDocumentResponse = await withholdingReceiptRoute.GET(
+    getRequest(
+      "/api/payroll/year-end/withholding-receipts?year=2026&employeeId=EMP-WDOC-1001&format=json",
+      actorHeaders("employee", "EMP-WDOC-1001", organization.id)
+    )
+  );
+  assert.equal(notFoundDocumentResponse.status, 404);
+
+  const issueResponse = await withholdingReceiptRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/year-end/withholding-receipts",
+      {
+        year: 2026,
+        employeeId: "EMP-WDOC-1001",
+        issue: true,
+        issuerName: "payroll-team"
+      },
+      actorHeaders("payroll_operator", "PAY-WDOC-1001", organization.id)
+    )
+  );
+  assert.equal(issueResponse.status, 200);
+
+  const documentJsonResponse = await withholdingReceiptRoute.GET(
+    getRequest(
+      "/api/payroll/year-end/withholding-receipts?year=2026&employeeId=EMP-WDOC-1001&format=json",
+      actorHeaders("employee", "EMP-WDOC-1001", organization.id)
+    )
+  );
+  assert.equal(documentJsonResponse.status, 200);
+  const documentJsonBody = await readJson<{
+    document: {
+      fileName: string;
+      format: "json" | "text";
+      contentType: string;
+      contentSha256: string;
+      issuedAt: string;
+      receipt: {
+        receiptNumber: string;
+      };
+      content: string;
+    };
+  }>(documentJsonResponse);
+  assert.equal(documentJsonBody.document.format, "json");
+  assert.equal(documentJsonBody.document.fileName, "withholding-receipt-2026-EMP-WDOC-1001.json");
+  assert.equal(documentJsonBody.document.contentType, "application/json; charset=utf-8");
+  assert.match(documentJsonBody.document.contentSha256, /^[a-f0-9]{64}$/);
+  assert.match(documentJsonBody.document.issuedAt, /^2026-/);
+  assert.match(documentJsonBody.document.content, /\"receiptNumber\": \"WR-2026-EMP-WDOC-1001\"/);
+
+  const documentTextResponse = await withholdingReceiptRoute.GET(
+    getRequest(
+      "/api/payroll/year-end/withholding-receipts?year=2026&employeeId=EMP-WDOC-1001&format=text",
+      actorHeaders("employee", "EMP-WDOC-1001", organization.id)
+    )
+  );
+  assert.equal(documentTextResponse.status, 200);
+  const documentTextBody = await readJson<{
+    document: {
+      fileName: string;
+      format: "json" | "text";
+      contentType: string;
+      content: string;
+    };
+  }>(documentTextResponse);
+  assert.equal(documentTextBody.document.format, "text");
+  assert.equal(documentTextBody.document.fileName, "withholding-receipt-2026-EMP-WDOC-1001.txt");
+  assert.equal(documentTextBody.document.contentType, "text/plain; charset=utf-8");
+  assert.match(documentTextBody.document.content, /^FlowHR Withholding Receipt/m);
+
+  const forbiddenOtherEmployeeResponse = await withholdingReceiptRoute.GET(
+    getRequest(
+      "/api/payroll/year-end/withholding-receipts?year=2026&employeeId=EMP-WDOC-1001&format=json",
+      actorHeaders("employee", "EMP-WDOC-2002", organization.id)
+    )
+  );
+  assert.equal(forbiddenOtherEmployeeResponse.status, 403);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0274-payroll-year-end-withholding-receipt-document-download.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.53.0
+  version: 1.54.0
 paths:
   /payroll/runs:
     get:
@@ -332,6 +332,29 @@ paths:
         "200":
           description: Filing evidence note appended
   /payroll/year-end/withholding-receipts:
+    get:
+      summary: Get issued withholding receipt document for employee/year
+      description: Reads latest issued withholding receipt artifact from audit-backed year-end snapshot for selected employee/year. Supports `format=json|text`, returns deterministic `contentSha256`, and rejects when issued receipt is missing.
+      parameters:
+        - in: query
+          name: year
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: employeeId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: format
+          required: false
+          schema:
+            type: string
+            enum: [json, text]
+      responses:
+        "200":
+          description: Issued withholding receipt document generated
     post:
       summary: Preview or issue withholding receipt for employee/year
       description: Returns withholding receipt readiness summary. When `issue=true`, issuance is blocked until all yearly runs are confirmed, distributed, and receipt-confirmed.

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,5 +1,5 @@
 owner: payroll-agent
-version: 1.53.0
+version: 1.54.0
 scope:
   in:
     - gross pay preview from approved attendance aggregates
@@ -31,6 +31,7 @@ scope:
     - payroll withholding settlement and period-close preview/apply workflow for confirmed payroll runs
     - payslip distribution and employee receipt confirmation workflow for confirmed payroll runs
     - year-end settlement preview and withholding receipt preview/issue workflow for employee annual payroll totals
+    - year-end issued withholding receipt document read/download workflow (`format=json|text`) for employee self-service and operator support
     - year-end deduction-item input and settlement recalculation workflow for employee annual payroll totals
     - year-end insurance reconciliation report workflow (confirmed-run social-insurance totals vs finalized deduction trace)
     - year-end preflight checklist workflow before finalization (run/distribution/receipt/submission/non-taxable/hash checks)
@@ -71,11 +72,11 @@ entities:
 api:
   auth:
     - role: payroll_operator
-      permission: run payroll preview (including 4-insurance settlement preview), preview/apply period close, distribute payslips, preview/issue/recalculate/finalize year-end settlement, export/submit/resubmit/cancel/reopen/ack/list/filter/summarize timeline/add evidence-note/list ack-catalog filing data packages, list runs, list/manage deduction profiles, and confirm run
+      permission: run payroll preview (including 4-insurance settlement preview), preview/apply period close, distribute payslips, preview/issue/recalculate/finalize year-end settlement, read issued withholding receipt document, export/submit/resubmit/cancel/reopen/ack/list/filter/summarize timeline/add evidence-note/list ack-catalog filing data packages, list runs, list/manage deduction profiles, and confirm run
     - role: admin
       permission: full payroll operations
     - role: employee
-      permission: list own confirmed payroll runs for payslip self-service, confirm own payslip receipt, and preview own year-end withholding receipt (employeeId must match actor id)
+      permission: list own confirmed payroll runs for payslip self-service, confirm own payslip receipt, and preview/read own year-end withholding receipt artifacts (employeeId must match actor id)
   endpoints:
     - method: GET
       path: /payroll/runs
@@ -146,6 +147,9 @@ api:
     - method: POST
       path: /payroll/year-end/filing-submissions/{submissionId}/evidence-note
       description: Add evidence note to selected filing submission for compliance traceability.
+    - method: GET
+      path: /payroll/year-end/withholding-receipts
+      description: Read latest issued withholding receipt document artifact by employee/year with `format=json|text`, deterministic content hash, and own/tenant authorization guard.
     - method: POST
       path: /payroll/year-end/withholding-receipts
       description: Preview or issue withholding receipt for selected employee/year; issuance requires confirmed+distributed+receipt-confirmed run chain.
@@ -374,6 +378,7 @@ test_plan:
     - year-end filing timeline event builder and ordering formulas
     - year-end filing evidence-note append payload formulas
     - withholding receipt issue guard (confirmed/distributed/receipt-confirmed chain)
+    - withholding receipt issued-document artifact formatter (`json|text`) and deterministic content-hash formula
     - rounding behavior for KRW totals
     - payroll run list query parsing and role guard
     - deduction profile list query parsing and role guard
@@ -434,6 +439,7 @@ test_plan:
     - year-end filing submission list returns deterministic summary counters and filtered subsets by status/ackStatus/validationStatus/transport/search/sort query
     - year-end filing evidence-note rejects unknown submission and disabled flag state
     - withholding receipt issue rejects issuance when previewed/undistributed/pending-receipt runs remain
+    - issued withholding receipt document read API rejects missing-issued snapshot and unauthorized other-employee access
     - year-end APIs reject requests when payroll_year_end_v1 is disabled
     - year-end recalculation API rejects requests when payroll_year_end_deduction_input_v1 is disabled
     - year-end finalization/export APIs reject requests when payroll_year_end_filing_export_v1 is disabled
@@ -477,6 +483,7 @@ test_plan:
     - year-end insurance reconciliation report deterministic replay via WI-0271 e2e
     - year-end preflight checklist deterministic replay via WI-0272 e2e
     - year-end hash-guard unified regression suite deterministic replay via WI-0273 e2e
+    - year-end issued withholding receipt document read/download deterministic replay via WI-0274 e2e
     - year-end finalization and filing-export deterministic replay via WI-0189 e2e
     - year-end filing multi-format/validation deterministic replay via WI-0190 e2e
     - year-end filing submission/ack deterministic replay via WI-0191 e2e
@@ -508,6 +515,7 @@ test_plan:
     - payroll_operator role enforcement for year-end filing cancel/reopen APIs
     - payroll_operator role enforcement for year-end filing timeline/evidence-note APIs
     - employee/payroll role guard for year-end withholding receipt preview/issue API
+    - employee/payroll role guard for year-end issued withholding receipt document read API
   payroll_accuracy:
     - overtime/night/holiday category payout checks
     - deduction sum and net-pay deterministic checks
@@ -533,6 +541,7 @@ test_plan:
     - close-period withholding/social/net aggregation and settlement-delta checks
     - payslip distribution and receipt confirmation state transitions stay deterministic
     - year-end tax-liability/withholding-delta and receipt-issue guard transitions stay deterministic
+    - year-end issued withholding receipt document content/hash output remains deterministic for same issued snapshot replay
     - year-end withholding delta refund/additional-due breakdown remains deterministic for same input vectors
     - year-end finalization settlementHash and stale-apply guard decisions remain deterministic for same input vectors
     - year-end filing export/submit/resubmit/acknowledge settlementHash guard decisions remain deterministic for same finalized snapshot vectors
@@ -590,6 +599,7 @@ observability:
     - payroll.year_end.withholding_receipt_previewed
     - payroll.year_end.withholding_receipt_issued
     - payroll.year_end.withholding_receipt.failed
+    - payroll.year_end.withholding_receipt_document.failed
     - payroll.deduction_profile.updated
     - payroll.confirmed
   metrics:
@@ -648,7 +658,7 @@ rollback:
   max_recovery_time: 30m
 deprecations: []
 breaking_changes: false
-consumer_impact: "Contract v1.53.0 additively documents unified year-end hash-guard regression coverage (WI-0273) for finalize/export/submit/ack/resubmit/list settlement-hash filter paths (no runtime breaking API change), while preserving existing preflight checklist/reporting, deduction/tax-credit explainability, settlement-hash guards, and settlement-hash list filter workflows plus withholding breakdown/non-taxable upper-bound/deduction-eligibility/deduction-cap/tax-credit-cap behaviors across payroll preview/confirm/profile/statutory preset/split/item-array, insurance-settlement, close-period, payslip delivery/receipt, and year-end preview/recalculate/finalize/export/submission/timeline/evidence-note/resubmit/cancel/reopen/ack/withholding-receipt APIs."
+consumer_impact: "Contract v1.54.0 additively introduces issued withholding receipt document read/download coverage (WI-0274) on `GET /payroll/year-end/withholding-receipts` with `format=json|text`, deterministic content hash output, and own/tenant authorization guard semantics, while preserving existing year-end settlement/finalization/export/filing/preflight/reconciliation/hash-guard workflows (no breaking API change)."
 references:
   - specs/common/time-and-payroll-rules.md
   - specs/payroll/phase2-compatibility-matrix.md
@@ -691,6 +701,7 @@ references:
   - work-items/WI-0271-payroll-year-end-insurance-reconciliation-report.md
   - work-items/WI-0272-payroll-year-end-preflight-checklist.md
   - work-items/WI-0273-payroll-year-end-hash-guard-regression-suite.md
+  - work-items/WI-0274-payroll-year-end-withholding-receipt-document-download.md
   - work-items/WI-0110-payroll-statutory-golden-regression.md
   - work-items/WI-0184-payroll-insurance-settlement-baseline.md
   - work-items/WI-0185-payroll-withholding-close-period-baseline.md

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -80,6 +80,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 72. Year-end insurance reconciliation report returns annual run social-insurance baseline, finalized insurance-premium comparison, reconciliation status, and monthly breakdown for selected employee/year.
 73. Year-end preflight checklist returns deterministic pass/fail/warn checks and ready-to-finalize summary for run/distribution/receipt/submission/non-taxable/hash guards.
 74. Unified year-end hash guard regression suite validates finalize/export/submit/ack/resubmit/list settlement-hash filter guards in a single deterministic replay scenario.
+75. Issued withholding receipt document read API returns deterministic artifact metadata/content (`format=json|text`, `contentSha256`) and rejects missing-issued snapshot or unauthorized employee access.
 
 ## Accuracy Cases
 
@@ -149,6 +150,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 63. Year-end insurance reconciliation report delta/status and monthly breakdown remain deterministic for same run/finalization replay.
 64. Year-end preflight checklist summary and check-detail outputs remain deterministic for same run/submission/finalization/non-taxable input replay.
 65. Unified year-end hash guard regression suite remains deterministic for same finalized snapshot and submission action replay sequence.
+66. Year-end issued withholding receipt document content/hash output remains deterministic for same issued snapshot replay.
 
 ## Regression Linkage
 
@@ -203,6 +205,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 - Year-End Insurance Reconciliation Gate: insurance reconciliation report API returns deterministic annual/monthly comparison and status summary.
 - Year-End Preflight Checklist Gate: preflight checklist API returns deterministic finalize-readiness and guard-detail outputs.
 - Year-End Hash Guard Regression Suite Gate: unified e2e replay covers finalize/export/submit/ack/resubmit/list settlement-hash guards end-to-end.
+- Year-End Withholding Receipt Document Gate: issued-document read API returns deterministic artifact metadata/content hash for same issued snapshot and enforces own/tenant authorization guard.
 - Year-End Deduction Cap Gate: year-end deduction item caps and cap-applied breakdown remain deterministic and auditable across recalculation/finalization/export APIs.
 - Year-End Tax Credit Cap Gate: year-end tax credit caps and cap-applied breakdown remain deterministic and auditable across preview/recalculation/finalization/export APIs.
 - Year-End Finalization/Export Gate: year-end finalization and filing-export APIs remain feature-flagged, permission-guarded, and deterministic with finalized-settlement precondition.

--- a/src/app/api/payroll/year-end/withholding-receipts/route.ts
+++ b/src/app/api/payroll/year-end/withholding-receipts/route.ts
@@ -1,5 +1,11 @@
-import { issuePayrollYearEndWithholdingReceiptSchema } from "@/features/payroll/schemas";
-import { issuePayrollYearEndWithholdingReceipt } from "@/features/payroll/service";
+import {
+  getPayrollYearEndWithholdingReceiptDocumentQuerySchema,
+  issuePayrollYearEndWithholdingReceiptSchema
+} from "@/features/payroll/schemas";
+import {
+  getPayrollYearEndWithholdingReceiptDocument,
+  issuePayrollYearEndWithholdingReceipt
+} from "@/features/payroll/service";
 import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
 import { isServiceError } from "@/features/shared/service-error";
 import { readActor } from "@/lib/actor";
@@ -7,6 +13,59 @@ import { fail, ok } from "@/lib/http";
 
 function shouldAuditYearEndReceiptFailure(status: number) {
   return status === 403 || status === 409;
+}
+
+function shouldAuditYearEndReceiptDocumentFailure(status: number) {
+  return status === 403 || status === 404 || status === 409;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const parsed = getPayrollYearEndWithholdingReceiptDocumentQuerySchema.safeParse({
+    year: url.searchParams.get("year"),
+    employeeId: url.searchParams.get("employeeId"),
+    format: url.searchParams.get("format") ?? undefined
+  });
+  if (!parsed.success) {
+    return fail(400, "invalid query", parsed.error.flatten());
+  }
+
+  const actor = await readActor(request);
+  const dataAccess = getRuntimeDataAccess();
+  const entityId = `${parsed.data.year}_${parsed.data.employeeId}`;
+
+  try {
+    const result = await getPayrollYearEndWithholdingReceiptDocument(
+      {
+        actor,
+        dataAccess
+      },
+      parsed.data
+    );
+    return ok(result);
+  } catch (error) {
+    if (isServiceError(error)) {
+      if (shouldAuditYearEndReceiptDocumentFailure(error.status)) {
+        try {
+          await dataAccess.audit.append({
+            action: "payroll.year_end.withholding_receipt_document.failed",
+            entityType: "PayrollYearEnd",
+            entityId,
+            actorRole: actor?.role ?? "system",
+            actorId: actor?.id ?? undefined,
+            payload: {
+              status: error.status,
+              message: error.message
+            }
+          });
+        } catch {
+          // Do not block response path by telemetry write failure.
+        }
+      }
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
 }
 
 export async function POST(request: Request) {

--- a/src/components/withholding-receipt/WithholdingReceiptConsole.tsx
+++ b/src/components/withholding-receipt/WithholdingReceiptConsole.tsx
@@ -5,7 +5,11 @@ import { useMemo, useState } from "react";
 
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useStickyStringState } from "@/lib/client/useStickyState";
-import type { ApiLog, WithholdingReceiptResponse } from "@/components/withholding-receipt/types";
+import type {
+  ApiLog,
+  WithholdingReceiptDocumentResponse,
+  WithholdingReceiptResponse
+} from "@/components/withholding-receipt/types";
 import { currentYear, formatKrw } from "@/components/withholding-receipt/types";
 
 function parseRequiredInt(value: string, fieldName: string) {
@@ -21,9 +25,11 @@ export default function WithholdingReceiptConsole() {
   const [employeeId, setEmployeeId] = useStickyStringState("flowhr:ctx:employeeId", "EMP-1001");
   const [accessToken, setAccessToken] = useState("");
   const [year, setYear] = useState(String(currentYear()));
+  const [documentFormat, setDocumentFormat] = useState<"json" | "text">("json");
   const [pendingLabel, setPendingLabel] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState("");
   const [receipt, setReceipt] = useState<WithholdingReceiptResponse | null>(null);
+  const [receiptDocument, setReceiptDocument] = useState<WithholdingReceiptDocumentResponse | null>(null);
   const [logs, setLogs] = useState<ApiLog[]>([]);
 
   const isProductionRuntime = process.env.NODE_ENV === "production";
@@ -90,6 +96,60 @@ export default function WithholdingReceiptConsole() {
     }
   }
 
+  function downloadDocument(document: WithholdingReceiptDocumentResponse["document"]) {
+    const blob = new Blob([document.content], { type: document.contentType });
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = window.document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = document.fileName;
+    window.document.body.appendChild(anchor);
+    anchor.click();
+    window.document.body.removeChild(anchor);
+    URL.revokeObjectURL(objectUrl);
+  }
+
+  async function loadIssuedDocument() {
+    try {
+      setPendingLabel("withholding receipt document");
+      const query = new URLSearchParams({
+        year: String(parseRequiredInt(year, "year")),
+        employeeId: employeeId.trim(),
+        format: documentFormat
+      });
+      const response = await fetch(
+        `/api/payroll/year-end/withholding-receipts?${query.toString()}`,
+        {
+          method: "GET",
+          headers: buildHeaders()
+        }
+      );
+      const body = (await response.json()) as
+        | WithholdingReceiptDocumentResponse
+        | { error: string };
+      setLogs((prev) => [
+        {
+          id: Date.now(),
+          label: "load withholding receipt document",
+          status: response.status,
+          ok: response.ok,
+          at: new Date().toLocaleString("ko-KR")
+        },
+        ...prev
+      ]);
+      if (!response.ok || "error" in body) {
+        setStatusMessage("request failed; check logs");
+        return;
+      }
+      setReceiptDocument(body);
+      setStatusMessage(`loaded document ${body.document.fileName}`);
+      setTimeout(() => setStatusMessage(""), 3000);
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : "invalid input");
+    } finally {
+      setPendingLabel(null);
+    }
+  }
+
   return (
     <main className="saas-content">
       <header className="hero">
@@ -103,11 +163,22 @@ export default function WithholdingReceiptConsole() {
           <div className="input-grid">
             <label>Year<input value={year} onChange={(event) => setYear(event.target.value)} /></label>
             <label>Employee ID<input value={employeeId} onChange={(event) => setEmployeeId(event.target.value)} /></label>
+            <label>
+              Document Format
+              <select
+                value={documentFormat}
+                onChange={(event) => setDocumentFormat(event.target.value === "text" ? "text" : "json")}
+              >
+                <option value="json">json</option>
+                <option value="text">text</option>
+              </select>
+            </label>
           </div>
           <label>Access Token (optional)<input value={accessToken} onChange={(event) => setAccessToken(event.target.value)} placeholder="Bearer token" /></label>
           <label>Organization ID (dev fallback)<input value={organizationId} onChange={(event) => setOrganizationId(event.target.value)} /></label>
           <div className="panel-actions">
             <button className="btn btn-primary" onClick={() => void previewReceipt()} disabled={pendingLabel !== null}>Preview Receipt</button>
+            <button className="btn btn-secondary" onClick={() => void loadIssuedDocument()} disabled={pendingLabel !== null}>Load Issued Document</button>
           </div>
           {statusMessage ? <p className="small">{statusMessage}</p> : null}
           {supabaseSessionError ? <p className="small fail">Session error: {supabaseSessionError}</p> : null}
@@ -123,6 +194,26 @@ export default function WithholdingReceiptConsole() {
               <li><span>Pending Receipt Runs</span><strong>{receipt.receipt.runStates.pendingReceiptRunIds.join(", ") || "-"}</strong></li>
               <li><span>Blocking Reasons</span><strong>{receipt.receipt.blockingReasons.join(" | ") || "-"}</strong></li>
             </ul>
+          )}
+          {!receiptDocument ? <p className="small">No issued document loaded.</p> : (
+            <>
+              <ul className="simple-list">
+                <li><span>Document File</span><strong>{receiptDocument.document.fileName}</strong></li>
+                <li><span>Format / Type</span><strong>{receiptDocument.document.format} / {receiptDocument.document.contentType}</strong></li>
+                <li><span>Issued At</span><strong>{receiptDocument.document.issuedAt}</strong></li>
+                <li><span>Generated At</span><strong>{receiptDocument.document.generatedAt}</strong></li>
+                <li><span>Content SHA256</span><strong>{receiptDocument.document.contentSha256.slice(0, 16)}...</strong></li>
+              </ul>
+              <div className="panel-actions">
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => downloadDocument(receiptDocument.document)}
+                >
+                  Download Loaded Document
+                </button>
+              </div>
+              <pre className="small">{receiptDocument.document.content.slice(0, 1000)}</pre>
+            </>
           )}
         </article>
         <article className="panel">

--- a/src/components/withholding-receipt/types.ts
+++ b/src/components/withholding-receipt/types.ts
@@ -30,6 +30,23 @@ export type WithholdingReceiptResponse = {
   };
 };
 
+export type WithholdingReceiptDocumentResponse = {
+  document: {
+    year: number;
+    employeeId: string;
+    receiptNumber: string;
+    issuedAt: string;
+    issuerName: string;
+    format: "json" | "text";
+    fileName: string;
+    contentType: string;
+    contentSha256: string;
+    generatedAt: string;
+    receipt: WithholdingReceiptResponse["receipt"];
+    content: string;
+  };
+};
+
 export type ApiLog = {
   id: number;
   label: string;

--- a/src/features/payroll/schemas.ts
+++ b/src/features/payroll/schemas.ts
@@ -485,6 +485,12 @@ export const issuePayrollYearEndWithholdingReceiptSchema = z.object({
   issuerName: z.string().min(1).max(120).optional()
 });
 
+export const getPayrollYearEndWithholdingReceiptDocumentQuerySchema = z.object({
+  year: z.coerce.number().int().min(2020).max(2100),
+  employeeId: z.string().min(1),
+  format: z.enum(["json", "text"]).default("json")
+});
+
 export const getPayrollYearEndInsuranceReconciliationReportQuerySchema = z.object({
   year: z.coerce.number().int().min(2020).max(2100),
   employeeId: z.string().min(1)

--- a/src/features/payroll/service.ts
+++ b/src/features/payroll/service.ts
@@ -353,6 +353,14 @@ type IssuePayrollYearEndWithholdingReceiptInput = {
   issuerName?: string;
 };
 
+type PayrollYearEndWithholdingReceiptDocumentFormat = "json" | "text";
+
+type GetPayrollYearEndWithholdingReceiptDocumentInput = {
+  year: number;
+  employeeId: string;
+  format: PayrollYearEndWithholdingReceiptDocumentFormat;
+};
+
 type GetPayrollYearEndInsuranceReconciliationReportInput = {
   year: number;
   employeeId: string;
@@ -856,37 +864,56 @@ type ListPayrollYearEndFilingAckCatalogResult = {
   rejectionReasons: PayrollYearEndFilingRejectionReasonCatalogItem[];
 };
 
+type PayrollYearEndWithholdingReceiptSummary = {
+  year: number;
+  employeeId: string;
+  periodStart: string;
+  periodEnd: string;
+  issue: boolean;
+  canIssue: boolean;
+  issued: boolean;
+  receiptNumber: string;
+  issuerName: string;
+  issuedAt: string | null;
+  runStates: {
+    totalRuns: number;
+    confirmedRuns: number;
+    previewedRuns: number;
+    undistributedRuns: number;
+    pendingReceiptRuns: number;
+    previewedRunIds: string[];
+    undistributedRunIds: string[];
+    pendingReceiptRunIds: string[];
+  };
+  annualTotalsKrw: {
+    grossPayKrw: number;
+    withholdingTaxKrw: number;
+    socialInsuranceKrw: number;
+    otherDeductionsKrw: number;
+    totalDeductionsKrw: number;
+    netPayKrw: number;
+  };
+  blockingReasons: string[];
+};
+
 type IssuePayrollYearEndWithholdingReceiptResult = {
-  receipt: {
+  receipt: PayrollYearEndWithholdingReceiptSummary;
+};
+
+type GetPayrollYearEndWithholdingReceiptDocumentResult = {
+  document: {
     year: number;
     employeeId: string;
-    periodStart: string;
-    periodEnd: string;
-    issue: boolean;
-    canIssue: boolean;
-    issued: boolean;
     receiptNumber: string;
+    issuedAt: string;
     issuerName: string;
-    issuedAt: string | null;
-    runStates: {
-      totalRuns: number;
-      confirmedRuns: number;
-      previewedRuns: number;
-      undistributedRuns: number;
-      pendingReceiptRuns: number;
-      previewedRunIds: string[];
-      undistributedRunIds: string[];
-      pendingReceiptRunIds: string[];
-    };
-    annualTotalsKrw: {
-      grossPayKrw: number;
-      withholdingTaxKrw: number;
-      socialInsuranceKrw: number;
-      otherDeductionsKrw: number;
-      totalDeductionsKrw: number;
-      netPayKrw: number;
-    };
-    blockingReasons: string[];
+    format: PayrollYearEndWithholdingReceiptDocumentFormat;
+    fileName: string;
+    contentType: string;
+    contentSha256: string;
+    generatedAt: string;
+    receipt: PayrollYearEndWithholdingReceiptSummary;
+    content: string;
   };
 };
 
@@ -3273,6 +3300,80 @@ function asYearEndFinalizationAuditPayload(payload: unknown): YearEndFinalizatio
     return null;
   }
   return candidate as YearEndFinalizationAuditPayload;
+}
+
+function asYearEndWithholdingReceiptSummaryPayload(
+  payload: unknown
+): PayrollYearEndWithholdingReceiptSummary | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const candidate = payload as Partial<PayrollYearEndWithholdingReceiptSummary>;
+  if (
+    typeof candidate.year !== "number" ||
+    typeof candidate.employeeId !== "string" ||
+    typeof candidate.receiptNumber !== "string" ||
+    typeof candidate.issuerName !== "string" ||
+    typeof candidate.issued !== "boolean" ||
+    typeof candidate.issuedAt !== "string" ||
+    !candidate.runStates ||
+    !candidate.annualTotalsKrw
+  ) {
+    return null;
+  }
+  return candidate as PayrollYearEndWithholdingReceiptSummary;
+}
+
+function buildYearEndWithholdingReceiptDocumentArtifact(
+  receipt: PayrollYearEndWithholdingReceiptSummary,
+  format: PayrollYearEndWithholdingReceiptDocumentFormat
+) {
+  if (format === "text") {
+    const lines = [
+      "FlowHR Withholding Receipt",
+      "",
+      `Year: ${receipt.year}`,
+      `Employee ID: ${receipt.employeeId}`,
+      `Receipt Number: ${receipt.receiptNumber}`,
+      `Issued At: ${receipt.issuedAt ?? "-"}`,
+      `Issuer: ${receipt.issuerName}`,
+      "",
+      "Annual Totals (KRW)",
+      `- Gross Pay: ${receipt.annualTotalsKrw.grossPayKrw.toLocaleString("ko-KR")}`,
+      `- Withholding Tax: ${receipt.annualTotalsKrw.withholdingTaxKrw.toLocaleString("ko-KR")}`,
+      `- Social Insurance: ${receipt.annualTotalsKrw.socialInsuranceKrw.toLocaleString("ko-KR")}`,
+      `- Other Deductions: ${receipt.annualTotalsKrw.otherDeductionsKrw.toLocaleString("ko-KR")}`,
+      `- Total Deductions: ${receipt.annualTotalsKrw.totalDeductionsKrw.toLocaleString("ko-KR")}`,
+      `- Net Pay: ${receipt.annualTotalsKrw.netPayKrw.toLocaleString("ko-KR")}`,
+      "",
+      "Run States",
+      `- Total: ${receipt.runStates.totalRuns}`,
+      `- Confirmed: ${receipt.runStates.confirmedRuns}`,
+      `- Previewed: ${receipt.runStates.previewedRuns}`,
+      `- Undistributed: ${receipt.runStates.undistributedRuns}`,
+      `- Pending Receipt: ${receipt.runStates.pendingReceiptRuns}`,
+      "",
+      `Blocking Reasons: ${receipt.blockingReasons.join(" | ") || "-"}`,
+      ""
+    ];
+    return {
+      content: lines.join("\n"),
+      contentType: "text/plain; charset=utf-8",
+      fileName: `withholding-receipt-${receipt.year}-${receipt.employeeId}.txt`
+    };
+  }
+
+  return {
+    content: JSON.stringify(
+      {
+        receipt
+      },
+      null,
+      2
+    ),
+    contentType: "application/json; charset=utf-8",
+    fileName: `withholding-receipt-${receipt.year}-${receipt.employeeId}.json`
+  };
 }
 
 function buildYearEndFilingRecords(runs: PayrollRunEntity[]): YearEndFilingRecord[] {
@@ -5744,6 +5845,67 @@ export async function getPayrollYearEndPreflightChecklist(
         settlementHash
       },
       checks
+    }
+  };
+}
+
+export async function getPayrollYearEndWithholdingReceiptDocument(
+  context: ServiceContext,
+  input: GetPayrollYearEndWithholdingReceiptDocumentInput
+): Promise<GetPayrollYearEndWithholdingReceiptDocumentResult> {
+  if (!isPayrollYearEndEnabled()) {
+    throw new ServiceError(409, "payroll_year_end_v1 feature flag is disabled");
+  }
+
+  const actor = context.actor;
+  if (!actor) {
+    throw new ServiceError(401, "missing or invalid actor context");
+  }
+
+  await requireEmployeeWithinTenant(context.dataAccess, actor, input.employeeId);
+  const permissions = await resolveActorPermissions({ actor, dataAccess: context.dataAccess });
+  const canManage = permissions.has(Permissions.payrollRunConfirm);
+  const canListAny = permissions.has(Permissions.payrollRunList);
+  const canListOwn = permissions.has(Permissions.payrollRunListOwn);
+
+  if (!canManage && !canListAny && !canListOwn) {
+    throw new ServiceError(403, `payroll list requires ${Permissions.payrollRunList} permission`);
+  }
+  if (!canManage && !canListAny && actor.id !== input.employeeId) {
+    throw new ServiceError(403, "employees can only read their own withholding receipt document");
+  }
+
+  const entityId = `${input.year}_${input.employeeId}`;
+  const issuedLogs = await context.dataAccess.audit.list({
+    actions: ["payroll.year_end.withholding_receipt_issued"],
+    entityType: "PayrollYearEnd",
+    entityId,
+    limit: 200
+  });
+  const latestIssuedLog = issuedLogs[issuedLogs.length - 1] ?? null;
+  const receipt = asYearEndWithholdingReceiptSummaryPayload(latestIssuedLog?.payload ?? null);
+  if (!receipt || !receipt.issued || !receipt.issuedAt) {
+    throw new ServiceError(404, "issued withholding receipt not found");
+  }
+
+  const artifact = buildYearEndWithholdingReceiptDocumentArtifact(receipt, input.format);
+  const generatedAt = new Date().toISOString();
+  const contentSha256 = createHash("sha256").update(artifact.content).digest("hex");
+
+  return {
+    document: {
+      year: input.year,
+      employeeId: input.employeeId,
+      receiptNumber: receipt.receiptNumber,
+      issuedAt: receipt.issuedAt,
+      issuerName: receipt.issuerName,
+      format: input.format,
+      fileName: artifact.fileName,
+      contentType: artifact.contentType,
+      contentSha256,
+      generatedAt,
+      receipt,
+      content: artifact.content
     }
   };
 }

--- a/work-items/WI-0274-payroll-year-end-withholding-receipt-document-download.md
+++ b/work-items/WI-0274-payroll-year-end-withholding-receipt-document-download.md
@@ -1,0 +1,39 @@
+﻿# WI-0274: Payroll Year-End Withholding Receipt Issued Document Download
+
+## Background
+
+Withholding receipt preview/issue flow existed, but there was no API to read/download
+an already issued receipt artifact for employee self-service or operator support.
+Users could confirm readiness but could not retrieve a deterministic issued document
+payload from the product.
+
+## Scope
+
+### In Scope
+
+- add issued receipt document read endpoint
+  - extend `GET /payroll/year-end/withholding-receipts` query mode (`year`, `employeeId`, `format`)
+  - support `format=json|text` document artifact output with `fileName`, `contentType`, and `contentSha256`
+  - return `404` when issued receipt audit snapshot does not exist
+  - enforce authorization guard:
+    - employee can read only own issued document
+    - payroll_operator/admin can read tenant-scoped employee document
+- add employee UI wiring
+  - `/employee/withholding-receipt` adds issued-document load action and download action
+  - show document metadata (`format`, `fileName`, hash, timestamps) with content preview
+- update payroll spec/contract/test-cases and contract version bump (`1.54.0`)
+- add WI-0274 regression e2e
+  - `scripts/tests/e2e-wi0274-payroll-year-end-withholding-receipt-document-download.test.ts`
+
+### Out of Scope
+
+- PDF renderer generation or binary attachment storage
+- scheduler/ops automation expansion
+- withholding formula/cap policy changes
+
+## Validation
+
+- `npm.cmd exec tsx scripts/tests/e2e-wi0274-payroll-year-end-withholding-receipt-document-download.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0273-payroll-year-end-hash-guard-regression-suite.test.ts`
+- `npm.cmd run typecheck`
+- `npm.cmd run build`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0274-payroll-year-end-withholding-receipt-document-download.md`
- Related Specs: `specs/payroll/api.yaml`, `specs/payroll/contract.yaml`, `specs/payroll/test-cases.md`
- Related ADR: N/A (additive, non-breaking payroll domain change)

### Scope

- add `GET /payroll/year-end/withholding-receipts` query mode (`year`, `employeeId`, `format=json|text`)
- add service-level issued-document retrieval with own/tenant authorization guard and deterministic `contentSha256`
- extend employee withholding receipt console with issued-document load/download flow
- add WI-0274 e2e regression coverage

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
    - Reason: additive endpoint/query mode and UI wiring only; no cross-domain/breaking/security-impacting change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

### Evidence (local)

- `npm.cmd exec tsx scripts/tests/e2e-wi0274-payroll-year-end-withholding-receipt-document-download.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0273-payroll-year-end-hash-guard-regression-suite.test.ts`
- `npm.cmd run typecheck`
- `npm.cmd run build`

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/withholding-receipt/WithholdingReceiptConsole.tsx`, `src/components/withholding-receipt/types.ts`
- Backend-only reason:
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
