### PR TITLE
feat: WI-0796 admin analytics onboarding KPI panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1091,3 +1091,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0794 employee account overview korean copy repair (normalize corrupted Korean runtime copy in /employee account overview workspace-hub/priority/account/summary/checklist panels, preserve existing behavior and devtools gating, and lock with e2e-wi0794 regression guard)
 
 - WI-0795 employee layout dev admin label clarity (change employee nav admin copy to explicit dev-only labels in ko/en locale maps while preserving showDevTools gate in mobile/sidebar layout, and lock with e2e-wi0795 regression guard)
+
+- WI-0796 admin analytics onboarding KPI panel (add onboarding snapshot panel in /admin/analytics with active employee count, invite coverage, contract response coverage, and readiness score from people/invites/contracts APIs, with e2e-wi0796 regression guard)

--- a/scripts/tests/e2e-wi0796-admin-analytics-onboarding-kpi-panel.test.ts
+++ b/scripts/tests/e2e-wi0796-admin-analytics-onboarding-kpi-panel.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+function run() {
+  const dashboard = readUtf8(
+    "src",
+    "components",
+    "admin-kpi",
+    "AdminKpiDashboard.tsx"
+  );
+  const panel = readUtf8(
+    "src",
+    "components",
+    "admin-kpi",
+    "AdminOnboardingKpiPanel.tsx"
+  );
+  const copy = readUtf8("src", "components", "admin-kpi", "copy.ts");
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0796-admin-analytics-onboarding-kpi-panel.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(
+    dashboard,
+    /loadOnboardingKpi/,
+    "admin KPI dashboard should load onboarding KPI snapshot"
+  );
+  assert.match(
+    dashboard,
+    /\/api\/people\/employees/,
+    "onboarding KPI should query employees API"
+  );
+  assert.match(
+    dashboard,
+    /\/api\/auth\/invites/,
+    "onboarding KPI should query invites API"
+  );
+  assert.match(
+    dashboard,
+    /\/api\/contracts\/documents/,
+    "onboarding KPI should query contracts API"
+  );
+  assert.match(
+    dashboard,
+    /<AdminOnboardingKpiPanel copy=\{copy\} snapshot=\{onboardingKpi\} \/>/,
+    "analytics mode should render onboarding KPI panel"
+  );
+
+  assert.match(
+    panel,
+    /buildOnboardingKpiSnapshot/,
+    "onboarding KPI panel should expose snapshot builder"
+  );
+  assert.match(
+    panel,
+    /inviteCoveragePercent/,
+    "onboarding KPI snapshot should include invite coverage"
+  );
+  assert.match(
+    panel,
+    /contractResponseCoveragePercent/,
+    "onboarding KPI snapshot should include contract response coverage"
+  );
+  assert.match(
+    panel,
+    /readinessPercent/,
+    "onboarding KPI snapshot should include readiness percent"
+  );
+
+  assert.match(copy, /onboardingPanel:/);
+
+  assert.match(workItem, /WI-0796/i);
+  assert.match(workItem, /admin|analytics|onboarding|kpi/i);
+  assert.match(roadmap, /WI-0796/i);
+}
+
+run();
+console.log("e2e-wi0796-admin-analytics-onboarding-kpi-panel.test passed");

--- a/src/components/admin-kpi/AdminKpiDashboard.tsx
+++ b/src/components/admin-kpi/AdminKpiDashboard.tsx
@@ -1,6 +1,11 @@
 "use client";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AdminOnboardingKpiPanel,
+  buildOnboardingKpiSnapshot,
+  type OnboardingKpiSnapshot
+} from "@/components/admin-kpi/AdminOnboardingKpiPanel";
 import { AdminNoticesKpiPanel, buildNoticeReadCoverageSnapshot, type NoticeReadCoverageSnapshot } from "@/components/admin-kpi/AdminNoticesKpiPanel";
 import { AdminRecruitmentKpiPanel, buildRecruitmentKpiSnapshot, type RecruitmentKpiSnapshot } from "@/components/admin-kpi/AdminRecruitmentKpiPanel";
 import { AdminKpiAnalyticsControls, AdminKpiCards, AdminKpiContextPanel, AdminKpiLogsPanel, AdminKpiTrendPanel, type AdminKpiFocusMetric, type ApiLog, type RangeKpi } from "@/components/admin-kpi/AdminKpiSections";
