### PR TITLE
feat: WI-0705 gate employee guide/account session identity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -996,3 +996,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0703 payroll year-end filing/employee session identity devtools gate (hide read-only session organization/actor identifiers on /admin/payroll-year-end-filing and session organization/employee identifiers on /employee/year-end-input by default; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0703 regression guard)
 
 - WI-0704 admin session identity devtools gate expansion (hide read-only session organization/actor identifiers by default in /admin/approval-executions work-conditions panel, /admin/people filters panel, and /admin/leave-calendar query panel; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0704 regression guard)
+
+- WI-0705 employee guide/account session identity devtools gate (hide read-only session organization/employee identifiers by default in employee guide context panel and employee account session/query settings panel; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0705 regression guard)

--- a/scripts/tests/e2e-wi0705-employee-guide-account-session-identity-devtools-gate.test.ts
+++ b/scripts/tests/e2e-wi0705-employee-guide-account-session-identity-devtools-gate.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const employeeGuideDashboard = readUtf8(
+    "src",
+    "components",
+    "employee-guide",
+    "EmployeeGuideDashboard.tsx"
+  );
+  const employeeGuideSections = readUtf8(
+    "src",
+    "components",
+    "employee-guide",
+    "EmployeeGuideSections.tsx"
+  );
+  const employeeAccountOverviewPanels = readUtf8(
+    "src",
+    "components",
+    "employee-dashboard",
+    "EmployeeAccountOverviewPanels.tsx"
+  );
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0705-employee-guide-account-session-identity-devtools-gate.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(employeeGuideDashboard, /showDevTools=\{data\.showDevTools\}/);
+  assert.match(employeeGuideSections, /showDevTools: boolean;/);
+  assert.match(
+    employeeGuideSections,
+    /\{showDevTools \? \([\s\S]*Session organization[\s\S]*Session employee[\s\S]*\) : null\}/
+  );
+
+  assert.match(
+    employeeAccountOverviewPanels,
+    /\{showDevTools \? \([\s\S]*Session organization[\s\S]*Session employee[\s\S]*\) : null\}/
+  );
+  assert.match(employeeAccountOverviewPanels, /showDevTools \|\| !isProductionRuntime/);
+
+  assert.match(workItem, /WI-0705/i);
+  assert.match(workItem, /employee|guide|account|session|identity|devtools/i);
+  assert.match(roadmap, /WI-0705/i);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi0705-employee-guide-account-session-identity-devtools-gate.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/components/employee-dashboard/EmployeeAccountOverviewPanels.tsx
+++ b/src/components/employee-dashboard/EmployeeAccountOverviewPanels.tsx
@@ -77,10 +77,12 @@ export function EmployeeAccountOverviewPanels({
               {isKoLocale ? "세션/조회 설정" : "Session & Query Settings"}
             </summary>
             <div className="input-grid" style={{ marginTop: 12 }}>
-              <p className="small full">
-                {isKoLocale ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> /{" "}
-                {isKoLocale ? "세션 직원" : "Session employee"}: <code>{employeeId || "-"}</code>
-              </p>
+              {showDevTools ? (
+                <p className="small full">
+                  {isKoLocale ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> /{" "}
+                  {isKoLocale ? "세션 직원" : "Session employee"}: <code>{employeeId || "-"}</code>
+                </p>
+              ) : null}
               <label>
                 {isKoLocale ? "조회 기간 시작" : "Period Start"}
                 <input type="datetime-local" value={periodStart} onChange={(event) => onPeriodStartChange(event.target.value)} />

--- a/src/components/employee-guide/EmployeeGuideDashboard.tsx
+++ b/src/components/employee-guide/EmployeeGuideDashboard.tsx
@@ -39,6 +39,7 @@ export function EmployeeGuideDashboard() {
         copy={copy}
         organizationId={data.organizationId}
         employeeId={data.employeeId}
+        showDevTools={data.showDevTools}
         pendingLabel={data.pendingLabel}
         refreshDisabled={data.refreshDisabled}
         isKoLocale={locale === "ko"}

--- a/src/components/employee-guide/EmployeeGuideSections.tsx
+++ b/src/components/employee-guide/EmployeeGuideSections.tsx
@@ -17,6 +17,7 @@ type ContextPanelProps = {
   copy: EmployeeGuideCopy;
   organizationId: string;
   employeeId: string;
+  showDevTools: boolean;
   pendingLabel: string | null;
   refreshDisabled: boolean;
   isKoLocale: boolean;
@@ -28,6 +29,7 @@ export function EmployeeGuideContextPanel(props: ContextPanelProps) {
     copy,
     organizationId,
     employeeId,
+    showDevTools,
     pendingLabel,
     refreshDisabled,
     isKoLocale,
@@ -38,10 +40,12 @@ export function EmployeeGuideContextPanel(props: ContextPanelProps) {
     <section className="panel-grid">
       <article className="panel">
         <h2>{copy.contextTitle}</h2>
-        <p className="small">
-          {isKoLocale ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> /{" "}
-          {isKoLocale ? "세션 직원" : "Session employee"}: <code>{employeeId || "-"}</code>
-        </p>
+        {showDevTools ? (
+          <p className="small">
+            {isKoLocale ? "세션 조직" : "Session organization"}: <code>{organizationId || "-"}</code> /{" "}
+            {isKoLocale ? "세션 직원" : "Session employee"}: <code>{employeeId || "-"}</code>
+          </p>
+        ) : null}
         <div className="actions">
           <button className="btn btn-primary" onClick={onRefresh} disabled={refreshDisabled}>
             {copy.loadButton}

--- a/work-items/WI-0705-employee-guide-account-session-identity-devtools-gate.md
+++ b/work-items/WI-0705-employee-guide-account-session-identity-devtools-gate.md
@@ -1,0 +1,21 @@
+# WI-0705 Employee Guide/Account Session Identity Devtools Gate
+
+## Summary
+- gated read-only session identity metadata behind
+  `NEXT_PUBLIC_FLOWHR_DEV_TOOLS` in employee guide/account surfaces:
+  - `src/components/employee-guide/EmployeeGuideSections.tsx`
+  - `src/components/employee-dashboard/EmployeeAccountOverviewPanels.tsx`
+- propagated `showDevTools` into guide context panel via:
+  - `src/components/employee-guide/EmployeeGuideDashboard.tsx`
+- kept employee page runtime behavior, period filters, and logs behavior unchanged.
+
+## Scope
+- UI exposure control only
+- no API/schema/contract changes
+- no ops route changes
+
+## Testing
+- `npm.cmd exec tsx scripts/tests/e2e-wi0705-employee-guide-account-session-identity-devtools-gate.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0635-employee-guide-session-context-productization.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0634-employee-root-session-context-productization.test.ts`
+- `npm.cmd run typecheck`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0705-employee-guide-account-session-identity-devtools-gate.md`
- Related Specs: N/A (UI-only enhancement)
- Related ADR: N/A
- hide read-only session organization/employee metadata in employee guide context and employee account settings by default
- expose these session identity rows only when `NEXT_PUBLIC_FLOWHR_DEV_TOOLS` is enabled
- add WI-0705 regression guard and ROADMAP entry

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
Reason: UI-only visibility guard updates with no API/schema/security-impacting change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/employee-guide/EmployeeGuideSections.tsx`, `src/components/employee-dashboard/EmployeeAccountOverviewPanels.tsx`, `src/components/employee-guide/EmployeeGuideDashboard.tsx`
- Backend-only reason: N/A
- Next UI WI: N/A

## Emergency Override (Break-Glass Only)

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID: N/A
- Approval:
  - Human approver: N/A
  - Co-sign approver (Orchestrator or QA): N/A
- Change scope: N/A
- Risk assessment: N/A
- Rollback plan: N/A
- Customer impact: N/A
- Temporary mitigation: N/A
- RCA due date (<= 48h after merge): N/A
