### PR TITLE
feat: WI-0797 admin analytics benefits KPI panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1093,3 +1093,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0795 employee layout dev admin label clarity (change employee nav admin copy to explicit dev-only labels in ko/en locale maps while preserving showDevTools gate in mobile/sidebar layout, and lock with e2e-wi0795 regression guard)
 
 - WI-0796 admin analytics onboarding KPI panel (add onboarding snapshot panel in /admin/analytics with active employee count, invite coverage, contract response coverage, and readiness score from people/invites/contracts APIs, with e2e-wi0796 regression guard)
+
+- WI-0797 admin analytics benefits KPI panel (add benefits snapshot panel in /admin/analytics with submitted/approved/rejected counts, 3-day aging submitted risk, and over-limit submitted count from benefits catalog/requests APIs, with e2e-wi0797 regression guard)

--- a/scripts/tests/e2e-wi0797-admin-analytics-benefits-kpi-panel.test.ts
+++ b/scripts/tests/e2e-wi0797-admin-analytics-benefits-kpi-panel.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+function run() {
+  const dashboard = readUtf8(
+    "src",
+    "components",
+    "admin-kpi",
+    "AdminKpiDashboard.tsx"
+  );
+  const panel = readUtf8(
+    "src",
+    "components",
+    "admin-kpi",
+    "AdminBenefitsKpiPanel.tsx"
+  );
+  const copy = readUtf8("src", "components", "admin-kpi", "copy.ts");
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0797-admin-analytics-benefits-kpi-panel.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(
+    dashboard,
+    /loadBenefitsKpi/,
+    "admin KPI dashboard should load benefits KPI snapshot"
+  );
+  assert.match(
+    dashboard,
+    /\/api\/benefits\/catalog/,
+    "benefits KPI should query benefits catalog API"
+  );
+  assert.match(
+    dashboard,
+    /\/api\/benefits\/requests/,
+    "benefits KPI should query benefits requests API"
+  );
+  assert.match(
+    dashboard,
+    /<AdminBenefitsKpiPanel copy=\{copy\} snapshot=\{benefitsKpi\} \/>/,
+    "analytics mode should render benefits KPI panel"
+  );
+
+  assert.match(
+    panel,
+    /buildBenefitsKpiSnapshot/,
+    "benefits KPI panel should expose snapshot builder"
+  );
+  assert.match(
+    panel,
+    /pendingAging3dCount/,
+    "benefits KPI snapshot should include pending aging risk metric"
+  );
+  assert.match(
+    panel,
+    /overLimitSubmittedCount/,
+    "benefits KPI snapshot should include over-limit submitted metric"
+  );
+
+  assert.match(copy, /benefitsPanel:/);
+
+  assert.match(workItem, /WI-0797/i);
+  assert.match(workItem, /admin|analytics|benefits|kpi/i);
+  assert.match(roadmap, /WI-0797/i);
+}
+
+run();
+console.log("e2e-wi0797-admin-analytics-benefits-kpi-panel.test passed");

