### PR TITLE
feat: WI-0704 expand admin session identity devtools gates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -994,3 +994,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0702 payroll year-end/preflight session identity devtools gate (hide read-only session organization/actor identifiers on /admin/payroll-year-end and /admin/payroll-year-end/preflight input panels by default; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0702 regression guard)
 
 - WI-0703 payroll year-end filing/employee session identity devtools gate (hide read-only session organization/actor identifiers on /admin/payroll-year-end-filing and session organization/employee identifiers on /employee/year-end-input by default; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0703 regression guard)
+
+- WI-0704 admin session identity devtools gate expansion (hide read-only session organization/actor identifiers by default in /admin/approval-executions work-conditions panel, /admin/people filters panel, and /admin/leave-calendar query panel; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0704 regression guard)

--- a/scripts/tests/e2e-wi0704-admin-session-identity-devtools-gate-expansion.test.ts
+++ b/scripts/tests/e2e-wi0704-admin-session-identity-devtools-gate-expansion.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const approvalExecutionsPage = readUtf8(
+    "src",
+    "app",
+    "admin",
+    "approval-executions",
+    "page.tsx"
+  );
+  const approvalWorkConditionsPanel = readUtf8(
+    "src",
+    "app",
+    "admin",
+    "approval-executions",
+    "page-sections-work-conditions.tsx"
+  );
+  const adminPeopleView = readUtf8("src", "app", "admin", "people", "page-view.tsx");
+  const adminPeopleFiltersPanel = readUtf8(
+    "src",
+    "app",
+    "admin",
+    "people",
+    "page-view-directory-filters-panel.tsx"
+  );
+  const leaveCalendarConsole = readUtf8(
+    "src",
+    "components",
+    "leave-calendar",
+    "LeaveCalendarConsole.tsx"
+  );
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0704-admin-session-identity-devtools-gate-expansion.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(approvalExecutionsPage, /showDevTools=\{showDevTools\}/);
+  assert.match(approvalWorkConditionsPanel, /showDevTools: boolean;/);
+  assert.match(
+    approvalWorkConditionsPanel,
+    /\{showDevTools \? \([\s\S]*Session actor[\s\S]*\) : null\}/
+  );
+
+  assert.match(adminPeopleView, /showDevTools=\{showDevTools\}/);
+  assert.match(adminPeopleFiltersPanel, /showDevTools: boolean;/);
+  assert.match(
+    adminPeopleFiltersPanel,
+    /\{showDevTools \? \([\s\S]*Session organization[\s\S]*Session actor[\s\S]*\) : null\}/
+  );
+
+  assert.match(
+    leaveCalendarConsole,
+    /\{showDevTools \? \([\s\S]*Session organization[\s\S]*Session admin[\s\S]*\) : null\}/
+  );
+
+  assert.match(workItem, /WI-0704/i);
+  assert.match(workItem, /approval|people|leave-calendar|session|identity|devtools/i);
+  assert.match(roadmap, /WI-0704/i);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0704-admin-session-identity-devtools-gate-expansion.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/admin/approval-executions/page-sections-work-conditions.tsx
+++ b/src/app/admin/approval-executions/page-sections-work-conditions.tsx
@@ -26,6 +26,7 @@ import { domainOptions, stateOptions } from "@/app/admin/approval-executions/pag
 
 type WorkConditionsPanelProps = {
   isKoLocale: boolean;
+  showDevTools: boolean;
   organizationId: string;
   adminActorId: string;
   sort: ApprovalExecutionSort;
@@ -61,6 +62,7 @@ type WorkConditionsPanelProps = {
 export function ApprovalExecutionWorkConditionsPanel(props: WorkConditionsPanelProps) {
   const {
     isKoLocale,
+    showDevTools,
     organizationId,
     adminActorId,
     sort,
@@ -96,10 +98,12 @@ export function ApprovalExecutionWorkConditionsPanel(props: WorkConditionsPanelP
   return (
     <article className="panel">
       <h2>{isKoLocale ? "작업 조건" : "Work conditions"}</h2>
-      <p className="small muted">
-        {isKoLocale ? "조직" : "Organization"}: <code>{organizationId || "-"}</code> /{" "}
-        {isKoLocale ? "세션 액터" : "Session actor"}: <code>{adminActorId || "-"}</code>
-      </p>
+      {showDevTools ? (
+        <p className="small muted">
+          {isKoLocale ? "조직" : "Organization"}: <code>{organizationId || "-"}</code> /{" "}
+          {isKoLocale ? "세션 액터" : "Session actor"}: <code>{adminActorId || "-"}</code>
+        </p>
+      ) : null}
       <div className="input-grid">
         <label>
           {isKoLocale ? "정렬" : "Sort"}

--- a/src/app/admin/approval-executions/page.tsx
+++ b/src/app/admin/approval-executions/page.tsx
@@ -361,6 +361,7 @@ export default function AdminApprovalExecutionsPage() {
       <section className="panel-grid">
         <ApprovalExecutionWorkConditionsPanel
           isKoLocale={isKoLocale}
+          showDevTools={showDevTools}
           organizationId={organizationId}
           adminActorId={adminActorId}
           sort={sort}

--- a/src/app/admin/people/page-view-directory-filters-panel.tsx
+++ b/src/app/admin/people/page-view-directory-filters-panel.tsx
@@ -2,6 +2,7 @@ import { type ActiveFilter, type Department, type Position, type UpdatedWindow }
 
 type AdminPeopleDirectoryFiltersPanelProps = {
   isKoLocale: boolean;
+  showDevTools: boolean;
   organizationId: string;
   adminActorId: string;
   isProductionRuntime: boolean;
@@ -30,6 +31,7 @@ type AdminPeopleDirectoryFiltersPanelProps = {
 
 export function AdminPeopleDirectoryFiltersPanel({
   isKoLocale,
+  showDevTools,
   organizationId,
   adminActorId,
   isProductionRuntime,
@@ -58,9 +60,11 @@ export function AdminPeopleDirectoryFiltersPanel({
   return (
     <article className="panel panel-directory-filters">
       <h2>{isKoLocale ? "필터" : "Filters"}</h2>
-      <p className="small muted">
-        {isKoLocale ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> / {isKoLocale ? "세션 액터" : "Session actor"}: <code>{adminActorId || "-"}</code>
-      </p>
+      {showDevTools ? (
+        <p className="small muted">
+          {isKoLocale ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> / {isKoLocale ? "세션 액터" : "Session actor"}: <code>{adminActorId || "-"}</code>
+        </p>
+      ) : null}
       {isProductionRuntime && !usesBearerToken ? (
         <p className="small fail">
           {isKoLocale

--- a/src/app/admin/people/page-view.tsx
+++ b/src/app/admin/people/page-view.tsx
@@ -206,6 +206,7 @@ export function AdminPeoplePageView(props: AdminPeoplePageViewProps) {
         <section id="directory-filters">
           <AdminPeopleDirectoryFiltersPanel
             isKoLocale={isKoLocale}
+            showDevTools={showDevTools}
             organizationId={organizationId}
             adminActorId={adminActorId}
             isProductionRuntime={isProductionRuntime}

--- a/src/components/leave-calendar/LeaveCalendarConsole.tsx
+++ b/src/components/leave-calendar/LeaveCalendarConsole.tsx
@@ -135,10 +135,12 @@ export default function LeaveCalendarConsole() {
       <section className="panel-grid">
         <article className="panel">
           <h2>{copy.queryTitle}</h2>
-          <p className="small">
-            {locale === "ko" ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> /{" "}
-            {locale === "ko" ? "세션 관리자" : "Session admin"}: <code>{adminActorId || "-"}</code>
-          </p>
+          {showDevTools ? (
+            <p className="small">
+              {locale === "ko" ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> /{" "}
+              {locale === "ko" ? "세션 관리자" : "Session admin"}: <code>{adminActorId || "-"}</code>
+            </p>
+          ) : null}
           <label>
             {copy.departmentIdOptionalLabel}
             <input value={departmentId} onChange={(event) => setDepartmentId(event.target.value)} />

--- a/work-items/WI-0704-admin-session-identity-devtools-gate-expansion.md
+++ b/work-items/WI-0704-admin-session-identity-devtools-gate-expansion.md
@@ -1,0 +1,23 @@
+# WI-0704 Admin Session Identity Devtools Gate Expansion
+
+## Summary
+- expanded devtools-only session identity exposure to additional admin/workspace surfaces:
+  - `src/app/admin/approval-executions/page-sections-work-conditions.tsx`
+  - `src/app/admin/people/page-view-directory-filters-panel.tsx`
+  - `src/components/leave-calendar/LeaveCalendarConsole.tsx`
+- propagated `showDevTools` props where needed:
+  - `src/app/admin/approval-executions/page.tsx`
+  - `src/app/admin/people/page-view.tsx`
+- preserved existing API/auth/runtime behavior and limited changes to UI visibility.
+
+## Scope
+- UI exposure control only
+- no API/schema/contract changes
+- no ops route changes
+
+## Testing
+- `npm.cmd exec tsx scripts/tests/e2e-wi0704-admin-session-identity-devtools-gate-expansion.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0643-admin-approval-executions-product-ux.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0648-admin-people-related-workspaces-locale-normalization.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0632-admin-leave-calendar-accrual-session-context-productization.test.ts`
+- `npm.cmd run typecheck`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0704-admin-session-identity-devtools-gate-expansion.md`
- Related Specs: N/A (UI-only enhancement)
- Related ADR: N/A
- hide read-only session identity metadata by default in admin approval-executions work conditions, admin people filters, and leave calendar query panels
- expose session identity metadata only when `NEXT_PUBLIC_FLOWHR_DEV_TOOLS` is enabled
- add WI-0704 regression guard and ROADMAP entry

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
Reason: UI-only visibility guard updates with no API/schema/security-impacting change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/app/admin/approval-executions/page-sections-work-conditions.tsx`, `src/app/admin/people/page-view-directory-filters-panel.tsx`, `src/components/leave-calendar/LeaveCalendarConsole.tsx`
- Backend-only reason: N/A
- Next UI WI: N/A

## Emergency Override (Break-Glass Only)

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID: N/A
- Approval:
  - Human approver: N/A
  - Co-sign approver (Orchestrator or QA): N/A
- Change scope: N/A
- Risk assessment: N/A
- Rollback plan: N/A
- Customer impact: N/A
- Temporary mitigation: N/A
- RCA due date (<= 48h after merge): N/A
