### PR TITLE
feat: WI-0865 admin analytics return focus parity for core workspaces

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1168,3 +1168,5 @@ Phase 8: Extensions (ATS, performance, expenses, analytics)
 - WI-0863 admin communication analytics return focus restore (propagate analyticsFocus from /admin/analytics into notices-benefits-recruitment KPI links and restore return-to-analytics focus query in destination workspaces while preserving existing source/focusMetric queue context behavior, with e2e-wi0863 regression guard)
 
 - WI-0864 admin contracts analytics return focus restore (propagate analyticsFocus from /admin/analytics contract KPI links and restore return-to-analytics focus query in /admin/contracts while preserving existing source/focusMetric banner behavior, with e2e-wi0864 regression guard)
+
+- WI-0865 admin analytics return focus parity (propagate analyticsFocus context from /admin/analytics into approval/payroll/attendance/leave workspace links and add focus-aware return-to-analytics actions in destination pages while preserving existing dashboard source banners and queue filters, with e2e-wi0865 regression guard)

--- a/scripts/tests/e2e-wi0798-admin-analytics-payroll-year-end-risk-kpi-panel.test.ts
+++ b/scripts/tests/e2e-wi0798-admin-analytics-payroll-year-end-risk-kpi-panel.test.ts
@@ -43,7 +43,7 @@ function run() {
   );
   assert.match(
     dashboard,
-    /<AdminPayrollRiskKpiPanel copy=\{copy\} snapshot=\{payrollRiskKpi\} \/>/,
+    /<AdminPayrollRiskKpiPanel[\s\S]*snapshot=\{payrollRiskKpi\}[\s\S]*\/>/,
     "analytics mode should render payroll risk KPI panel"
   );
 