--- a/src/components/admin-kpi/AdminBenefitsKpiPanel.tsx
+++ b/src/components/admin-kpi/AdminBenefitsKpiPanel.tsx
@@ -1,0 +1,118 @@
+import { type KpiCopy } from "@/components/admin-kpi/copy";
+
+type BenefitCatalogLite = {
+  id: string;
+  annualLimitKrw: number;
+  status: "ACTIVE" | "INACTIVE";
+};
+
+type BenefitRequestLite = {
+  benefitId: string;
+  amountKrw: number;
+  status: "SUBMITTED" | "APPROVED" | "REJECTED" | "CANCELED";
+  requestedAt: string;
+};
+
+export type BenefitsKpiSnapshot = {
+  submittedCount: number;
+  approvedCount: number;
+  rejectedCount: number;
+  pendingAging3dCount: number;
+  overLimitSubmittedCount: number;
+};
+
+const PENDING_AGING_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000;
+
+export function buildBenefitsKpiSnapshot(
+  input: {
+    catalog: BenefitCatalogLite[];
+    requests: BenefitRequestLite[];
+  },
+  now = new Date()
+): BenefitsKpiSnapshot {
+  const nowMs = now.getTime();
+  const annualLimitByBenefitId = new Map<string, number>();
+  input.catalog.forEach((item) =>
+    annualLimitByBenefitId.set(item.id, item.annualLimitKrw)
+  );
+
+  let submittedCount = 0;
+  let approvedCount = 0;
+  let rejectedCount = 0;
+  let pendingAging3dCount = 0;
+  let overLimitSubmittedCount = 0;
+
+  for (const request of input.requests) {
+    if (request.status === "SUBMITTED") {
+      submittedCount += 1;
+      const requestedAtMs = new Date(request.requestedAt).getTime();
+      if (
+        Number.isFinite(requestedAtMs) &&
+        nowMs - requestedAtMs >= PENDING_AGING_THRESHOLD_MS
+      ) {
+        pendingAging3dCount += 1;
+      }
+      const annualLimit = annualLimitByBenefitId.get(request.benefitId);
+      if (typeof annualLimit === "number" && request.amountKrw > annualLimit) {
+        overLimitSubmittedCount += 1;
+      }
+      continue;
+    }
+    if (request.status === "APPROVED") {
+      approvedCount += 1;
+      continue;
+    }
+    if (request.status === "REJECTED") {
+      rejectedCount += 1;
+    }
+  }
+
+  return {
+    submittedCount,
+    approvedCount,
+    rejectedCount,
+    pendingAging3dCount,
+    overLimitSubmittedCount
+  };
+}
+
+type AdminBenefitsKpiPanelProps = {
+  copy: KpiCopy;
+  snapshot: BenefitsKpiSnapshot;
+};
+
+export function AdminBenefitsKpiPanel({
+  copy,
+  snapshot
+}: AdminBenefitsKpiPanelProps) {
+  return (
+    <article className="panel">
+      <h2>{copy.benefitsPanel.title}</h2>
+      <p className="small muted">{copy.benefitsPanel.description}</p>
+      <div className="kpi-strip">
+        <article className="kpi-card">
+          <p>{copy.benefitsPanel.submittedCount}</p>
+          <strong>{snapshot.submittedCount}</strong>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.benefitsPanel.approvedCount}</p>
+          <strong>{snapshot.approvedCount}</strong>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.benefitsPanel.rejectedCount}</p>
+          <strong>{snapshot.rejectedCount}</strong>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.benefitsPanel.pendingAging3dCount}</p>
+          <strong>{snapshot.pendingAging3dCount}</strong>
+          <small>{copy.benefitsPanel.agingThreshold}</small>
+        </article>
+        <article className="kpi-card">
+          <p>{copy.benefitsPanel.overLimitSubmittedCount}</p>
+          <strong>{snapshot.overLimitSubmittedCount}</strong>
+          <small>{copy.benefitsPanel.overLimitHint}</small>
+        </article>
+      </div>
+    </article>
+  );
+}

--- a/src/components/admin-kpi/AdminKpiDashboard.tsx
+++ b/src/components/admin-kpi/AdminKpiDashboard.tsx
@@ -2,6 +2,11 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  AdminBenefitsKpiPanel,
+  buildBenefitsKpiSnapshot,
+  type BenefitsKpiSnapshot
+} from "@/components/admin-kpi/AdminBenefitsKpiPanel";
+import {
   AdminOnboardingKpiPanel,
   buildOnboardingKpiSnapshot,
   type OnboardingKpiSnapshot
@@ -26,6 +31,8 @@ type ContractDocumentLite = { status: "DRAFT" | "APPROVAL_REQUESTED" | "SENT" | 
 type OnboardingContractDocumentLite = { employeeId: string; status: "DRAFT" | "APPROVAL_REQUESTED" | "SENT" | "SIGNED" | "REJECTED" | "EXPIRED" | "RENEWED" };
 type EmployeeLite = { id: string; email: string | null };
 type AuthInviteLite = { email: string };
+type BenefitCatalogLite = { id: string; annualLimitKrw: number; status: "ACTIVE" | "INACTIVE" };
+type BenefitRequestLite = { benefitId: string; amountKrw: number; status: "SUBMITTED" | "APPROVED" | "REJECTED" | "CANCELED"; requestedAt: string };
 type NoticeLite = { id: string; status: "DRAFT" | "SCHEDULED" | "PUBLISHED"; publishedAt: string | null; updatedAt: string };
 type NoticeReadReceiptLite = { noticeId: string; readAt: string };
 const contractSlaTrackedStatuses = new Set<ContractDocumentLite["status"]>(["DRAFT", "APPROVAL_REQUESTED", "SENT"]);
@@ -43,6 +50,7 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
   const [previousRangeKpi, setPreviousRangeKpi] = useState<RangeKpi | null>(null);
   const [recruitmentKpi, setRecruitmentKpi] = useState<RecruitmentKpiSnapshot | null>(null);
   const [noticesKpi, setNoticesKpi] = useState<NoticeReadCoverageSnapshot | null>(null);
+  const [benefitsKpi, setBenefitsKpi] = useState<BenefitsKpiSnapshot | null>(null);
   const [onboardingKpi, setOnboardingKpi] = useState<OnboardingKpiSnapshot | null>(null);
   const [pendingLabel, setPendingLabel] = useState<string | null>(null);
   const [logs, setLogs] = useState<ApiLog[]>([]);
@@ -181,6 +189,23 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     const noticesBody = await requestJson("notices", `/api/notices${buildQuery({ organizationId: organizationId.trim() || undefined, audience: "all", status: "all" })}`);
     return buildNoticeReadCoverageSnapshot({ notices: parseArray<NoticeLite>(noticesBody, "notices"), readReceipts: parseArray<NoticeReadReceiptLite>(noticesBody, "readReceipts") });
   }, [organizationId, requestJson]);
