### PR TITLE
feat: WI-0707 employee payslip session identity devtools gate completion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1000,3 +1000,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0705 employee guide/account session identity devtools gate (hide read-only session organization/employee identifiers by default in employee guide context panel and employee account session/query settings panel; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0705 regression guard)
 
 - WI-0706 leave accrual KO normalization and session devtools gate (normalize corrupted Korean runtime copy on /admin/leave-accrual and hide read-only session organization/admin identifiers in product mode; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0706 regression guard)
+
+- WI-0707 employee payslip session identity devtools gate completion (hide read-only session organization/employee identifiers on /employee/payslips filter panel and /employee/payslip-receipts filters panel by default; expose only when NEXT_PUBLIC_FLOWHR_DEV_TOOLS is enabled + e2e-wi0707 regression guard)

--- a/scripts/tests/e2e-wi0707-employee-payslip-session-identity-devtools-gate-completion.test.ts
+++ b/scripts/tests/e2e-wi0707-employee-payslip-session-identity-devtools-gate-completion.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+async function run() {
+  const employeePayslipFilterPanel = readUtf8(
+    "src",
+    "app",
+    "employee",
+    "payslips",
+    "page-view-filter-panel.tsx"
+  );
+  const payslipReceiptConsole = readUtf8(
+    "src",
+    "components",
+    "payslip-receipts",
+    "PayslipReceiptConsole.tsx"
+  );
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0707-employee-payslip-session-identity-devtools-gate-completion.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(
+    employeePayslipFilterPanel,
+    /\{showDevTools \? \(\s*<p className="small muted">[\s\S]*organizationIdOptional[\s\S]*filters\.employeeId[\s\S]*\) : null\}/
+  );
+
+  assert.match(
+    payslipReceiptConsole,
+    /\{showDevTools \? \(\s*<p className="small muted">[\s\S]*sessionOrganizationLabel[\s\S]*sessionEmployeeLabel[\s\S]*\) : null\}/
+  );
+
+  assert.match(workItem, /WI-0707/i);
+  assert.match(workItem, /payslip|receipt|session|identity|devtools/i);
+  assert.match(roadmap, /WI-0707/i);
+}
+
+run()
+  .then(() => {
+    console.log(
+      "e2e-wi0707-employee-payslip-session-identity-devtools-gate-completion.test passed"
+    );
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/employee/payslips/page-view-filter-panel.tsx
+++ b/src/app/employee/payslips/page-view-filter-panel.tsx
@@ -126,10 +126,12 @@ export function EmployeePayslipFilterPanel({
 
       <article className="panel">
         <h2>{pageCopy.filters.title}</h2>
-        <p className="small muted">
-          {pageCopy.filters.organizationIdOptional}: <code>{organizationId || "-"}</code> /{" "}
-          {pageCopy.filters.employeeId}: <code>{employeeId || "-"}</code>
-        </p>
+        {showDevTools ? (
+          <p className="small muted">
+            {pageCopy.filters.organizationIdOptional}: <code>{organizationId || "-"}</code> /{" "}
+            {pageCopy.filters.employeeId}: <code>{employeeId || "-"}</code>
+          </p>
+        ) : null}
         <div className="input-grid">
           <label>
             {pageCopy.filters.periodStart}

--- a/src/components/payslip-receipts/PayslipReceiptConsole.tsx
+++ b/src/components/payslip-receipts/PayslipReceiptConsole.tsx
@@ -189,10 +189,12 @@ export default function PayslipReceiptConsole() {
       <section className="panel-grid">
         <article className="panel">
           <h2>{copy.filtersTitle}</h2>
-          <p className="small muted">
-            {copy.sessionOrganizationLabel}: <code>{organizationId || "-"}</code> / {copy.sessionEmployeeLabel}:{" "}
-            <code>{employeeId || "-"}</code>
-          </p>
+          {showDevTools ? (
+            <p className="small muted">
+              {copy.sessionOrganizationLabel}: <code>{organizationId || "-"}</code> / {copy.sessionEmployeeLabel}:{" "}
+              <code>{employeeId || "-"}</code>
+            </p>
+          ) : null}
           <div className="input-grid">
             <label>{copy.periodStartLabel}<input type="date" value={periodStartDate} onChange={(event) => setPeriodStartDate(event.target.value)} /></label>
             <label>{copy.periodEndLabel}<input type="date" value={periodEndDate} onChange={(event) => setPeriodEndDate(event.target.value)} /></label>

--- a/work-items/WI-0707-employee-payslip-session-identity-devtools-gate-completion.md
+++ b/work-items/WI-0707-employee-payslip-session-identity-devtools-gate-completion.md
@@ -1,0 +1,20 @@
+# WI-0707 Employee Payslip Session Identity Devtools Gate Completion
+
+## Summary
+- hid read-only session identity metadata by default in employee payslip surfaces:
+  - `src/app/employee/payslips/page-view-filter-panel.tsx`
+  - `src/components/payslip-receipts/PayslipReceiptConsole.tsx`
+- session organization/employee identifiers are now visible only when
+  `NEXT_PUBLIC_FLOWHR_DEV_TOOLS` is enabled.
+- kept payslip/receipt API calls, search/filter behavior, and confirmation flow unchanged.
+
+## Scope
+- employee payslip UI exposure control only
+- no API/schema/contract changes
+- no ops route changes
+
+## Testing
+- `npm.cmd exec tsx scripts/tests/e2e-wi0707-employee-payslip-session-identity-devtools-gate-completion.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0627-employee-tax-receipt-session-context-productization.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0701-payroll-receipt-session-identity-devtools-gate.test.ts`
+- `npm.cmd run typecheck`


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0707-employee-payslip-session-identity-devtools-gate-completion.md`
- Related Specs: N/A (UI-only exposure control)
- Related ADR: N/A

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
Reason: UI-only visibility change on existing employee surfaces; no breaking/cross-domain/security-impacting contract change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/app/employee/payslips/page-view-filter-panel.tsx`, `src/components/payslip-receipts/PayslipReceiptConsole.tsx`
- Backend-only reason:
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):

## Testing

- `npm.cmd exec tsx scripts/tests/e2e-wi0707-employee-payslip-session-identity-devtools-gate-completion.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0627-employee-tax-receipt-session-context-productization.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0701-payroll-receipt-session-identity-devtools-gate.test.ts`
- `npm.cmd run typecheck`