--- a/scripts/tests/e2e-wi0803-admin-analytics-csv-focus-workspace-context.test.ts
+++ b/scripts/tests/e2e-wi0803-admin-analytics-csv-focus-workspace-context.test.ts
@@ -22,7 +22,15 @@ function run() {
 
   assert.match(dashboard, /buildAnalyticsFocusHref/);
   assert.match(dashboard, /const focusAnalyticsHref = buildAnalyticsFocusHref\(pathname, focusMetric\)/);
-  assert.match(dashboard, /const focusWorkspaceHref = appendAnalyticsSourceQuery\(focusWorkspace\.href, focusMetric\)/);
+  assert.ok(
+    /const focusWorkspaceHref = appendAnalyticsSourceQuery\(focusWorkspace\.href, focusMetric\)/.test(
+      dashboard
+    ) ||
+      /const focusWorkspaceHref = appendAnalyticsSourceQuery\(\s*focusWorkspace\.href,\s*focusMetric,\s*focusMetric\s*\)/.test(
+        dashboard
+      ),
+    "focus workspace href should append admin analytics context from selected focus metric"
+  );
   assert.match(dashboard, /focusWorkspaceLabel: focusWorkspace\.label/);
   assert.match(dashboard, /focusWorkspaceHref,/);
 

--- a/scripts/tests/e2e-wi0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.test.ts
+++ b/scripts/tests/e2e-wi0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function readUtf8(...parts: string[]) {
+  return readFileSync(join(process.cwd(), ...parts), "utf8");
+}
+
+function run() {
+  const dashboard = readUtf8("src", "components", "admin-kpi", "AdminKpiDashboard.tsx");
+  const payrollRiskPanel = readUtf8(
+    "src",
+    "components",
+    "admin-kpi",
+    "AdminPayrollRiskKpiPanel.tsx"
+  );
+  const approvalExecutions = readUtf8("src", "app", "admin", "approval-executions", "page.tsx");
+  const attendanceLive = readUtf8(
+    "src",
+    "components",
+    "admin-attendance-live",
+    "AdminAttendanceLiveDashboard.tsx"
+  );
+  const leaveCalendar = readUtf8(
+    "src",
+    "components",
+    "leave-calendar",
+    "LeaveCalendarConsole.tsx"
+  );
+  const payrollClose = readUtf8(
+    "src",
+    "components",
+    "payroll-close",
+    "PayrollClosePeriodConsole.tsx"
+  );
+  const analyticsContext = readUtf8(
+    "src",
+    "components",
+    "admin-kpi",
+    "admin-analytics-context.ts"
+  );
+  const workItem = readUtf8(
+    "work-items",
+    "WI-0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.md"
+  );
+  const roadmap = readUtf8("ROADMAP.md");
+
+  assert.match(dashboard, /contextParams\.set\("analyticsFocus", analyticsFocusMetric\)/);
+  assert.match(
+    dashboard,
+    /appendAnalyticsSourceQuery\(workspace\.href, metric, focusMetric\)/
+  );
+  assert.match(
+    dashboard,
+    /<AdminPayrollRiskKpiPanel[\s\S]*analyticsFocusMetric=\{focusMetric\}[\s\S]*\/>/
+  );
+  assert.match(dashboard, /focusWorkspaceContextHref/);
+
+  assert.match(payrollRiskPanel, /withAnalyticsSourceContext/);
+  assert.match(payrollRiskPanel, /source: "admin-analytics"/);
+  assert.match(payrollRiskPanel, /contextParams\.set\("analyticsFocus", options\.analyticsFocusMetric\)/);
+  assert.match(payrollRiskPanel, /focusMetric: "payrollConfirmedRate"/);
+
+  assert.match(
+    approvalExecutions,
+    /normalizeAdminAnalyticsFocusMetric\(\s*searchParams\.get\("analyticsFocus"\)\s*\)/
+  );
+  assert.match(
+    approvalExecutions,
+    /const analyticsBackHref = resolveAdminAnalyticsBackHref\(source, analyticsFocusMetric\);/
+  );
+  assert.match(approvalExecutions, /Back to analytics/);
+
+  assert.match(
+    attendanceLive,
+    /normalizeAdminAnalyticsFocusMetric\(\s*searchParams\.get\("analyticsFocus"\)\s*\)/
+  );
+  assert.match(attendanceLive, /resolveAdminAnalyticsBackHref\(source, analyticsFocusMetric\)/);
+  assert.match(attendanceLive, /Back to analytics/);
+
+  assert.match(
+    leaveCalendar,
+    /normalizeAdminAnalyticsFocusMetric\(\s*searchParams\.get\("analyticsFocus"\)\s*\)/
+  );
+  assert.match(leaveCalendar, /resolveAdminAnalyticsBackHref\(source, analyticsFocusMetric\)/);
+  assert.match(leaveCalendar, /Back to analytics/);
+
+  assert.match(
+    payrollClose,
+    /normalizeAdminAnalyticsFocusMetric\(\s*searchParams\.get\("analyticsFocus"\)\s*\)/
+  );
+  assert.match(payrollClose, /resolveAdminAnalyticsBackHref\(source, analyticsFocusMetric\)/);
+  assert.match(payrollClose, /Back to analytics/);
+
+  assert.match(analyticsContext, /export function normalizeAdminAnalyticsFocusMetric/);
+  assert.match(analyticsContext, /export function resolveAdminAnalyticsBackHref/);
+  assert.match(analyticsContext, /\/admin\/analytics\?focus=\$\{encodeURIComponent\(analyticsFocusMetric\)\}/);
+
+  assert.match(workItem, /WI-0865/i);
+  assert.match(workItem, /admin|analytics|return|focus|parity|approval|payroll|attendance|leave/i);
+  assert.match(roadmap, /WI-0865/i);
+}
+
+run();
+console.log(
+  "e2e-wi0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.test passed"
+);

--- a/src/app/admin/approval-executions/page.tsx
+++ b/src/app/admin/approval-executions/page.tsx
@@ -1,5 +1,6 @@
 ﻿"use client";
 
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
@@ -29,6 +30,10 @@ import type {
   ApprovalStageHistoryDto,
   EscalationResultDto
 } from "@/app/admin/approval-executions/page-types";
+import {
+  normalizeAdminAnalyticsFocusMetric,
+  resolveAdminAnalyticsBackHref
+} from "@/components/admin-kpi/admin-analytics-context";
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useI18n } from "@/lib/i18n/provider";
 
@@ -60,9 +65,26 @@ function normalizePositiveIntegerText(value: string | null, fallback: string) {
   return String(Math.floor(parsed));
 }
 