@@ -18,6 +23,9 @@ type PayrollRunLite = { state: "PREVIEWED" | "CONFIRMED" };
 type RecruitmentOpeningLite = { status: "OPEN" | "CLOSED" };
 type RecruitmentReferralLite = { stage: "SUBMITTED" | "SCREENING" | "INTERVIEW" | "OFFER" | "HIRED" | "REJECTED" | "WITHDRAWN"; updatedAt: string };
 type ContractDocumentLite = { status: "DRAFT" | "APPROVAL_REQUESTED" | "SENT" | "SIGNED" | "REJECTED" | "EXPIRED" | "RENEWED"; approvalStatus: "NONE" | "PENDING" | "APPROVED" | "REJECTED"; requiresApproval: boolean; expiresAt: string | null };
+type OnboardingContractDocumentLite = { employeeId: string; status: "DRAFT" | "APPROVAL_REQUESTED" | "SENT" | "SIGNED" | "REJECTED" | "EXPIRED" | "RENEWED" };
+type EmployeeLite = { id: string; email: string | null };
+type AuthInviteLite = { email: string };
 type NoticeLite = { id: string; status: "DRAFT" | "SCHEDULED" | "PUBLISHED"; publishedAt: string | null; updatedAt: string };
 type NoticeReadReceiptLite = { noticeId: string; readAt: string };
 const contractSlaTrackedStatuses = new Set<ContractDocumentLite["status"]>(["DRAFT", "APPROVAL_REQUESTED", "SENT"]);
@@ -35,6 +43,7 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
   const [previousRangeKpi, setPreviousRangeKpi] = useState<RangeKpi | null>(null);
   const [recruitmentKpi, setRecruitmentKpi] = useState<RecruitmentKpiSnapshot | null>(null);
   const [noticesKpi, setNoticesKpi] = useState<NoticeReadCoverageSnapshot | null>(null);
+  const [onboardingKpi, setOnboardingKpi] = useState<OnboardingKpiSnapshot | null>(null);
   const [pendingLabel, setPendingLabel] = useState<string | null>(null);
   const [logs, setLogs] = useState<ApiLog[]>([]);
   const showDevTools = isTruthyFlag(process.env.NEXT_PUBLIC_FLOWHR_DEV_TOOLS);
@@ -172,6 +181,32 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     const noticesBody = await requestJson("notices", `/api/notices${buildQuery({ organizationId: organizationId.trim() || undefined, audience: "all", status: "all" })}`);
     return buildNoticeReadCoverageSnapshot({ notices: parseArray<NoticeLite>(noticesBody, "notices"), readReceipts: parseArray<NoticeReadReceiptLite>(noticesBody, "readReceipts") });
   }, [organizationId, requestJson]);
