### PR TITLE
fix: WI-1003 payslips unauthenticated 401

### DIFF
--- a/src/app/api/payslips/route.ts
+++ b/src/app/api/payslips/route.ts
@@ -19,6 +19,9 @@ const listPayslipsQuerySchema = z.object({
 
 export async function GET(request: Request) {
   const actor = await readActor(request);
+  if (!actor) {
+    return fail(401, "payslip.list.unauthorized");
+  }
   if (!isPayslipActor(actor)) {
     return fail(403, "payslip.list.forbidden");
   }


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-1003-payslips-auth-401-fix.md`
- Related Specs:
- Related ADR:

Updated `GET /api/payslips` so unauthenticated requests return 401 before role authorization. Authenticated users without a payslip role still receive 403.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [ ] UI/UX surface changed (at least one page/component/style updated).
- [x] Backend-only exception approved (reason and next UI WI required).
- UI changed files:
- Backend-only reason: API auth response semantics fix only; no page/component/style changes.
- Next UI WI: <!-- work-items/WI-1003-payslips-auth-401-fix.md -->

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
