### PR TITLE
feat: WI-0492 payslips employee-id locale normalization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 ﻿# FlowHR Production Roadmap
 
 > **Last updated**: 2026-02-26
-> **Current version**: 0.1.173 (Scheduling Runtime Korean Error Normalization)
+> **Current version**: 0.1.174 (Payslips Employee ID Locale Normalization)
 > **Target**: Production-grade Korean HR SaaS (Shiftee/Flex superior)
 
 ---
@@ -756,3 +756,4 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0489 contracts http fallback runtime alignment (`contracts/http.ts` ko 런타임 계약 도메인 오류 매핑 확장 + 상태 제약/해시 불일치/리소스 미존재 한국어 안내 고정 + `e2e-wi0489` 회귀 테스트 추가)
 - WI-0490 contracts permission message korean normalization phase 2 (`contracts/http.ts` 권한/본인문서 제약 오류 한국어 매핑 확장 + generic permission fallback 유지 + `e2e-wi0490` 회귀 테스트 추가)
 - WI-0491 scheduling runtime korean error normalization (`scheduling/helpers.ts` 런타임 오류 한국어 정규화 helper 추가 + admin/employee 일정 오류 메시지 매핑 강화 + `e2e-wi0491` 회귀 테스트 추가)
+- WI-0492 payslips employee-id locale normalization (`/employee/payslips` 직원번호 입력/표시를 `직원-*`↔`EMP-*` locale helper로 일원화 + API 호출은 `EMP-*` 정규화 고정 + CSV/상세/파일명 표기 한국어화 + `e2e-wi0492` 회귀 테스트 추가)

--- a/scripts/tests/e2e-wi0492-payslips-employee-id-locale-normalization.test.ts
+++ b/scripts/tests/e2e-wi0492-payslips-employee-id-locale-normalization.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  formatEmployeeIdForLocaleDisplay,
+  getLocalizedEmployeeIdInputDefault,
+  normalizeEmployeeIdForApi,
+  normalizeEmployeeIdForLocaleInput
+} from "@/lib/i18n/employee-id-locale";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const payslipPage = readUtf8("src", "app", "employee", "payslips", "page.tsx");
+  const payslipApi = readUtf8("src", "app", "employee", "payslips", "use-payslip-api.ts");
+  const payslipDerivedState = readUtf8(
+    "src",
+    "app",
+    "employee",
+    "payslips",
+    "use-payslip-derived-state.ts"
+  );
+  const payslipDetailPanel = readUtf8(
+    "src",
+    "app",
+    "employee",
+    "payslips",
+    "page-view-detail-panel.tsx"
+  );
+  const workItem = readUtf8("work-items", "WI-0492-payslips-employee-id-locale-normalization.md");
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.equal(getLocalizedEmployeeIdInputDefault("ko"), "직원-1001");
+  assert.equal(getLocalizedEmployeeIdInputDefault("en"), "EMP-1001");
+  assert.equal(normalizeEmployeeIdForApi("직원-1200", "ko"), "EMP-1200");
+  assert.equal(normalizeEmployeeIdForApi("EMP-1200", "ko"), "EMP-1200");
+  assert.equal(normalizeEmployeeIdForLocaleInput("EMP-1200", "ko"), "직원-1200");
+  assert.equal(normalizeEmployeeIdForLocaleInput("직원-1200", "en"), "EMP-1200");
+  assert.equal(formatEmployeeIdForLocaleDisplay("EMP-1200", "ko"), "직원-1200");
+
+  assert.match(payslipPage, /getLocalizedEmployeeIdInputDefault\(locale\)/);
+  assert.match(payslipPage, /normalizeEmployeeIdForLocaleInput\(value, locale\)/);
+  assert.match(payslipPage, /normalizeEmployeeIdForApi\(employeeLabelSource, locale\)/);
+  assert.match(payslipApi, /employeeIdForApi/);
+  assert.match(payslipApi, /defaultEmployeeIdForApi/);
+  assert.match(payslipDerivedState, /formatEmployeeIdForLocaleDisplay/);
+  assert.match(payslipDerivedState, /normalizeEmployeeIdForApi/);
+  assert.match(payslipDetailPanel, /formatEmployeeIdForLocaleDisplay/);
+  assert.match(workItem, /WI-0492/i);
+  assert.match(workItem, /payslips|employee-id|locale|normalization/i);
+  assert.match(roadmap, /WI-0492/i);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0492-payslips-employee-id-locale-normalization.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/employee/payslips/page-view-detail-panel.tsx
+++ b/src/app/employee/payslips/page-view-detail-panel.tsx
@@ -4,6 +4,7 @@ import {
   formatMonthLabel,
   type PayslipPageCopy
 } from "@/app/employee/payslips/page-locale-helpers";