+  const loadOnboardingKpi = useCallback(async () => {
+    const targetOrganizationId = organizationId.trim() || undefined;
+    const [employeesBody, invitesBody, contractsBody] = await Promise.all([
+      requestJson(
+        "onboarding employees",
+        `/api/people/employees${buildQuery({ organizationId: targetOrganizationId, active: "true" })}`
+      ),
+      requestJson(
+        "onboarding invites",
+        `/api/auth/invites${buildQuery({
+          organizationId: targetOrganizationId,
+          role: "employee",
+          limit: "500"
+        })}`
+      ),
+      requestJson(
+        "onboarding contracts",
+        `/api/contracts/documents${buildQuery({ organizationId: targetOrganizationId })}`
+      )
+    ]);
+    return buildOnboardingKpiSnapshot({
+      employees: parseArray<EmployeeLite>(employeesBody, "employees"),
+      invites: parseArray<AuthInviteLite>(invitesBody, "invites"),
+      contractDocuments: parseArray<OnboardingContractDocumentLite>(contractsBody, "documents")
+    });
+  }, [organizationId, requestJson]);
   const loadKpis = useCallback(async () => {
     if (!usesBearerToken && !organizationId.trim()) {
       return;
@@ -180,20 +215,22 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     try {
       const currentRange = { from: toIso(periodStart), to: toIso(periodEnd) };
       const previousRange = computePreviousPeriodRange(currentRange.from, currentRange.to);
-      const [current, previous, recruitment, notices] = await Promise.all([
+      const [current, previous, recruitment, notices, onboarding] = await Promise.all([
         loadRangeKpi(currentRange),
         loadRangeKpi(previousRange),
         loadRecruitmentKpi(),
-        loadNoticesKpi()
+        loadNoticesKpi(),
+        loadOnboardingKpi()
       ]);
       setCurrentRangeKpi(current);
       setPreviousRangeKpi(previous);
       setRecruitmentKpi(recruitment);
       setNoticesKpi(notices);
+      setOnboardingKpi(onboarding);
     } finally {
       setPendingLabel(null);
     }
-  }, [copy.loadingLabel, loadNoticesKpi, loadRangeKpi, loadRecruitmentKpi, organizationId, periodEnd, periodStart, usesBearerToken]);
+  }, [copy.loadingLabel, loadNoticesKpi, loadOnboardingKpi, loadRangeKpi, loadRecruitmentKpi, organizationId, periodEnd, periodStart, usesBearerToken]);
   useEffect(() => {
     void loadKpis();
   }, [loadKpis]);
@@ -288,6 +325,7 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
         }}
       />
       {currentRangeKpi ? <AdminKpiCards copy={copy} kpi={currentRangeKpi} /> : <p className="small muted">{copy.noData}</p>}
+      {analyticsMode && onboardingKpi ? <AdminOnboardingKpiPanel copy={copy} snapshot={onboardingKpi} /> : null}
       {analyticsMode && recruitmentKpi ? <AdminRecruitmentKpiPanel copy={copy} snapshot={recruitmentKpi} /> : null}
       {analyticsMode && noticesKpi ? <AdminNoticesKpiPanel copy={copy} snapshot={noticesKpi} /> : null}
       <section className="panel-grid">