+function resolveApprovalAnalyticsFocusLabel(
+  isKoLocale: boolean,
+  focusMetric: string | null
+) {
+  if (focusMetric === "stalledApprovals") {
+    return isKoLocale ? "정체 결재 대기함" : "Stalled approval queue";
+  }
+  if (focusMetric === "pendingApprovals") {
+    return isKoLocale ? "결재 대기함" : "Pending approval queue";
+  }
+  return isKoLocale ? "결재 실행 현황" : "Approval execution queue";
+}
+
 export default function AdminApprovalExecutionsPage() {
   const searchParams = useSearchParams();
   const source = searchParams.get("source");
+  const analyticsFocusMetric = normalizeAdminAnalyticsFocusMetric(
+    searchParams.get("analyticsFocus")
+  );
+  const analyticsBackHref = resolveAdminAnalyticsBackHref(source, analyticsFocusMetric);
   const [domain, setDomain] = useState<ApprovalDomain | "">("");
   const [state, setState] = useState<ApprovalExecutionState | "">("PENDING");
   const [sort, setSort] = useState<ApprovalExecutionSort>("priority_desc");
@@ -145,6 +167,11 @@ export default function AdminApprovalExecutionsPage() {
     }
     return isKoLocale ? "결재 실행 현황" : "Approval execution queue";
   }, [isKoLocale, stalledHoursMin, state]);