+import { formatEmployeeIdForLocaleDisplay } from "@/lib/i18n/employee-id-locale";
 import {
   minutesToHours,
   type AttendanceAggregateDto,
@@ -38,6 +39,8 @@ export function PayslipDetailPanel({
   copyPayslipFileName,
   copySelectedRunId
 }: PayslipDetailPanelProps) {
+  const locale = isKoLocale ? "ko" : "en";
+
   return (
     <article className="panel panel-payslip-print">
       <h2>{pageCopy.detail.title}</h2>
@@ -77,7 +80,7 @@ export function PayslipDetailPanel({
               <ul className="payslip-meta-list">
                 <li>
                   <span>{pageCopy.detail.employeeId}</span>
-                  <strong>{selectedRun.employeeId ?? employeeId}</strong>
+                  <strong>{formatEmployeeIdForLocaleDisplay(selectedRun.employeeId ?? employeeId, locale)}</strong>
                 </li>
                 <li>
                   <span>{pageCopy.detail.payslipId}</span>

--- a/src/app/employee/payslips/page.tsx
+++ b/src/app/employee/payslips/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useStickyStringState } from "@/lib/client/useStickyState";
+import {
+  formatEmployeeIdForLocaleDisplay,
+  getLocalizedEmployeeIdInputDefault,
+  normalizeEmployeeIdForApi,
+  normalizeEmployeeIdForLocaleInput
+} from "@/lib/i18n/employee-id-locale";
 import { useI18n } from "@/lib/i18n/provider";
 import {
   type DeductionDescriptionMap,
@@ -31,9 +37,16 @@ import { usePayslipApi } from "@/app/employee/payslips/use-payslip-api";
 import { usePayslipDerivedState } from "@/app/employee/payslips/use-payslip-derived-state";
 import { EmployeePayslipsPageView } from "@/app/employee/payslips/page-view";
 export default function EmployeePayslipsPage() {
+  const { locale } = useI18n();
+  const isKoLocale = locale === "ko";
+  const runtimeLocale = isKoLocale ? "ko-KR" : "en-US";
+
   const [accessToken, setAccessToken] = useState("");
   const [organizationId, setOrganizationId] = useStickyStringState("flowhr:ctx:organizationId", "");
-  const [employeeId, setEmployeeId] = useStickyStringState("flowhr:ctx:employeeId", "EMP-1001");
+  const [employeeId, setEmployeeId] = useStickyStringState(
+    "flowhr:ctx:employeeId",
+    getLocalizedEmployeeIdInputDefault(locale)
+  );
 
   const [periodStart, setPeriodStart] = useState(firstDayOfMonthLocal());
   const [periodEnd, setPeriodEnd] = useState(lastDayOfMonthLocal());
@@ -49,12 +62,26 @@ export default function EmployeePayslipsPage() {
   const showDevTools = isDevToolsEnabled();
   const isProductionRuntime = process.env.NODE_ENV === "production";
   const { snapshot: supabaseSession, error: supabaseSessionError } = useSupabaseSession();
-  const { locale } = useI18n();
-  const isKoLocale = locale === "ko";
-  const runtimeLocale = isKoLocale ? "ko-KR" : "en-US";
 
   const searchSortCopy = useMemo(() => resolvePayslipSearchSortCopy(isKoLocale), [isKoLocale]);
   const pageCopy = useMemo(() => resolvePayslipPageCopy(isKoLocale), [isKoLocale]);
+  const normalizedEmployeeIdForApi = useMemo(
+    () => normalizeEmployeeIdForApi(employeeId, locale),
+    [employeeId, locale]
+  );
+  const setEmployeeIdForLocaleInput = useCallback(
+    (value: string) => {
+      setEmployeeId(normalizeEmployeeIdForLocaleInput(value, locale));
+    },
+    [locale, setEmployeeId]
+  );
+
+  useEffect(() => {
+    const localizedEmployeeId = normalizeEmployeeIdForLocaleInput(employeeId, locale);
+    if (localizedEmployeeId !== employeeId) {
+      setEmployeeId(localizedEmployeeId);
+    }
+  }, [employeeId, locale, setEmployeeId]);
 
   useEffect(() => {
     setPayslipRuntimeLocale(runtimeLocale);
@@ -91,7 +118,7 @@ export default function EmployeePayslipsPage() {
     runtimeLocale,
     usesBearerToken,
     bearerToken,
-    employeeId,
+    employeeIdForApi: normalizedEmployeeIdForApi,
     organizationId,
     periodStart,
     periodEnd,
@@ -168,10 +195,14 @@ export default function EmployeePayslipsPage() {
       return;
     }
     const actorId = (supabaseSession?.actorId ?? supabaseSession?.userId ?? "").trim();
-    if (actorId.length > 0 && employeeId.trim() !== actorId) {
-      setEmployeeId(actorId);
+    if (actorId.length === 0) {
+      return;
     }
-  }, [employeeId, isProductionRuntime, setEmployeeId, supabaseSession?.actorId, supabaseSession?.userId]);
+    const localizedActorId = normalizeEmployeeIdForLocaleInput(actorId, locale);
+    if (employeeId.trim() !== localizedActorId) {
+      setEmployeeId(localizedActorId);
+    }
+  }, [employeeId, isProductionRuntime, locale, setEmployeeId, supabaseSession?.actorId, supabaseSession?.userId]);
 
   function applyCurrentMonthRange() {
     setPeriodStart(firstDayOfMonthLocal());
@@ -302,7 +333,12 @@ export default function EmployeePayslipsPage() {
     const anchor = document.createElement("a");
     anchor.href = url;
     const csvPrefix = isKoLocale ? "플로우HR-명세서" : "flowhr-payslips";
-    const employeeLabel = (employeeId || (isKoLocale ? "직원" : "employee")).replace(/\s+/g, "-");
+    const employeeLabelSource =
+      employeeId.trim().length > 0 ? employeeId : getLocalizedEmployeeIdInputDefault(locale);
+    const employeeLabel = formatEmployeeIdForLocaleDisplay(
+      normalizeEmployeeIdForApi(employeeLabelSource, locale),
+      locale
+    ).replace(/\s+/g, "-");
     anchor.download = `${csvPrefix}-${employeeLabel}.csv`;
     document.body.appendChild(anchor);
     anchor.click();
@@ -342,7 +378,7 @@ export default function EmployeePayslipsPage() {
       organizationId={organizationId}
       setOrganizationId={setOrganizationId}
       employeeId={employeeId}
-      setEmployeeId={setEmployeeId}
+      setEmployeeId={setEmployeeIdForLocaleInput}
       periodStart={periodStart}
       setPeriodStart={setPeriodStart}
       periodEnd={periodEnd}

--- a/src/app/employee/payslips/use-payslip-api.ts
+++ b/src/app/employee/payslips/use-payslip-api.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 
+import { defaultEmployeeIdForApi } from "@/lib/i18n/employee-id-locale";
 import type { PayslipPageCopy } from "@/app/employee/payslips/page-locale-helpers";
 import {
   buildQuery,
@@ -14,7 +15,7 @@ type UsePayslipApiParams = {
   runtimeLocale: string;
   usesBearerToken: boolean;
   bearerToken: string;
-  employeeId: string;
+  employeeIdForApi: string;
   organizationId: string;
   periodStart: string;
   periodEnd: string;
@@ -48,7 +49,7 @@ export function usePayslipApi({
   runtimeLocale,
   usesBearerToken,
   bearerToken,
-  employeeId,
+  employeeIdForApi,
   organizationId,
   periodStart,
   periodEnd,
@@ -83,7 +84,7 @@ export function usePayslipApi({
           headers.authorization = `Bearer ${bearerToken.trim()}`;
         } else {
           headers["x-actor-role"] = "employee";
-          headers["x-actor-id"] = employeeId.trim() || "EMP-1001";
+          headers["x-actor-id"] = employeeIdForApi.trim() || defaultEmployeeIdForApi;
           if (organizationId.trim().length > 0) {
             headers["x-actor-organization-id"] = organizationId.trim();
           }
@@ -115,13 +116,13 @@ export function usePayslipApi({
         setPendingLabel(null);
       }
     },
-    [bearerToken, employeeId, organizationId, runtimeLocale, usesBearerToken]
+    [bearerToken, employeeIdForApi, organizationId, runtimeLocale, usesBearerToken]
   );
 
   const refreshPayslips = useCallback(async () => {
     const from = toIso(periodStart);
     const to = toIso(periodEnd);
-    const targetEmployeeId = employeeId.trim() || "EMP-1001";
+    const targetEmployeeId = employeeIdForApi.trim() || defaultEmployeeIdForApi;
 
     const [runsRes, aggregateRes] = await Promise.all([
       callApi(
@@ -151,7 +152,16 @@ export function usePayslipApi({
       const aggregates = Array.isArray(parsed.aggregates) ? parsed.aggregates : [];
       setAggregate(aggregates[0] ?? null);
     }
-  }, [callApi, employeeId, pageCopy.logs.fetchAttendance, pageCopy.logs.fetchPayslips, periodEnd, periodStart, setAggregate, setRuns]);
+  }, [
+    callApi,
+    employeeIdForApi,
+    pageCopy.logs.fetchAttendance,
+    pageCopy.logs.fetchPayslips,
+    periodEnd,
+    periodStart,
+    setAggregate,
+    setRuns
+  ]);
 
   const clearLogs = useCallback(() => {
     setLogs([]);

--- a/src/app/employee/payslips/use-payslip-derived-state.ts
+++ b/src/app/employee/payslips/use-payslip-derived-state.ts
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 
 import {
+  formatEmployeeIdForLocaleDisplay,
+  getLocalizedEmployeeIdInputDefault,
+  normalizeEmployeeIdForApi
+} from "@/lib/i18n/employee-id-locale";
+import {
   type DeductionDescriptionMap,
   extractErrorMessage,
   formatCompareWindowLabel,
@@ -348,8 +353,13 @@ export function usePayslipDerivedState(input: UsePayslipDerivedStateInput): UseP
     const period = new Date(selectedRun.periodStart);
     const year = Number.isNaN(period.getTime()) ? "unknown" : String(period.getFullYear());
     const month = Number.isNaN(period.getTime()) ? "00" : String(period.getMonth() + 1).padStart(2, "0");
-    const actorFallback = isKoLocale ? "직원" : "employee";
-    const actor = (selectedRun.employeeId ?? employeeId ?? actorFallback).replace(/\s+/g, "-");
+    const locale = isKoLocale ? "ko" : "en";
+    const actorFallback = getLocalizedEmployeeIdInputDefault(locale);
+    const actorSource = selectedRun.employeeId ?? employeeId ?? actorFallback;
+    const actor = formatEmployeeIdForLocaleDisplay(normalizeEmployeeIdForApi(actorSource, locale), locale).replace(
+      /\s+/g,
+      "-"
+    );
     const filePrefix = isKoLocale ? "플로우HR-급여명세" : "flowhr-payslip";
     return `${filePrefix}-${actor}-${year}${month}.pdf`;
   }, [employeeId, isKoLocale, selectedRun]);

--- a/work-items/WI-0492-payslips-employee-id-locale-normalization.md
+++ b/work-items/WI-0492-payslips-employee-id-locale-normalization.md
@@ -1,0 +1,24 @@
+# WI-0492: Payslips Employee ID Locale Normalization
+
+## Summary
+- Goal: remove residual English employee-id exposure in Korean payslips runtime by separating UI input/display locale from API id format.
+- Scope:
+  - `src/app/employee/payslips/page.tsx`
+  - `src/app/employee/payslips/use-payslip-api.ts`
+  - `src/app/employee/payslips/use-payslip-derived-state.ts`
+  - `src/app/employee/payslips/page-view-detail-panel.tsx`
+  - `scripts/tests/e2e-wi0492-payslips-employee-id-locale-normalization.test.ts`
+  - `ROADMAP.md`
+
+## Delivery
+- Applied locale-aware employee id defaults in payslips page (`직원-1001` for ko, `EMP-1001` for en).
+- Normalized payslips API calls to always use `EMP-*` format through `normalizeEmployeeIdForApi(...)`.
+- Localized payslip employee-id display and filename labels through `formatEmployeeIdForLocaleDisplay(...)`.
+- Added locale input normalization so ko runtime keeps `직원-*` style in visible input while preserving API compatibility.
+- Added WI-0492 regression guard for locale helper wiring and Korean employee-id normalization behavior.
+
+## Validation
+- [x] `npm.cmd exec tsx scripts/tests/e2e-wi0492-payslips-employee-id-locale-normalization.test.ts`
+- [x] `npm.cmd exec tsx scripts/tests/e2e-wi0416-korean-runtime-english-residual-sweep-withholding-payslip-contracts.test.ts`
+- [x] `npm.cmd exec tsx scripts/tests/e2e-wi0487-korean-surface-english-suppression-withholding-payslips-contracts.test.ts`
+- [x] `npm.cmd run typecheck`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0492-payslips-employee-id-locale-normalization.md`
- Related Specs: N/A (UI runtime localization enhancement)
- Related ADR: N/A

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- Reason: employee payslips locale display/input normalization only, no breaking/cross-domain/security-impacting contract change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/app/employee/payslips/page.tsx`, `src/app/employee/payslips/use-payslip-api.ts`, `src/app/employee/payslips/use-payslip-derived-state.ts`, `src/app/employee/payslips/page-view-detail-panel.tsx`
- Backend-only reason: N/A
- Next UI WI: N/A

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID: N/A
- Approval:
  - Human approver: N/A
  - Co-sign approver (Orchestrator or QA): N/A
- Change scope: N/A
- Risk assessment: N/A
- Rollback plan: N/A
- Customer impact: N/A
- Temporary mitigation: N/A
- RCA due date (<= 48h after merge): N/A

## Testing

- `npm.cmd exec tsx scripts/tests/e2e-wi0492-payslips-employee-id-locale-normalization.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0416-korean-runtime-english-residual-sweep-withholding-payslip-contracts.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0487-korean-surface-english-suppression-withholding-payslips-contracts.test.ts`
- `npm.cmd run typecheck`