--- a/src/components/admin-kpi/AdminOnboardingKpiPanel.tsx
+++ b/src/components/admin-kpi/AdminOnboardingKpiPanel.tsx
@@ -1,0 +1,158 @@
+import { type KpiCopy } from "@/components/admin-kpi/copy";
+
+type EmployeeLite = {
+  id: string;
+  email: string | null;
+};
+
+type AuthInviteLite = {
+  email: string;
+};
+
+type ContractDocumentLite = {
+  employeeId: string;
+  status: "DRAFT" | "APPROVAL_REQUESTED" | "SENT" | "SIGNED" | "REJECTED" | "EXPIRED" | "RENEWED";
+};
+
+export type OnboardingKpiSnapshot = {
+  activeEmployeeCount: number;
+  inviteCoveragePercent: number;
+  pendingInviteCount: number;
+  contractResponseCoveragePercent: number;
+  pendingContractResponseCount: number;
+  readinessPercent: number;
+};
+
+function normalizeEmail(value: string | null | undefined) {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function formatPercent(value: number) {
+  return `${Math.round(Math.max(0, Math.min(100, value)))}%`;
+}
+
+function resolvePercent(part: number, total: number) {
+  if (total <= 0) {
+    return 0;
+  }
+  return (part / total) * 100;
+}
+
+export function buildOnboardingKpiSnapshot(input: {
+  employees: EmployeeLite[];
+  invites: AuthInviteLite[];
+  contractDocuments: ContractDocumentLite[];
+}): OnboardingKpiSnapshot {
+  const activeEmployeeCount = input.employees.length;
+  const inviteEligibleEmployees = input.employees.filter(
+    (employee) => normalizeEmail(employee.email).length > 0
+  );
+  const inviteEmailSet = new Set(
+    input.invites
+      .map((invite) => normalizeEmail(invite.email))
+      .filter((email) => email.length > 0)
+  );
+
+  const coveredInviteEmployeeCount = inviteEligibleEmployees.filter((employee) =>
+    inviteEmailSet.has(normalizeEmail(employee.email))
+  ).length;
+  const pendingInviteCount = Math.max(
+    0,
+    inviteEligibleEmployees.length - coveredInviteEmployeeCount
+  );
+  const inviteCoveragePercent = resolvePercent(
+    coveredInviteEmployeeCount,
+    inviteEligibleEmployees.length
+  );
+
+  const sentEmployeeSet = new Set(
+    input.contractDocuments
+      .filter((document) => ["SENT", "SIGNED", "RENEWED"].includes(document.status))
+      .map((document) => document.employeeId)
+  );
+  const respondedEmployeeSet = new Set(
+    input.contractDocuments
+      .filter((document) => ["SIGNED", "REJECTED", "RENEWED"].includes(document.status))
+      .map((document) => document.employeeId)
+  );
+
+  const pendingContractResponseCount = Math.max(
+    0,
+    sentEmployeeSet.size - respondedEmployeeSet.size
+  );
+  const contractResponseCoveragePercent = resolvePercent(
+    respondedEmployeeSet.size,
+    sentEmployeeSet.size
+  );
+
+  let readinessChecklistTotal = 0;
+  let readinessChecklistDone = 0;
+  const readinessChecks = [
+    activeEmployeeCount > 0,
+    inviteEligibleEmployees.length > 0 && pendingInviteCount === 0,
+    sentEmployeeSet.size > 0 && pendingContractResponseCount === 0
+  ];
+  for (const check of readinessChecks) {
+    readinessChecklistTotal += 1;
+    if (check) {
+      readinessChecklistDone += 1;
+    }
+  }
+  const readinessPercent = resolvePercent(
+    readinessChecklistDone,
+    readinessChecklistTotal
+  );
+
+  return {
+    activeEmployeeCount,
+    inviteCoveragePercent,
+    pendingInviteCount,
+    contractResponseCoveragePercent,
+    pendingContractResponseCount,
+    readinessPercent
+  };
+}
+
+type AdminOnboardingKpiPanelProps = {
+  copy: KpiCopy;
+  snapshot: OnboardingKpiSnapshot;
+};
+
+export function AdminOnboardingKpiPanel({
+  copy,
+  snapshot
+}: AdminOnboardingKpiPanelProps) {
+  return (
+    <article className="panel">
+      <h2>{copy.onboardingPanel.title}</h2>
+      <p className="small muted">{copy.onboardingPanel.description}</p>
+      <div className="kpi-strip">
+        <article className="kpi-card">
+          <p>{copy.onboardingPanel.activeEmployeeCount}</p>
+          <strong>{snapshot.activeEmployeeCount}</strong>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.onboardingPanel.inviteCoveragePercent}</p>
+          <strong>{formatPercent(snapshot.inviteCoveragePercent)}</strong>
+          <small>
+            {copy.onboardingPanel.pendingInviteCount}:{" "}
+            {snapshot.pendingInviteCount}
+          </small>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.onboardingPanel.contractResponseCoveragePercent}</p>
+          <strong>{formatPercent(snapshot.contractResponseCoveragePercent)}</strong>
+          <small>
+            {copy.onboardingPanel.pendingContractResponseCount}:{" "}
+            {snapshot.pendingContractResponseCount}
+          </small>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.onboardingPanel.readinessPercent}</p>
+          <strong>{formatPercent(snapshot.readinessPercent)}</strong>
+          <small>{copy.onboardingPanel.readinessHint}</small>
+        </article>
+      </div>
+    </article>
+  );
+}

--- a/src/components/admin-kpi/copy.ts
+++ b/src/components/admin-kpi/copy.ts
@@ -56,6 +56,17 @@ export type KpiCopy = {
     unreadAging3dCount: string;
     agingThreshold: string;
   };
+  onboardingPanel: {
+    title: string;
+    description: string;
+    activeEmployeeCount: string;
+    inviteCoveragePercent: string;
+    pendingInviteCount: string;
+    contractResponseCoveragePercent: string;
+    pendingContractResponseCount: string;
+    readinessPercent: string;
+    readinessHint: string;
+  };
   trendTitle: string;
   trendCurrent: string;
   trendPrevious: string;
@@ -135,6 +146,17 @@ const defaultCopy: KpiCopy = {
     unreadAging3dCount: "No-read notices (3d+)",
     agingThreshold: "published or updated 3+ days ago"
   },
