### PR TITLE
WI-0995: payroll close tax breakdown display

### DIFF
--- a/scripts/tests/e2e-wi0185-payroll-withholding-close-period-baseline.test.ts
+++ b/scripts/tests/e2e-wi0185-payroll-withholding-close-period-baseline.test.ts
@@ -111,6 +111,26 @@ async function run() {
     otherDeductionsKrw: 1000,
     totalDeductionsKrw: 13000,
     netPayKrw: 87000,
+    deductionBreakdown: {
+      mode: "statutory_kr_baseline",
+      additional: {
+        components: {
+          incomeTaxKrw: 6364,
+          localIncomeTaxKrw: 636,
+          nationalPensionKrw: 2000,
+          healthInsuranceKrw: 1600,
+          longTermCareKrw: 200,
+          employmentInsuranceKrw: 800,
+          workersCompensationKrw: 400
+        },
+        insuranceBreakdown: {
+          nps: 2000,
+          nhi: 1600,
+          ei: 800,
+          wci: 400
+        }
+      }
+    },
     sourceRecordCount: 1
   });
   await memoryDataAccess.payroll.update(confirmedRun.id, {
@@ -130,6 +150,26 @@ async function run() {
     otherDeductionsKrw: 500,
     totalDeductionsKrw: 11000,
     netPayKrw: 79000,
+    deductionBreakdown: {
+      mode: "statutory_kr_baseline",
+      additional: {
+        components: {
+          incomeTaxKrw: 5455,
+          localIncomeTaxKrw: 545,
+          nationalPensionKrw: 1800,
+          healthInsuranceKrw: 1400,
+          longTermCareKrw: 150,
+          employmentInsuranceKrw: 700,
+          workersCompensationKrw: 450
+        },
+        insuranceBreakdown: {
+          nps: 1800,
+          nhi: 1400,
+          ei: 700,
+          wci: 450
+        }
+      }
+    },
     sourceRecordCount: 1
   });
 
@@ -161,7 +201,17 @@ async function run() {
       totalsKrw: {
         grossPayKrw: number;
         withholdingTaxKrw: number;
+        withholdingBreakdownKrw: {
+          incomeTaxKrw: number;
+          residentTaxKrw: number;
+        };
         socialInsuranceKrw: number;
+        socialInsuranceBreakdownKrw: {
+          nationalPensionKrw: number;
+          healthInsuranceKrw: number;
+          employmentInsuranceKrw: number;
+          industrialAccidentKrw: number;
+        };
         otherDeductionsKrw: number;
         totalDeductionsKrw: number;
         netPayKrw: number;
@@ -186,7 +236,17 @@ async function run() {
   assert.deepEqual(previewBody.summary.totalsKrw, {
     grossPayKrw: 100000,
     withholdingTaxKrw: 7000,
+    withholdingBreakdownKrw: {
+      incomeTaxKrw: 6364,
+      residentTaxKrw: 636
+    },
     socialInsuranceKrw: 5000,
+    socialInsuranceBreakdownKrw: {
+      nationalPensionKrw: 2000,
+      healthInsuranceKrw: 1800,
+      employmentInsuranceKrw: 800,
+      industrialAccidentKrw: 400
+    },
     otherDeductionsKrw: 1000,
     totalDeductionsKrw: 13000,
     netPayKrw: 87000
@@ -236,7 +296,22 @@ async function run() {
         blockingRunIds: string[];
         blockingReasons: string[];
       };
-      totalsKrw: { grossPayKrw: number; withholdingTaxKrw: number; socialInsuranceKrw: number; netPayKrw: number };
+      totalsKrw: {
+        grossPayKrw: number;
+        withholdingTaxKrw: number;
+        withholdingBreakdownKrw: {
+          incomeTaxKrw: number;
+          residentTaxKrw: number;
+        };
+        socialInsuranceKrw: number;
+        socialInsuranceBreakdownKrw: {
+          nationalPensionKrw: number;
+          healthInsuranceKrw: number;
+          employmentInsuranceKrw: number;
+          industrialAccidentKrw: number;
+        };
+        netPayKrw: number;
+      };
       settlementKrw: { withholdingTaxDeltaKrw: number; socialInsuranceDeltaKrw: number; remittanceDeltaKrw: number };
     };
   }>(applyResponse);
@@ -250,7 +325,17 @@ async function run() {
   });
   assert.equal(applyBody.summary.totalsKrw.grossPayKrw, 190000);
   assert.equal(applyBody.summary.totalsKrw.withholdingTaxKrw, 13000);
+  assert.deepEqual(applyBody.summary.totalsKrw.withholdingBreakdownKrw, {
+    incomeTaxKrw: 11819,
+    residentTaxKrw: 1181
+  });
   assert.equal(applyBody.summary.totalsKrw.socialInsuranceKrw, 9500);
+  assert.deepEqual(applyBody.summary.totalsKrw.socialInsuranceBreakdownKrw, {
+    nationalPensionKrw: 3800,
+    healthInsuranceKrw: 3350,
+    employmentInsuranceKrw: 1500,
+    industrialAccidentKrw: 850
+  });
   assert.equal(applyBody.summary.totalsKrw.netPayKrw, 166000);
   assert.equal(applyBody.summary.settlementKrw.withholdingTaxDeltaKrw, 7000);
   assert.equal(applyBody.summary.settlementKrw.socialInsuranceDeltaKrw, 5500);

--- a/specs/payroll/api.yaml
+++ b/specs/payroll/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: FlowHR Payroll API
-  version: 1.61.0
+  version: 1.61.1
 paths:
   /payroll/runs:
     get:
@@ -80,7 +80,7 @@ paths:
   /payroll/runs/close-period:
     post:
       summary: Preview or apply payroll period close with withholding settlement delta
-      description: Summarizes confirmed payroll runs for a period and computes withholding/social/net deltas against prior-paid values. `apply=true` is rejected when unconfirmed runs remain.
+      description: Summarizes confirmed payroll runs for a period, including withholding breakdown (`incomeTaxKrw`, `residentTaxKrw`) and 4-insurance breakdown (`nationalPensionKrw`, `healthInsuranceKrw`, `employmentInsuranceKrw`, `industrialAccidentKrw`), and computes withholding/social/net deltas against prior-paid values. `apply=true` is rejected when unconfirmed runs remain.
       responses:
         "200":
           description: Payroll period close summary generated

--- a/specs/payroll/contract.yaml
+++ b/specs/payroll/contract.yaml
@@ -1,5 +1,5 @@
 owner: payroll-agent
-version: 1.61.0
+version: 1.61.1
 scope:
   in:
     - gross pay preview from approved attendance aggregates
@@ -101,7 +101,7 @@ api:
       description: Generate 4-insurance settlement preview with employee/employer contribution breakdown, optional caps, optional settlement insurance rounding (`mode` + component units), optional policy preset selection (`insurancePolicyPresetId`) or auto-selection (`insurancePolicyPresetAuto` + optional `insurancePolicyAsOf`), raw contribution trace, and prior-withheld/prior-paid deltas. Admin `/admin/payroll-insurance` may expose manual/preset-id/preset-auto controls while preserving the same request contract.
     - method: POST
       path: /payroll/runs/close-period
-      description: Preview/apply payroll period close from confirmed runs with withholding/social/net settlement deltas and blocking reasons when unconfirmed runs remain.
+      description: Preview/apply payroll period close from confirmed runs with withholding breakdown (income/resident), 4-insurance breakdown (national/health/employment/industrial-accident), and withholding/social/net settlement deltas plus blocking reasons when unconfirmed runs remain.
     - method: POST
       path: /payroll/payslips/distribute
       description: Preview/apply confirmed payslip distribution by period with delivery metadata (`in_app`/`email`) and per-run delivery status.
@@ -434,7 +434,7 @@ test_plan:
     - preview-insurance-settlement validates monthly-boundary guard in Asia/Seoul when requireMonthlyBoundary=true
     - preview-insurance-settlement supports deterministic insurance policy preset selection (`insurancePolicyPresetId`) and auto-selection (`insurancePolicyPresetAuto` + optional `insurancePolicyAsOf`) with mixed-mode validation guards
     - admin payroll-insurance policy mode controls deterministically wire manual/preset-id/preset-auto request payload and show summary policy preset/rate/cap trace
-    - close-period preview returns run-state summary (confirmed/previewed) and withholding/social/net settlement deltas
+    - close-period preview returns run-state summary (confirmed/previewed), withholding breakdown (income/resident), 4-insurance breakdown (national/health/employment/industrial-accident), and withholding/social/net settlement deltas
     - close-period apply rejects requests when unconfirmed runs remain
     - close-period rejects requests when payroll_close_period_v1 is disabled
     - payslip distribution dry-run/apply returns deterministic run-state summary and delivery counts
@@ -570,7 +570,7 @@ test_plan:
     - admin payroll-insurance policy mode control and summary trace deterministic checks
     - year-end insurance reconciliation delta/status and monthly breakdown remain deterministic for same run/finalization replay
     - year-end preflight checklist ready/fail/warn and guard-detail outputs remain deterministic for same run/submission/finalization replay
-    - close-period withholding/social/net aggregation and settlement-delta checks
+    - close-period withholding breakdown, 4-insurance breakdown, withholding/social/net aggregation, and settlement-delta checks
     - payslip distribution and receipt confirmation state transitions stay deterministic
     - year-end tax-liability/withholding-delta and receipt-issue guard transitions stay deterministic
     - year-end finalized settlement read snapshot (liability/delta/hash) remains deterministic for same finalization replay

--- a/specs/payroll/test-cases.md
+++ b/specs/payroll/test-cases.md
@@ -29,7 +29,7 @@ Payroll gross pay preview and confirmation behavior for WI-0001 plus phase2 dedu
 21. Run payroll 4-insurance settlement preview with contribution caps and verify employee/employer component breakdown.
 22. Reject 4-insurance settlement preview when `payroll_kr_insurance_settlement_v1` feature flag is disabled.
 23. Reject 4-insurance settlement preview when `requireMonthlyBoundary=true` and period is not monthly boundary in `Asia/Seoul`.
-24. Preview payroll close-period summary and verify confirmed/previewed run-state counts plus withholding/social/net settlement deltas.
+24. Preview payroll close-period summary and verify confirmed/previewed run-state counts, withholding breakdown (`incomeTaxKrw`/`residentTaxKrw`), 4-insurance breakdown (`nationalPensionKrw`/`healthInsuranceKrw`/`employmentInsuranceKrw`/`industrialAccidentKrw`), and withholding/social/net settlement deltas.
 25. Apply payroll close-period and reject when unconfirmed (`PREVIEWED`) runs remain.
 26. Reject payroll close-period when `payroll_close_period_v1` feature flag is disabled.
 27. Preview/apply payslip distribution for confirmed runs and verify newly distributed/already distributed counts.

--- a/src/components/payroll-close/PayrollClosePeriodConsole.tsx
+++ b/src/components/payroll-close/PayrollClosePeriodConsole.tsx
@@ -257,6 +257,12 @@ export default function PayrollClosePeriodConsole() {
             <ul className="simple-list">
               <li><span>{copy.grossNetLabel}</span><strong>{formatKrw(result.summary.totalsKrw.grossPayKrw, runtimeLocale)} / {formatKrw(result.summary.totalsKrw.netPayKrw, runtimeLocale)}</strong></li>
               <li><span>{copy.withholdingSocialInsuranceLabel}</span><strong>{formatKrw(result.summary.totalsKrw.withholdingTaxKrw, runtimeLocale)} / {formatKrw(result.summary.totalsKrw.socialInsuranceKrw, runtimeLocale)}</strong></li>
+              <li><span>{copy.incomeTaxLabel}</span><strong>{formatKrw(result.summary.totalsKrw.withholdingBreakdownKrw.incomeTaxKrw, runtimeLocale)}</strong></li>
+              <li><span>{copy.residentTaxLabel}</span><strong>{formatKrw(result.summary.totalsKrw.withholdingBreakdownKrw.residentTaxKrw, runtimeLocale)}</strong></li>
+              <li><span>{copy.nationalPensionLabel}</span><strong>{formatKrw(result.summary.totalsKrw.socialInsuranceBreakdownKrw.nationalPensionKrw, runtimeLocale)}</strong></li>
+              <li><span>{copy.healthInsuranceLabel}</span><strong>{formatKrw(result.summary.totalsKrw.socialInsuranceBreakdownKrw.healthInsuranceKrw, runtimeLocale)}</strong></li>
+              <li><span>{copy.employmentInsuranceLabel}</span><strong>{formatKrw(result.summary.totalsKrw.socialInsuranceBreakdownKrw.employmentInsuranceKrw, runtimeLocale)}</strong></li>
+              <li><span>{copy.industrialAccidentLabel}</span><strong>{formatKrw(result.summary.totalsKrw.socialInsuranceBreakdownKrw.industrialAccidentKrw, runtimeLocale)}</strong></li>
               <li><span>{copy.deductionsOtherLabel}</span><strong>{formatKrw(result.summary.totalsKrw.totalDeductionsKrw, runtimeLocale)} / {formatKrw(result.summary.totalsKrw.otherDeductionsKrw, runtimeLocale)}</strong></li>
               <li><span>{copy.withholdingDeltaLabel}</span><strong>{formatKrw(result.summary.settlementKrw.withholdingTaxDeltaKrw, runtimeLocale)}</strong></li>
               <li><span>{copy.socialInsuranceDeltaLabel}</span><strong>{formatKrw(result.summary.settlementKrw.socialInsuranceDeltaKrw, runtimeLocale)}</strong></li>

--- a/src/components/payroll-close/copy.ts
+++ b/src/components/payroll-close/copy.ts
@@ -36,6 +36,12 @@ export type PayrollCloseCopy = {
   noTotalsYet: string;
   grossNetLabel: string;
   withholdingSocialInsuranceLabel: string;
+  incomeTaxLabel: string;
+  residentTaxLabel: string;
+  nationalPensionLabel: string;
+  healthInsuranceLabel: string;
+  employmentInsuranceLabel: string;
+  industrialAccidentLabel: string;
   deductionsOtherLabel: string;
   withholdingDeltaLabel: string;
   socialInsuranceDeltaLabel: string;
@@ -98,6 +104,12 @@ const copyEn: PayrollCloseCopy = {
   noTotalsYet: "No totals yet.",
   grossNetLabel: "Gross / Net",
   withholdingSocialInsuranceLabel: "Withholding / Social Insurance",
+  incomeTaxLabel: "Income Tax",
+  residentTaxLabel: "Resident Tax",
+  nationalPensionLabel: "National Pension",
+  healthInsuranceLabel: "Health Insurance",
+  employmentInsuranceLabel: "Employment Insurance",
+  industrialAccidentLabel: "Industrial Accident Insurance",
   deductionsOtherLabel: "Deductions / Other",
   withholdingDeltaLabel: "Withholding Delta",
   socialInsuranceDeltaLabel: "Social Insurance Delta",
@@ -159,6 +171,12 @@ const copyKo: PayrollCloseCopy = {
   noTotalsYet: "아직 합계가 없습니다.",
   grossNetLabel: "총지급 / 실지급",
   withholdingSocialInsuranceLabel: "원천세 / 사회보험",
+  incomeTaxLabel: "소득세",
+  residentTaxLabel: "주민세",
+  nationalPensionLabel: "국민연금",
+  healthInsuranceLabel: "건강보험",
+  employmentInsuranceLabel: "고용보험",
+  industrialAccidentLabel: "산재보험",
   deductionsOtherLabel: "공제합계 / 기타공제",
   withholdingDeltaLabel: "원천세 차이",
   socialInsuranceDeltaLabel: "사회보험 차이",

--- a/src/components/payroll-close/types.ts
+++ b/src/components/payroll-close/types.ts
@@ -14,7 +14,17 @@ export type PayrollClosePeriodResponse = {
     totalsKrw: {
       grossPayKrw: number;
       withholdingTaxKrw: number;
+      withholdingBreakdownKrw: {
+        incomeTaxKrw: number;
+        residentTaxKrw: number;
+      };
       socialInsuranceKrw: number;
+      socialInsuranceBreakdownKrw: {
+        nationalPensionKrw: number;
+        healthInsuranceKrw: number;
+        employmentInsuranceKrw: number;
+        industrialAccidentKrw: number;
+      };
       otherDeductionsKrw: number;
       totalDeductionsKrw: number;
       netPayKrw: number;

--- a/src/features/payroll/service-close-period-breakdown-helpers.ts
+++ b/src/features/payroll/service-close-period-breakdown-helpers.ts
@@ -1,0 +1,136 @@
+import type { PayrollRunEntity } from "@/features/shared/data-access";
+
+type WithholdingBreakdownKrw = {
+  incomeTaxKrw: number;
+  residentTaxKrw: number;
+};
+
+type SocialInsuranceBreakdownKrw = {
+  nationalPensionKrw: number;
+  healthInsuranceKrw: number;
+  employmentInsuranceKrw: number;
+  industrialAccidentKrw: number;
+};
+
+type ClosePeriodBreakdownKrw = {
+  withholdingBreakdownKrw: WithholdingBreakdownKrw;
+  socialInsuranceBreakdownKrw: SocialInsuranceBreakdownKrw;
+};
+
+function toNonNegativeIntegerOrNull(value: unknown) {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function resolveRunWithholdingBreakdownKrw(run: PayrollRunEntity): WithholdingBreakdownKrw {
+  const withholdingTaxKrw = run.withholdingTaxKrw ?? 0;
+  const breakdown = asRecord(run.deductionBreakdown);
+  const additional = asRecord(breakdown?.additional);
+  const components = asRecord(additional?.components);
+
+  const incomeTaxKrw = toNonNegativeIntegerOrNull(components?.incomeTaxKrw);
+  const residentTaxKrw = toNonNegativeIntegerOrNull(components?.localIncomeTaxKrw);
+  if (incomeTaxKrw !== null && residentTaxKrw !== null) {
+    return { incomeTaxKrw, residentTaxKrw };
+  }
+  if (incomeTaxKrw !== null) {
+    return {
+      incomeTaxKrw,
+      residentTaxKrw: Math.max(withholdingTaxKrw - incomeTaxKrw, 0)
+    };
+  }
+  if (residentTaxKrw !== null) {
+    return {
+      incomeTaxKrw: Math.max(withholdingTaxKrw - residentTaxKrw, 0),
+      residentTaxKrw
+    };
+  }
+
+  const derivedIncomeTaxKrw = Math.round(withholdingTaxKrw / 1.1);
+  return {
+    incomeTaxKrw: derivedIncomeTaxKrw,
+    residentTaxKrw: withholdingTaxKrw - derivedIncomeTaxKrw
+  };
+}
+
+function resolveRunSocialInsuranceBreakdownKrw(run: PayrollRunEntity): SocialInsuranceBreakdownKrw {
+  const breakdown = asRecord(run.deductionBreakdown);
+  const additional = asRecord(breakdown?.additional);
+  const components = asRecord(additional?.components);
+  const insuranceBreakdown = asRecord(additional?.insuranceBreakdown);
+
+  const longTermCareKrw = toNonNegativeIntegerOrNull(components?.longTermCareKrw) ?? 0;
+
+  const nationalPensionKrw =
+    toNonNegativeIntegerOrNull(insuranceBreakdown?.nps) ??
+    toNonNegativeIntegerOrNull(components?.nationalPensionKrw) ??
+    0;
+
+  const healthInsuranceBaseKrw =
+    toNonNegativeIntegerOrNull(insuranceBreakdown?.nhi) ??
+    toNonNegativeIntegerOrNull(components?.healthInsuranceKrw) ??
+    0;
+
+  const employmentInsuranceKrw =
+    toNonNegativeIntegerOrNull(insuranceBreakdown?.ei) ??
+    toNonNegativeIntegerOrNull(components?.employmentInsuranceKrw) ??
+    0;
+
+  const industrialAccidentKrw =
+    toNonNegativeIntegerOrNull(insuranceBreakdown?.wci) ??
+    toNonNegativeIntegerOrNull(components?.workersCompensationKrw) ??
+    0;
+
+  return {
+    nationalPensionKrw,
+    healthInsuranceKrw: healthInsuranceBaseKrw + longTermCareKrw,
+    employmentInsuranceKrw,
+    industrialAccidentKrw
+  };
+}
+
+export function aggregateClosePeriodBreakdownKrw(runs: PayrollRunEntity[]): ClosePeriodBreakdownKrw {
+  return runs.reduce<ClosePeriodBreakdownKrw>(
+    (acc, run) => {
+      const withholding = resolveRunWithholdingBreakdownKrw(run);
+      const socialInsurance = resolveRunSocialInsuranceBreakdownKrw(run);
+      return {
+        withholdingBreakdownKrw: {
+          incomeTaxKrw: acc.withholdingBreakdownKrw.incomeTaxKrw + withholding.incomeTaxKrw,
+          residentTaxKrw: acc.withholdingBreakdownKrw.residentTaxKrw + withholding.residentTaxKrw
+        },
+        socialInsuranceBreakdownKrw: {
+          nationalPensionKrw:
+            acc.socialInsuranceBreakdownKrw.nationalPensionKrw + socialInsurance.nationalPensionKrw,
+          healthInsuranceKrw:
+            acc.socialInsuranceBreakdownKrw.healthInsuranceKrw + socialInsurance.healthInsuranceKrw,
+          employmentInsuranceKrw:
+            acc.socialInsuranceBreakdownKrw.employmentInsuranceKrw + socialInsurance.employmentInsuranceKrw,
+          industrialAccidentKrw:
+            acc.socialInsuranceBreakdownKrw.industrialAccidentKrw + socialInsurance.industrialAccidentKrw
+        }
+      };
+    },
+    {
+      withholdingBreakdownKrw: {
+        incomeTaxKrw: 0,
+        residentTaxKrw: 0
+      },
+      socialInsuranceBreakdownKrw: {
+        nationalPensionKrw: 0,
+        healthInsuranceKrw: 0,
+        employmentInsuranceKrw: 0,
+        industrialAccidentKrw: 0
+      }
+    }
+  );
+}

--- a/src/features/payroll/service-output-types.ts
+++ b/src/features/payroll/service-output-types.ts
@@ -162,7 +162,9 @@ export type ClosePayrollPeriodResult = {
     totalsKrw: {
       grossPayKrw: number;
       withholdingTaxKrw: number;
+      withholdingBreakdownKrw: PayrollWithholdingBreakdownKrw;
       socialInsuranceKrw: number;
+      socialInsuranceBreakdownKrw: PayrollSocialInsuranceBreakdownKrw;
       otherDeductionsKrw: number;
       totalDeductionsKrw: number;
       netPayKrw: number;
@@ -245,6 +247,18 @@ export type PayrollTotalsKrw = {
   otherDeductionsKrw: number;
   totalDeductionsKrw: number;
   netPayKrw: number;
+};
+
+export type PayrollWithholdingBreakdownKrw = {
+  incomeTaxKrw: number;
+  residentTaxKrw: number;
+};
+
+export type PayrollSocialInsuranceBreakdownKrw = {
+  nationalPensionKrw: number;
+  healthInsuranceKrw: number;
+  employmentInsuranceKrw: number;
+  industrialAccidentKrw: number;
 };
 
 export type YearEndSettlementSummary = {

--- a/src/features/payroll/service-payslip-period-helpers.ts
+++ b/src/features/payroll/service-payslip-period-helpers.ts
@@ -17,6 +17,7 @@ import {
 import {
   aggregatePayrollTotalsKrw
 } from "@/features/payroll/service-year-end-run-snapshot-helpers";
+import { aggregateClosePeriodBreakdownKrw } from "@/features/payroll/service-close-period-breakdown-helpers";
 import type {
   AcknowledgePayrollPayslipReceiptInput,
   ClosePayrollPeriodInput,
@@ -70,6 +71,7 @@ export async function closePayrollPeriodFromHelper(
   const canClose = blockingReasons.length === 0;
 
   const totalsKrw = aggregatePayrollTotalsKrw(confirmedRuns);
+  const breakdownKrw = aggregateClosePeriodBreakdownKrw(confirmedRuns);
 
   const priorPaidWithholdingTaxKrw = toKrwInteger(
     input.settlement?.priorPaidWithholdingTaxKrw ?? 0,
@@ -101,7 +103,11 @@ export async function closePayrollPeriodFromHelper(
       blockingRunIds,
       blockingReasons
     },
-    totalsKrw,
+    totalsKrw: {
+      ...totalsKrw,
+      withholdingBreakdownKrw: breakdownKrw.withholdingBreakdownKrw,
+      socialInsuranceBreakdownKrw: breakdownKrw.socialInsuranceBreakdownKrw
+    },
     settlementKrw: {
       priorPaidWithholdingTaxKrw,
       priorPaidSocialInsuranceKrw,


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-0995-payroll-tax-breakdown.md`
- Related Specs: `specs/payroll/api.yaml`, `specs/payroll/contract.yaml`, `specs/payroll/test-cases.md`
- Related ADR: N/A
- Add payroll close-period withholding breakdown (소득세/주민세) and 4-insurance breakdown (국민연금/건강보험/고용보험/산재보험) to API summary and admin `/admin/payroll-close` display.
- Ensure the "합계 / 차이" panel is populated with breakdown values after payroll close preview.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- ADR reason: 일반 WI의 표시/집계 확장으로 ADR 추가가 필요하지 않습니다.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/components/payroll-close/PayrollClosePeriodConsole.tsx`, `src/components/payroll-close/copy.ts`, `src/components/payroll-close/types.ts`
- Backend-only reason:
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