+  const loadBenefitsKpi = useCallback(async () => {
+    const targetOrganizationId = organizationId.trim() || undefined;
+    const [catalogBody, requestsBody] = await Promise.all([
+      requestJson(
+        "benefits catalog",
+        `/api/benefits/catalog${buildQuery({ organizationId: targetOrganizationId })}`
+      ),
+      requestJson(
+        "benefits requests",
+        `/api/benefits/requests${buildQuery({ organizationId: targetOrganizationId })}`
+      )
+    ]);
+    return buildBenefitsKpiSnapshot({
+      catalog: parseArray<BenefitCatalogLite>(catalogBody, "catalog"),
+      requests: parseArray<BenefitRequestLite>(requestsBody, "requests")
+    });
+  }, [organizationId, requestJson]);
   const loadOnboardingKpi = useCallback(async () => {
     const targetOrganizationId = organizationId.trim() || undefined;
     const [employeesBody, invitesBody, contractsBody] = await Promise.all([
@@ -215,22 +240,24 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     try {
       const currentRange = { from: toIso(periodStart), to: toIso(periodEnd) };
       const previousRange = computePreviousPeriodRange(currentRange.from, currentRange.to);
-      const [current, previous, recruitment, notices, onboarding] = await Promise.all([
+      const [current, previous, recruitment, notices, benefits, onboarding] = await Promise.all([
         loadRangeKpi(currentRange),
         loadRangeKpi(previousRange),
         loadRecruitmentKpi(),
         loadNoticesKpi(),
+        loadBenefitsKpi(),
         loadOnboardingKpi()
       ]);
       setCurrentRangeKpi(current);
       setPreviousRangeKpi(previous);
       setRecruitmentKpi(recruitment);
       setNoticesKpi(notices);
+      setBenefitsKpi(benefits);
       setOnboardingKpi(onboarding);
     } finally {
       setPendingLabel(null);
     }
-  }, [copy.loadingLabel, loadNoticesKpi, loadOnboardingKpi, loadRangeKpi, loadRecruitmentKpi, organizationId, periodEnd, periodStart, usesBearerToken]);
+  }, [copy.loadingLabel, loadBenefitsKpi, loadNoticesKpi, loadOnboardingKpi, loadRangeKpi, loadRecruitmentKpi, organizationId, periodEnd, periodStart, usesBearerToken]);
   useEffect(() => {
     void loadKpis();
   }, [loadKpis]);
@@ -325,6 +352,7 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
         }}
       />
       {currentRangeKpi ? <AdminKpiCards copy={copy} kpi={currentRangeKpi} /> : <p className="small muted">{copy.noData}</p>}
+      {analyticsMode && benefitsKpi ? <AdminBenefitsKpiPanel copy={copy} snapshot={benefitsKpi} /> : null}
       {analyticsMode && onboardingKpi ? <AdminOnboardingKpiPanel copy={copy} snapshot={onboardingKpi} /> : null}
       {analyticsMode && recruitmentKpi ? <AdminRecruitmentKpiPanel copy={copy} snapshot={recruitmentKpi} /> : null}
       {analyticsMode && noticesKpi ? <AdminNoticesKpiPanel copy={copy} snapshot={noticesKpi} /> : null}

--- a/src/components/admin-kpi/copy.ts
+++ b/src/components/admin-kpi/copy.ts
@@ -56,6 +56,17 @@ export type KpiCopy = {
     unreadAging3dCount: string;
     agingThreshold: string;
   };