+  onboardingPanel: {
+    title: "Onboarding readiness snapshot",
+    description: "Track invite coverage and contract response completion for active employees.",
+    activeEmployeeCount: "Active employees",
+    inviteCoveragePercent: "Invite coverage",
+    pendingInviteCount: "Pending invites",
+    contractResponseCoveragePercent: "Contract response coverage",
+    pendingContractResponseCount: "Pending contract responses",
+    readinessPercent: "Readiness score",
+    readinessHint: "People + invite + contract response checkpoints"
+  },
   trendTitle: "Period comparison",
   trendCurrent: "Current",
   trendPrevious: "Previous",
@@ -213,6 +235,17 @@ export const kpiCopyByLocale: Record<FlowLocale, KpiCopy> = {
       noReadNoticeCount: "미열람 공지 수",
       unreadAging3dCount: "3일+ 미열람 공지",
       agingThreshold: "게시/수정 후 3일 이상 경과"
+    },
+    onboardingPanel: {
+      title: "온보딩 준비 스냅샷",
+      description: "활성 직원 기준 초대 커버리지와 계약 응답 완료율을 확인합니다.",
+      activeEmployeeCount: "활성 직원 수",
+      inviteCoveragePercent: "초대 커버리지",
+      pendingInviteCount: "미발급 초대",
+      contractResponseCoveragePercent: "계약 응답 커버리지",
+      pendingContractResponseCount: "미응답 계약",
+      readinessPercent: "준비 점수",
+      readinessHint: "직원/초대/계약응답 체크포인트"
     },
     trendTitle: "기간 비교",
     trendCurrent: "현재",

--- a/work-items/WI-0796-admin-analytics-onboarding-kpi-panel.md
+++ b/work-items/WI-0796-admin-analytics-onboarding-kpi-panel.md
@@ -1,0 +1,27 @@
+# WI-0796 Admin Analytics Onboarding KPI Panel
+
+## Background
+
+- `/admin/analytics` already provides KPI panels for recruitment and notices, but onboarding execution visibility is missing.
+- Admins need a single analytics view to identify onboarding bottlenecks (invite coverage and contract response lag).
+
+## Scope
+
+- Add onboarding KPI snapshot builder/panel in `src/components/admin-kpi/AdminOnboardingKpiPanel.tsx`.
+- Extend `AdminKpiDashboard` to load onboarding metrics from:
+  - `/api/people/employees` (active employees)
+  - `/api/auth/invites` (employee invites)
+  - `/api/contracts/documents` (contract response coverage)
+- Render onboarding panel only in analytics mode.
+- Add localized copy keys and regression guard.
+
+## Acceptance Criteria
+
+1. `/admin/analytics` shows onboarding KPI panel with invite coverage, contract response coverage, and readiness score.
+2. Onboarding KPI is API-backed and organization-scoped.
+3. Regression test and roadmap/work-item links are updated.
+
+## Notes
+
+- Product analytics surface enhancement only.
+- No API contract/schema change.


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0796-admin-analytics-onboarding-kpi-panel.md`
- Related Specs: N/A (analytics UI enhancement)
- Related ADR: N/A
- Add `AdminOnboardingKpiPanel` and `buildOnboardingKpiSnapshot` to expose onboarding readiness metrics in `/admin/analytics`.
- Extend `AdminKpiDashboard` to load onboarding data from employees/invites/contracts APIs and render onboarding panel in analytics mode.
- Add localized onboarding panel copy in `admin-kpi/copy.ts` and WI-0796 regression guard.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

Reason: UI analytics panel addition using existing APIs only; no contract/schema/security-impacting changes.

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

Executed checks:
- `npm.cmd exec tsx scripts/tests/e2e-wi0796-admin-analytics-onboarding-kpi-panel.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0763-admin-analytics-recruitment-kpi-panel.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0769-admin-analytics-notices-read-kpi-panel.test.ts`
- `npm.cmd run typecheck`
- `python scripts/ci/check_contracts.py`
- `python scripts/ci/check_traceability.py`
- `npm.cmd run build`

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/admin-kpi/AdminKpiDashboard.tsx`, `src/components/admin-kpi/AdminOnboardingKpiPanel.tsx`, `src/components/admin-kpi/copy.ts`
- Backend-only reason: N/A
- Next UI WI: Continue analytics productization by adding payroll year-end risk snapshot panel.

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