+
+  const analyticsFocusLabel = useMemo(
+    () => resolveApprovalAnalyticsFocusLabel(isKoLocale, searchParams.get("focusMetric")),
+    [isKoLocale, searchParams]
+  );
 
   const selectedExecution = useMemo(() => {
     return executions.find((item) => toTargetKey(item) === selectedTargetKey) ?? null;
@@ -425,6 +452,19 @@ export default function AdminApprovalExecutionsPage() {
             {isKoLocale ? "관리자 대시보드에서 이동했습니다" : "Opened from admin dashboard"} ·{" "}
             {isKoLocale ? "집중 대기함" : "Focused queue"}: {dashboardFocusLabel}
           </p>
+        ) : null}
+        {source === "admin-analytics" ? (
+          <p className="small muted">
+            {isKoLocale ? "관리자 분석에서 이동했습니다" : "Opened from admin analytics"} ·{" "}
+            {isKoLocale ? "집중 대기함" : "Focused queue"}: {analyticsFocusLabel}
+          </p>
+        ) : null}
+        {analyticsBackHref ? (
+          <div className="actions" style={{ marginTop: 8 }}>
+            <Link href={analyticsBackHref} className="btn btn-secondary btn-small">
+              {isKoLocale ? "분석으로 돌아가기" : "Back to analytics"}
+            </Link>
+          </div>
         ) : null}
       </header>
 

--- a/src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx
+++ b/src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx
@@ -1,8 +1,8 @@
 ﻿"use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
-
 import {
   AdminAttendanceLiveContextPanel,
   AdminAttendanceLiveLogsPanel,
@@ -25,6 +25,10 @@ import {
   summarizeAttendanceLiveRows,
   type AttendanceLiveSnapshot
 } from "@/features/admin-attendance-live/summary";
+import {
+  normalizeAdminAnalyticsFocusMetric,
+  resolveAdminAnalyticsBackHref
+} from "@/components/admin-kpi/admin-analytics-context";
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useI18n } from "@/lib/i18n/provider";
 
@@ -38,11 +42,22 @@ type AttendanceRecordLite = {
   checkOutAt: string | null;
   state: "PENDING" | "APPROVED" | "REJECTED";
 };
-
 export function AdminAttendanceLiveDashboard() {
+  const searchParams = useSearchParams();
   const { locale } = useI18n();
   const copy = attendanceLiveCopyByLocale[locale];
   const runtimeLocale = locale === "ko" ? "ko-KR" : "en-US";
+  const source = searchParams.get("source");
+  const analyticsFocusMetric = normalizeAdminAnalyticsFocusMetric(
+    searchParams.get("analyticsFocus")
+  );
+  const analyticsBackHref = resolveAdminAnalyticsBackHref(source, analyticsFocusMetric);
+  const analyticsFocusLabel =
+    searchParams.get("focusMetric") === "attendanceApprovalRate"
+      ? locale === "ko"
+        ? "근태 승인율"
+        : "Attendance approval rate"
+      : copy.title;
   const initialRange = useMemo(() => getTodayRangeLocal(), []);
   const [periodStart, setPeriodStart] = useState(initialRange.from);
   const [periodEnd, setPeriodEnd] = useState(initialRange.to);
@@ -198,6 +213,26 @@ export function AdminAttendanceLiveDashboard() {
         <p className="eyebrow">FlowHR Admin</p>
         <h1>{copy.title}</h1>
         <p>{copy.description}</p>
+        {source === "admin-dashboard" ? (
+          <p className="small muted">
+            {locale === "ko"
+              ? "관리자 대시보드에서 이동했습니다"
+              : "Opened from admin dashboard"}
+          </p>
+        ) : null}
+        {source === "admin-analytics" ? (
+          <p className="small muted">
+            {locale === "ko" ? "관리자 분석에서 이동했습니다" : "Opened from admin analytics"} ·{" "}
+            {locale === "ko" ? "집중 큐" : "Focus queue"}: {analyticsFocusLabel}
+          </p>
+        ) : null}
+        {analyticsBackHref ? (
+          <div className="actions" style={{ marginTop: 8 }}>
+            <Link href={analyticsBackHref} className="btn btn-secondary btn-small">
+              {locale === "ko" ? "분석으로 돌아가기" : "Back to analytics"}
+            </Link>
+          </div>
+        ) : null}
       </header>
 
       {isProductionRuntime && !usesBearerToken ? (

--- a/src/components/admin-kpi/AdminKpiDashboard.tsx
+++ b/src/components/admin-kpi/AdminKpiDashboard.tsx
@@ -141,11 +141,15 @@ function resolveFocusWorkspaceLink(
 
 function appendAnalyticsSourceQuery(
   href: string,
-  focusMetric: AdminKpiFocusMetric
+  focusMetric: AdminKpiFocusMetric,
+  analyticsFocusMetric: AdminKpiFocusMetric = focusMetric
 ): string {
   const contextParams = new URLSearchParams({ source: "admin-analytics" });
   if (focusMetric !== "all") {
     contextParams.set("focusMetric", focusMetric);
+  }
+  if (analyticsFocusMetric !== "all") {
+    contextParams.set("analyticsFocus", analyticsFocusMetric);
   }
   const separator = href.includes("?") ? "&" : "?";
   return `${href}${separator}${contextParams.toString()}`;
@@ -464,12 +468,12 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     return adminKpiDrilldownMetrics.reduce<AdminKpiCardQuickLinkMap>((acc, metric) => {
       const workspace = resolveFocusWorkspaceLink(metric, copy);
       acc[metric] = {
-        href: appendAnalyticsSourceQuery(workspace.href, metric),
+        href: appendAnalyticsSourceQuery(workspace.href, metric, focusMetric),
         workspaceLabel: workspace.label
       };
       return acc;
     }, {});
-  }, [analyticsMode, copy]);
+  }, [analyticsMode, copy, focusMetric]);
   const contractKpi = useMemo(() => {
     if (!currentRangeKpi) {
       return null;
@@ -487,7 +491,11 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     }
     const generatedAt = new Date();
     const focusAnalyticsHref = buildAnalyticsFocusHref(pathname, focusMetric);
-    const focusWorkspaceHref = appendAnalyticsSourceQuery(focusWorkspace.href, focusMetric);
+    const focusWorkspaceHref = appendAnalyticsSourceQuery(
+      focusWorkspace.href,
+      focusMetric,
+      focusMetric
+    );
     const payload = buildAdminKpiCsvPayload({
       analyticsMode,
       trendRows: visibleTrendRows,
@@ -573,6 +581,10 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
     }
     return copy.focusWorkspaceTrendFlat;
   }, [copy.focusWorkspaceTrendDown, copy.focusWorkspaceTrendFlat, copy.focusWorkspaceTrendUp, focusedTrendRow]);
+  const focusWorkspaceContextHref = useMemo(
+    () => appendAnalyticsSourceQuery(focusWorkspace.href, focusMetric, focusMetric),
+    [focusMetric, focusWorkspace.href]
+  );
   return (
     <main className="saas-content">
       <header className="hero">
@@ -630,7 +642,7 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
           <h2>{copy.focusWorkspaceTitle}</h2>
           <p className="small muted">{copy.focusWorkspaceDescription}</p>
           <div className="actions" style={{ marginTop: 8 }}>
-            <Link href={focusWorkspace.href} className="btn btn-secondary">
+            <Link href={focusWorkspaceContextHref} className="btn btn-secondary">
               {copy.focusWorkspaceOpenAction}: {focusWorkspace.label}
             </Link>
             <button type="button" className="btn btn-secondary" onClick={() => {
@@ -658,7 +670,11 @@ export function AdminKpiDashboard({ analyticsMode = false }: AdminKpiDashboardPr
         </section>
       ) : null}
       {analyticsMode && payrollRiskKpi ? (
-        <AdminPayrollRiskKpiPanel copy={copy} snapshot={payrollRiskKpi} />
+        <AdminPayrollRiskKpiPanel
+          copy={copy}
+          snapshot={payrollRiskKpi}
+          analyticsFocusMetric={focusMetric}
+        />
       ) : null}
       {analyticsMode && contractKpi ? (
         <AdminContractKpiPanel copy={copy} snapshot={contractKpi} analyticsFocusMetric={focusMetric} />

--- a/src/components/admin-kpi/AdminPayrollRiskKpiPanel.tsx
+++ b/src/components/admin-kpi/AdminPayrollRiskKpiPanel.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { type KpiCopy } from "@/components/admin-kpi/copy";
+import { type AdminKpiFocusMetric } from "@/components/admin-kpi/AdminKpiSections";
 
 type PayrollRunRiskLite = {
   state: "PREVIEWED" | "CONFIRMED";
@@ -72,6 +73,7 @@ export function buildPayrollRiskKpiSnapshot(input: {
 type AdminPayrollRiskKpiPanelProps = {
   copy: KpiCopy;
   snapshot: PayrollRiskKpiSnapshot;
+  analyticsFocusMetric?: AdminKpiFocusMetric;
 };
 
 type PayrollRiskActionLink = {
@@ -79,27 +81,50 @@ type PayrollRiskActionLink = {
   label: string;
 };
 
+type AnalyticsContextOptions = {
+  focusMetric?: string;
+  analyticsFocusMetric?: AdminKpiFocusMetric;
+};
+
+function withAnalyticsSourceContext(
+  href: string,
+  options?: AnalyticsContextOptions
+) {
+  if (!options?.analyticsFocusMetric) {
+    return href;
+  }
+  const contextParams = new URLSearchParams({ source: "admin-analytics" });
+  if (options.focusMetric) {
+    contextParams.set("focusMetric", options.focusMetric);
+  }
+  if (options.analyticsFocusMetric !== "all") {
+    contextParams.set("analyticsFocus", options.analyticsFocusMetric);
+  }
+  const separator = href.includes("?") ? "&" : "?";
+  return `${href}${separator}${contextParams.toString()}`;
+}
+
 function resolvePrimaryPayrollRiskAction(
   snapshot: PayrollRiskKpiSnapshot,
   copy: KpiCopy
 ) {
   if (snapshot.previewedRunCount > 0) {
     return {
-      href: "/admin/payroll-close",
+      href: "/admin/payroll-close?focus=previewed",
       label: copy.payrollRiskPanel.actionOpenPayrollClose,
       reason: copy.payrollRiskPanel.priorityReasonPreviewed
     };
   }
   if (snapshot.confirmedUndistributedCount > 0) {
     return {
-      href: "/admin/payroll-payslip-delivery",
+      href: "/admin/payroll-payslip-delivery?focus=undistributed",
       label: copy.payrollRiskPanel.actionOpenPayslipDelivery,
       reason: copy.payrollRiskPanel.priorityReasonUndistributed
     };
   }
   if (snapshot.distributedUnacknowledgedCount > 0) {
     return {
-      href: "/admin/payroll-payslip-delivery",
+      href: "/admin/payroll-payslip-delivery?focus=undistributed",
       label: copy.payrollRiskPanel.actionOpenPayslipDelivery,
       reason: copy.payrollRiskPanel.priorityReasonUnacknowledged
     };
@@ -130,10 +155,15 @@ function buildPayrollRiskQuickActions(copy: KpiCopy): PayrollRiskActionLink[] {
 
 export function AdminPayrollRiskKpiPanel({
   copy,
-  snapshot
+  snapshot,
+  analyticsFocusMetric
 }: AdminPayrollRiskKpiPanelProps) {
   const primaryAction = resolvePrimaryPayrollRiskAction(snapshot, copy);
   const quickActions = buildPayrollRiskQuickActions(copy);
+  const primaryActionHref = withAnalyticsSourceContext(primaryAction.href, {
+    focusMetric: "payrollConfirmedRate",
+    analyticsFocusMetric
+  });
   return (
     <article className="panel">
       <h2>{copy.payrollRiskPanel.title}</h2>
@@ -172,7 +202,7 @@ export function AdminPayrollRiskKpiPanel({
           {primaryAction.reason}
         </p>
         <div className="actions" style={{ marginTop: 8 }}>
-          <Link href={primaryAction.href} className="btn btn-primary btn-small">
+          <Link href={primaryActionHref} className="btn btn-primary btn-small">
             {primaryAction.label}
           </Link>
         </div>
@@ -183,7 +213,10 @@ export function AdminPayrollRiskKpiPanel({
           {quickActions.map((action) => (
             <Link
               key={action.href}
-              href={action.href}
+              href={withAnalyticsSourceContext(action.href, {
+                focusMetric: "payrollConfirmedRate",
+                analyticsFocusMetric
+              })}
               className="btn btn-secondary btn-small"
             >
               {action.label}

--- a/src/components/admin-kpi/admin-analytics-context.ts
+++ b/src/components/admin-kpi/admin-analytics-context.ts
@@ -1,0 +1,37 @@
+import { type AdminKpiFocusMetric } from "@/components/admin-kpi/AdminKpiSections";
+
+const adminAnalyticsFocusMetricSet = new Set<AdminKpiFocusMetric>([
+  "all",
+  "pendingApprovals",
+  "stalledApprovals",
+  "attendanceApprovalRate",
+  "leaveApprovedDays",
+  "payrollConfirmedRate",
+  "contractDecisionQueueCount",
+  "contractSlaOverdueCount"
+]);
+
+export function normalizeAdminAnalyticsFocusMetric(
+  value: string | null
+): AdminKpiFocusMetric | null {
+  if (!value) {
+    return null;
+  }
+  if (adminAnalyticsFocusMetricSet.has(value as AdminKpiFocusMetric)) {
+    return value as AdminKpiFocusMetric;
+  }
+  return null;
+}
+
+export function resolveAdminAnalyticsBackHref(
+  source: string | null,
+  analyticsFocusMetric: AdminKpiFocusMetric | null
+) {
+  if (source !== "admin-analytics") {
+    return "";
+  }
+  if (!analyticsFocusMetric || analyticsFocusMetric === "all") {
+    return "/admin/analytics";
+  }
+  return `/admin/analytics?focus=${encodeURIComponent(analyticsFocusMetric)}`;
+}

--- a/src/components/leave-calendar/LeaveCalendarConsole.tsx
+++ b/src/components/leave-calendar/LeaveCalendarConsole.tsx
@@ -1,8 +1,13 @@
 "use client";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useI18n } from "@/lib/i18n/provider";
+import {
+  normalizeAdminAnalyticsFocusMetric,
+  resolveAdminAnalyticsBackHref
+} from "@/components/admin-kpi/admin-analytics-context";
 import { leaveCalendarCopyByLocale } from "@/components/leave-calendar/copy";
 import type { ApiLog, LeaveCalendarResponse } from "@/components/leave-calendar/types";
 import { addDays, defaultCalendarRange, toDateInputValue, toSeoulIsoStart } from "@/components/leave-calendar/types";
@@ -13,8 +18,20 @@ function isTruthyFlag(value: string | undefined) {
 }
 
 export default function LeaveCalendarConsole() {
+  const searchParams = useSearchParams();
   const { locale } = useI18n();
   const copy = leaveCalendarCopyByLocale[locale];
+  const source = searchParams.get("source");
+  const analyticsFocusMetric = normalizeAdminAnalyticsFocusMetric(
+    searchParams.get("analyticsFocus")
+  );
+  const analyticsBackHref = resolveAdminAnalyticsBackHref(source, analyticsFocusMetric);
+  const analyticsFocusLabel =
+    searchParams.get("focusMetric") === "leaveApprovedDays"
+      ? locale === "ko"
+        ? "승인 휴가일"
+        : "Approved leave days"
+      : copy.title;
   const runtimeLocale = locale === "ko" ? "ko-KR" : "en-US";
   const formatDateByLocale = (value: string) => new Date(value).toLocaleDateString(runtimeLocale);
   const formatDateTimeByLocale = (value: string) => new Date(value).toLocaleString(runtimeLocale);
@@ -131,6 +148,26 @@ export default function LeaveCalendarConsole() {
         <p className="eyebrow">{copy.heroEyebrow}</p>
         <h1>{copy.title}</h1>
         <p>{copy.description}</p>
+        {source === "admin-dashboard" ? (
+          <p className="small muted">
+            {locale === "ko"
+              ? "관리자 대시보드에서 이동했습니다"
+              : "Opened from admin dashboard"}
+          </p>
+        ) : null}
+        {source === "admin-analytics" ? (
+          <p className="small muted">
+            {locale === "ko" ? "관리자 분석에서 이동했습니다" : "Opened from admin analytics"} ·{" "}
+            {locale === "ko" ? "집중 큐" : "Focus queue"}: {analyticsFocusLabel}
+          </p>
+        ) : null}
+        {analyticsBackHref ? (
+          <div className="actions" style={{ marginTop: 8 }}>
+            <Link href={analyticsBackHref} className="btn btn-secondary btn-small">
+              {locale === "ko" ? "분석으로 돌아가기" : "Back to analytics"}
+            </Link>
+          </div>
+        ) : null}
       </header>
       <section className="panel-grid">
         <article className="panel">
@@ -262,6 +299,11 @@ export default function LeaveCalendarConsole() {
         <article className="panel">
           <h2>{locale === "ko" ? "워크스페이스 이동" : "Workspace shortcuts"}</h2>
           <div className="panel-actions">
+            {analyticsBackHref ? (
+              <Link href={analyticsBackHref} className="btn btn-secondary">
+                {locale === "ko" ? "분석으로 돌아가기" : "Back to analytics"}
+              </Link>
+            ) : null}
             <Link href="/admin" className="btn btn-secondary">
               {copy.backToAdminAction}
             </Link>

--- a/src/components/payroll-close/PayrollClosePeriodConsole.tsx
+++ b/src/components/payroll-close/PayrollClosePeriodConsole.tsx
@@ -6,6 +6,10 @@ import { useMemo, useState } from "react";
 
 import { payrollCloseCopyByLocale } from "@/components/payroll-close/copy";
 import { isTruthyFlag } from "@/app/admin/page-helpers";
+import {
+  normalizeAdminAnalyticsFocusMetric,
+  resolveAdminAnalyticsBackHref
+} from "@/components/admin-kpi/admin-analytics-context";
 import { useSupabaseSession } from "@/lib/client/useSupabaseSession";
 import { useI18n } from "@/lib/i18n/provider";
 import type { ApiLog, PayrollClosePeriodResponse } from "@/components/payroll-close/types";
@@ -47,12 +51,22 @@ export default function PayrollClosePeriodConsole() {
   const copy = payrollCloseCopyByLocale[locale];
   const source = searchParams.get("source");
   const focus = searchParams.get("focus");
+  const analyticsFocusMetric = normalizeAdminAnalyticsFocusMetric(
+    searchParams.get("analyticsFocus")
+  );
+  const analyticsBackHref = resolveAdminAnalyticsBackHref(source, analyticsFocusMetric);
   const focusLabel =
     focus === "previewed"
       ? copy.focusPreviewedLabel
       : focus === "undistributed"
         ? copy.focusUndistributedLabel
         : copy.focusAllLabel;
+  const analyticsFocusLabel =
+    searchParams.get("focusMetric") === "payrollConfirmedRate"
+      ? locale === "ko"
+        ? "급여 확정률"
+        : "Payroll confirmation rate"
+      : focusLabel;
   const bearerToken = isProductionRuntime ? (supabaseSession?.accessToken ?? "") : "";
   const usesBearerToken = bearerToken.trim().length > 0;
 
@@ -158,6 +172,19 @@ export default function PayrollClosePeriodConsole() {
           <p className="small muted">
             {copy.dashboardSourceBanner} · {copy.dashboardSourceFocusLabel}: {focusLabel}
           </p>
+        ) : null}
+        {source === "admin-analytics" ? (
+          <p className="small muted">
+            {locale === "ko" ? "관리자 분석에서 이동했습니다" : "Opened from admin analytics"} ·{" "}
+            {locale === "ko" ? "집중 큐" : "Focus queue"}: {analyticsFocusLabel}
+          </p>
+        ) : null}
+        {analyticsBackHref ? (
+          <div className="actions" style={{ marginTop: 8 }}>
+            <Link href={analyticsBackHref} className="btn btn-secondary btn-small">
+              {locale === "ko" ? "분석으로 돌아가기" : "Back to analytics"}
+            </Link>
+          </div>
         ) : null}
       </header>
 

--- a/work-items/WI-0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.md
+++ b/work-items/WI-0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.md
@@ -1,0 +1,34 @@
+# WI-0865 Admin Analytics Return Focus Parity (Approval/Payroll/Attendance/Leave)
+
+## Summary
+- Extended admin analytics workspace context links to preserve selected analytics focus (`analyticsFocus`) alongside queue metric (`focusMetric`).
+- Added analytics-origin banners and "Back to analytics" return actions for:
+  - `/admin/approval-executions`
+  - `/admin/attendance-live`
+  - `/admin/leave-calendar`
+  - `/admin/payroll-close`
+- Propagated analytics focus context into payroll risk panel priority/quick links.
+
+## Scope
+- `src/components/admin-kpi/AdminKpiDashboard.tsx`
+- `src/components/admin-kpi/AdminPayrollRiskKpiPanel.tsx`
+- `src/components/admin-kpi/admin-analytics-context.ts` (new)
+- `src/app/admin/approval-executions/page.tsx`
+- `src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx`
+- `src/components/leave-calendar/LeaveCalendarConsole.tsx`
+- `src/components/payroll-close/PayrollClosePeriodConsole.tsx`
+- `scripts/tests/e2e-wi0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.test.ts` (new)
+- `scripts/tests/e2e-wi0798-admin-analytics-payroll-year-end-risk-kpi-panel.test.ts` (updated)
+- `scripts/tests/e2e-wi0803-admin-analytics-csv-focus-workspace-context.test.ts` (updated)
+
+## Acceptance
+1. Admin analytics links carry both source (`source=admin-analytics`) and selected focus context (`analyticsFocus`) to target workspaces.
+2. Approval, attendance, leave, and payroll-close workspaces parse analytics focus context and expose an analytics return CTA.
+3. Existing dashboard/admin source banners and queue-focused behavior remain available.
+
+## Validation
+- `npm.cmd exec tsx scripts/tests/e2e-wi0798-admin-analytics-payroll-year-end-risk-kpi-panel.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0803-admin-analytics-csv-focus-workspace-context.test.ts`
+- `npm.cmd exec tsx scripts/tests/e2e-wi0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.test.ts`
+- `python scripts/ci/check_traceability.py`
+- `npm.cmd run build`


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.md`
- Related Specs: N/A (UI/context enhancement in existing admin analytics flows)
- Related ADR: N/A

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- Reason: UI-only context propagation/return-navigation enhancement on existing admin surfaces with no contract or cross-domain breaking change.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/admin-kpi/AdminKpiDashboard.tsx`, `src/components/admin-kpi/AdminPayrollRiskKpiPanel.tsx`, `src/app/admin/approval-executions/page.tsx`, `src/components/admin-attendance-live/AdminAttendanceLiveDashboard.tsx`, `src/components/leave-calendar/LeaveCalendarConsole.tsx`, `src/components/payroll-close/PayrollClosePeriodConsole.tsx`
- Backend-only reason: N/A
- Next UI WI: N/A

## Testing

- `npm.cmd exec tsx scripts/tests/e2e-wi0798-admin-analytics-payroll-year-end-risk-kpi-panel.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0803-admin-analytics-csv-focus-workspace-context.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0853-admin-payroll-queue-dashboard-source-banner.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0855-admin-dashboard-queue-open-source-context-links.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0864-admin-contracts-analytics-return-focus-restore.test.ts`
- `npm.cmd exec tsx scripts/tests/e2e-wi0865-admin-analytics-return-focus-parity-approval-payroll-attendance-leave.test.ts`
- `python scripts/ci/check_traceability.py`
- `npm.cmd run build`