+  benefitsPanel: {
+    title: string;
+    description: string;
+    submittedCount: string;
+    approvedCount: string;
+    rejectedCount: string;
+    pendingAging3dCount: string;
+    agingThreshold: string;
+    overLimitSubmittedCount: string;
+    overLimitHint: string;
+  };
   onboardingPanel: {
     title: string;
     description: string;
@@ -146,6 +157,17 @@ const defaultCopy: KpiCopy = {
     unreadAging3dCount: "No-read notices (3d+)",
     agingThreshold: "published or updated 3+ days ago"
   },
+  benefitsPanel: {
+    title: "Benefits request snapshot",
+    description: "Track approval queue and risk signals for employee benefits requests.",
+    submittedCount: "Submitted requests",
+    approvedCount: "Approved requests",
+    rejectedCount: "Rejected requests",
+    pendingAging3dCount: "Submitted aging (3d+)",
+    agingThreshold: "submitted for 3+ days",
+    overLimitSubmittedCount: "Over-limit submitted",
+    overLimitHint: "amount exceeds annual limit"
+  },
   onboardingPanel: {
     title: "Onboarding readiness snapshot",
     description: "Track invite coverage and contract response completion for active employees.",
@@ -235,6 +257,17 @@ export const kpiCopyByLocale: Record<FlowLocale, KpiCopy> = {
       noReadNoticeCount: "미열람 공지 수",
       unreadAging3dCount: "3일+ 미열람 공지",
       agingThreshold: "게시/수정 후 3일 이상 경과"
+    },
+    benefitsPanel: {
+      title: "복리후생 요청 스냅샷",
+      description: "복리후생 요청 승인 큐와 위험 신호를 추적합니다.",
+      submittedCount: "제출 요청 수",
+      approvedCount: "승인 요청 수",
+      rejectedCount: "반려 요청 수",
+      pendingAging3dCount: "3일+ 제출 대기",
+      agingThreshold: "제출 후 3일 이상 경과",
+      overLimitSubmittedCount: "한도 초과 제출",
+      overLimitHint: "연간 한도 초과 요청"
     },
     onboardingPanel: {
       title: "온보딩 준비 스냅샷",

--- a/work-items/WI-0797-admin-analytics-benefits-kpi-panel.md
+++ b/work-items/WI-0797-admin-analytics-benefits-kpi-panel.md
@@ -1,0 +1,29 @@
+# WI-0797 Admin Analytics Benefits KPI Panel
+
+## Background
+
+- `/admin/analytics` currently covers recruitment/notices/onboarding snapshots, but benefits approval queue risk is not visible.
+- Benefits requests can stall or exceed policy limits without a single KPI summary surface.
+
+## Scope
+
+- Add `AdminBenefitsKpiPanel` and `buildBenefitsKpiSnapshot` in `src/components/admin-kpi/AdminBenefitsKpiPanel.tsx`.
+- Extend `AdminKpiDashboard` to load benefits metrics from:
+  - `/api/benefits/catalog`
+  - `/api/benefits/requests`
+- Render benefits panel in analytics mode with:
+  - submitted/approved/rejected counts
+  - 3-day aging submitted risk count
+  - over-limit submitted request count
+- Add localized copy keys and regression guard.
+
+## Acceptance Criteria
+
+1. `/admin/analytics` shows benefits KPI panel with queue status and risk indicators.
+2. Panel metrics are API-backed and organization-scoped.
+3. Regression test and roadmap/work-item links are updated.
+
+## Notes
+
+- Product analytics UI enhancement only.
+- No API contract/schema change.


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0797-admin-analytics-benefits-kpi-panel.md`
- Related Specs: N/A (analytics UI enhancement)
- Related ADR: N/A
- Add `AdminBenefitsKpiPanel` and `buildBenefitsKpiSnapshot` to expose benefits queue/risk metrics in `/admin/analytics`.
- Extend `AdminKpiDashboard` to load benefits data from catalog/requests APIs and render benefits panel in analytics mode.
- Add localized benefits panel copy and WI-0797 regression guard.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

Reason: analytics UI extension on existing APIs only; no contract/schema/security-impacting changes.

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

Executed checks:
- `npm.cmd exec tsx scripts/tests/e2e-wi0797-admin-analytics-benefits-kpi-panel.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0796-admin-analytics-onboarding-kpi-panel.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0763-admin-analytics-recruitment-kpi-panel.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0769-admin-analytics-notices-read-kpi-panel.test.ts`
- `npm.cmd run typecheck`
- `python scripts/ci/check_contracts.py`
- `python scripts/ci/check_traceability.py`
- `npm.cmd run build`

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/admin-kpi/AdminBenefitsKpiPanel.tsx`, `src/components/admin-kpi/AdminKpiDashboard.tsx`, `src/components/admin-kpi/copy.ts`
- Backend-only reason: N/A
- Next UI WI: add payroll year-end filing risk panel after introducing org-level filing summary endpoint.

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
