### PR TITLE
feat: WI-0699 gate admin core session identity behind devtools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -984,3 +984,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0697 admin workspace session identity devtools gate (hide read-only session organization/actor identifiers on core admin workspaces by default and expose them only in NEXT_PUBLIC_FLOWHR_DEV_TOOLS mode; add recruitment workspace devtools flag propagation + e2e-wi0697 guard)
 
 - WI-0698 employee workspace session identity devtools gate (hide read-only session organization/employee identifiers on employee benefits/recruitment workspaces by default and expose them only in NEXT_PUBLIC_FLOWHR_DEV_TOOLS mode; add showDevTools propagation + e2e-wi0698 guard)
+
+- WI-0699 admin core context session identity devtools gate (hide read-only session organization/actor identifiers on admin attendance-live/onboarding/kpi context panels by default and expose them only in NEXT_PUBLIC_FLOWHR_DEV_TOOLS mode; propagate showDevTools through dashboards/hooks + e2e-wi0699 guard)

--- a/scripts/tests/e2e-wi0699-admin-core-context-session-identity-devtools-gate.test.ts
+++ b/scripts/tests/e2e-wi0699-admin-core-context-session-identity-devtools-gate.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const attendanceSections = readUtf8(
+    "src",
+    "components",
+    "admin-attendance-live",
+    "AdminAttendanceLiveSections.tsx"
+  );
+  const attendanceDashboard = readUtf8(
+    "src",
+    "components",
+    "admin-attendance-live",
+    "AdminAttendanceLiveDashboard.tsx"
+  );
+
+  const onboardingSections = readUtf8(
+    "src",
+    "components",
+    "admin-onboarding",
+    "AdminOnboardingSections.tsx"
+  );
+  const onboardingDashboard = readUtf8(
+    "src",
+    "components",
+    "admin-onboarding",
+    "AdminOnboardingDashboard.tsx"
+  );
+  const onboardingData = readUtf8(
+    "src",
+    "components",
+    "admin-onboarding",
+    "useAdminOnboardingData.ts"
+  );
+
+  const kpiSections = readUtf8("src", "components", "admin-kpi", "AdminKpiSections.tsx");
+  const kpiDashboard = readUtf8("src", "components", "admin-kpi", "AdminKpiDashboard.tsx");
+
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0699-admin-core-context-session-identity-devtools-gate.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(attendanceSections, /showDevTools: boolean;/);
+  assert.match(
+    attendanceSections,
+    /\{showDevTools \? \([\s\S]*<p className="small muted">[\s\S]*\{copy\.organizationIdLabel\}:/
+  );
+  assert.match(attendanceDashboard, /showDevTools=\{showDevTools\}/);
+
+  assert.match(onboardingSections, /showDevTools: boolean;/);
+  assert.match(
+    onboardingSections,
+    /\{showDevTools \? \([\s\S]*<p className="small muted">[\s\S]*\{copy\.organizationIdLabel\}:/
+  );
+  assert.match(onboardingDashboard, /showDevTools=\{data\.showDevTools\}/);
+  assert.match(onboardingData, /const showDevTools = isTruthyFlag\(process\.env\.NEXT_PUBLIC_FLOWHR_DEV_TOOLS\)/);
+  assert.match(onboardingData, /showDevTools,/);
+
+  assert.match(kpiSections, /showDevTools: boolean;/);
+  assert.match(
+    kpiSections,
+    /\{showDevTools \? \([\s\S]*<p className="small muted">[\s\S]*\{copy\.organizationIdLabel\}:/
+  );
+  assert.match(kpiDashboard, /showDevTools=\{showDevTools\}/);
+
+  assert.match(workItem, /WI-0699/i);
+  assert.match(workItem, /admin core|context|session|identity|devtools/i);
+  assert.match(roadmap, /WI-0699/i);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0699-admin-core-context-session-identity-devtools-gate.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx
+++ b/src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx
@@ -208,6 +208,7 @@ export function AdminAttendanceLiveDashboard() {
 
       <AdminAttendanceLiveContextPanel
         copy={copy}
+        showDevTools={showDevTools}
         sessionOrganizationId={organizationId}
         sessionActorId={adminActorId}
         periodStart={periodStart}

--- a/src/components/admin-attendance-live/AdminAttendanceLiveSections.tsx
+++ b/src/components/admin-attendance-live/AdminAttendanceLiveSections.tsx
@@ -27,6 +27,7 @@ export type AttendanceLiveApiLog = {
 
 type ContextPanelProps = {
   copy: AttendanceLiveCopy;
+  showDevTools: boolean;
   sessionOrganizationId: string;
   sessionActorId: string;
   periodStart: string;
@@ -53,6 +54,7 @@ type ContextPanelProps = {
 export function AdminAttendanceLiveContextPanel(props: ContextPanelProps) {
   const {
     copy,
+    showDevTools,
     sessionOrganizationId,
     sessionActorId,
     periodStart,
@@ -80,10 +82,12 @@ export function AdminAttendanceLiveContextPanel(props: ContextPanelProps) {
     <section className="panel-grid">
       <article className="panel">
         <h2>{copy.contextTitle}</h2>
-        <p className="small muted">
-          {copy.organizationIdLabel}: <code>{sessionOrganizationId || "-"}</code> / {copy.adminActorIdLabel}:{" "}
-          <code>{sessionActorId || "-"}</code>
-        </p>
+        {showDevTools ? (
+          <p className="small muted">
+            {copy.organizationIdLabel}: <code>{sessionOrganizationId || "-"}</code> / {copy.adminActorIdLabel}:{" "}
+            <code>{sessionActorId || "-"}</code>
+          </p>
+        ) : null}
         <div className="input-grid">
           <label>{copy.periodStartLabel}<input type="datetime-local" value={periodStart} onChange={(event) => onSetPeriodStart(event.target.value)} /></label>
           <label>{copy.periodEndLabel}<input type="datetime-local" value={periodEnd} onChange={(event) => onSetPeriodEnd(event.target.value)} /></label>

--- a/src/components/admin-kpi/AdminKpiDashboard.tsx
+++ b/src/components/admin-kpi/AdminKpiDashboard.tsx
@@ -234,6 +234,7 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
       ) : null}
       <AdminKpiContextPanel
         copy={copy}
+        showDevTools={showDevTools}
         sessionOrganizationId={organizationId}
         sessionActorId={adminActorId}
         periodStart={periodStart}

--- a/src/components/admin-kpi/AdminKpiSections.tsx
+++ b/src/components/admin-kpi/AdminKpiSections.tsx
@@ -44,6 +44,7 @@ type AdminKpiDrilldownMetric = Exclude<AdminKpiFocusMetric, "all">;
 
 type ContextPanelProps = {
   copy: KpiCopy;
+  showDevTools: boolean;
   sessionOrganizationId: string;
   sessionActorId: string;
   periodStart: string;
@@ -117,6 +118,7 @@ export function AdminKpiAnalyticsControls({
 export function AdminKpiContextPanel(props: ContextPanelProps) {
   const {
     copy,
+    showDevTools,
     sessionOrganizationId,
     sessionActorId,
     periodStart,
@@ -134,10 +136,12 @@ export function AdminKpiContextPanel(props: ContextPanelProps) {
     <section className="panel-grid">
       <article className="panel">
         <h2>{copy.contextTitle}</h2>
-        <p className="small muted">
-          {copy.organizationIdLabel}: <code>{sessionOrganizationId || "-"}</code> / {copy.adminActorIdLabel}:{" "}
-          <code>{sessionActorId || "-"}</code>
-        </p>
+        {showDevTools ? (
+          <p className="small muted">
+            {copy.organizationIdLabel}: <code>{sessionOrganizationId || "-"}</code> / {copy.adminActorIdLabel}:{" "}
+            <code>{sessionActorId || "-"}</code>
+          </p>
+        ) : null}
         <div className="input-grid">
           <label>
             {copy.periodStartLabel}

--- a/src/components/admin-onboarding/AdminOnboardingDashboard.tsx
+++ b/src/components/admin-onboarding/AdminOnboardingDashboard.tsx
@@ -37,6 +37,7 @@ export function AdminOnboardingDashboard() {
 
       <AdminOnboardingContextPanel
         copy={copy}
+        showDevTools={data.showDevTools}
         sessionOrganizationId={data.organizationId}
         sessionActorId={data.adminActorId}
         pendingLabel={data.pendingLabel}

--- a/src/components/admin-onboarding/AdminOnboardingSections.tsx
+++ b/src/components/admin-onboarding/AdminOnboardingSections.tsx
@@ -16,6 +16,7 @@ export type AdminOnboardingActionLog = {
 
 type ContextPanelProps = {
   copy: AdminOnboardingCopy;
+  showDevTools: boolean;
   sessionOrganizationId: string;
   sessionActorId: string;
   pendingLabel: string | null;
@@ -26,6 +27,7 @@ type ContextPanelProps = {
 export function AdminOnboardingContextPanel(props: ContextPanelProps) {
   const {
     copy,
+    showDevTools,
     sessionOrganizationId,
     sessionActorId,
     pendingLabel,
@@ -37,10 +39,12 @@ export function AdminOnboardingContextPanel(props: ContextPanelProps) {
     <section className="panel-grid">
       <article className="panel">
         <h2>{copy.contextTitle}</h2>
-        <p className="small muted">
-          {copy.organizationIdLabel}: <code>{sessionOrganizationId || "-"}</code> / {copy.adminActorIdLabel}:{" "}
-          <code>{sessionActorId || "-"}</code>
-        </p>
+        {showDevTools ? (
+          <p className="small muted">
+            {copy.organizationIdLabel}: <code>{sessionOrganizationId || "-"}</code> / {copy.adminActorIdLabel}:{" "}
+            <code>{sessionActorId || "-"}</code>
+          </p>
+        ) : null}
         <div className="actions">
           <button className="btn btn-primary" onClick={onRefresh} disabled={refreshDisabled}>{copy.loadButton}</button>
         </div>

--- a/src/components/admin-onboarding/useAdminOnboardingData.ts
+++ b/src/components/admin-onboarding/useAdminOnboardingData.ts
@@ -331,6 +331,7 @@ export function useAdminOnboardingData(input: UseAdminOnboardingDataInput) {
     setEmployeeSeedInput,
     setHourlyIncrementMinutes,
     setMaxHoursPerRequest,
+    showDevTools,
     usesBearerToken
   };
 }

--- a/work-items/WI-0699-admin-core-context-session-identity-devtools-gate.md
+++ b/work-items/WI-0699-admin-core-context-session-identity-devtools-gate.md
@@ -1,0 +1,26 @@
+# WI-0699 Admin Core Context Session Identity Devtools Gate
+
+## Summary
+- gated read-only session identity metadata (`organizationId`, `actorId`) behind
+  `NEXT_PUBLIC_FLOWHR_DEV_TOOLS` on core admin context panels:
+  - `src/components/admin-attendance-live/AdminAttendanceLiveSections.tsx`
+  - `src/components/admin-onboarding/AdminOnboardingSections.tsx`
+  - `src/components/admin-kpi/AdminKpiSections.tsx`
+- propagated `showDevTools` wiring through dashboards so context panels receive
+  runtime flag state:
+  - `src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx`
+  - `src/components/admin-onboarding/AdminOnboardingDashboard.tsx`
+  - `src/components/admin-kpi/AdminKpiDashboard.tsx`
+- exposed `showDevTools` from onboarding data hook for dashboard-level panel
+  control:
+  - `src/components/admin-onboarding/useAdminOnboardingData.ts`
+
+## Scope
+- core admin UI exposure control only
+- no API/schema/contract changes
+- no ops route changes
+
+## Testing
+- `npm.cmd exec tsx scripts/tests/e2e-wi0699-admin-core-context-session-identity-devtools-gate.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0622-admin-workspaces-session-context-productization.test.ts`
+- `npm.cmd run typecheck`


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0699-admin-core-context-session-identity-devtools-gate.md`
- Related Specs: N/A (UI-only enhancement)
- Related ADR: N/A

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
Reason: UI-only exposure gating on existing admin surfaces. No breaking/cross-domain/security-impacting change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/admin-attendance-live/AdminAttendanceLiveSections.tsx`, `src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx`, `src/components/admin-onboarding/AdminOnboardingSections.tsx`, `src/components/admin-onboarding/AdminOnboardingDashboard.tsx`, `src/components/admin-onboarding/useAdminOnboardingData.ts`, `src/components/admin-kpi/AdminKpiSections.tsx`, `src/components/admin-kpi/AdminKpiDashboard.tsx`
- Backend-only reason: N/A
- Next UI WI: N/A

## Emergency Override (Break-Glass Only)

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID: N/A
- Approval:
  - Human approver: N/A
  - Co-sign approver (Orchestrator or QA): N/A
- Change scope: N/A
- Risk assessment: N/A
- Rollback plan: N/A
- Customer impact: N/A
- Temporary mitigation: N/A
- RCA due date (<= 48h after merge): N/A
