### PR TITLE
WI-1006: add employee people read permission

### DIFF
--- a/scripts/tests/e2e-wi0034-people.test.ts
+++ b/scripts/tests/e2e-wi0034-people.test.ts
@@ -145,6 +145,46 @@ async function run() {
   );
   assert.equal(employeeGetResponse.status, 200, "admin can get employee by id");
 
+  const employeeListAsEmployeeResponse = await employeeRoute.GET(
+    new Request("http://localhost/api/people/employees", {
+      method: "GET",
+      headers: actorHeaders("employee", "EMP-2001")
+    })
+  );
+  assert.equal(employeeListAsEmployeeResponse.status, 200, "employee can list employees");
+  const employeeListAsEmployeeBody = (await readJson(employeeListAsEmployeeResponse)) as {
+    employees: Array<{ id: string }>;
+  };
+  assert.ok(
+    employeeListAsEmployeeBody.employees.some((employee) => employee.id === "EMP-2001"),
+    "employee list should include directory entries"
+  );
+
+  const employeeGetAsEmployeeResponse = await employeeByIdRoute.GET(
+    new Request("http://localhost/api/people/employees/EMP-2001", {
+      method: "GET",
+      headers: actorHeaders("employee", "EMP-2001")
+    }),
+    { params: Promise.resolve({ employeeId: "EMP-2001" }) } as RouteContext<{ employeeId: string }>
+  );
+  assert.equal(employeeGetAsEmployeeResponse.status, 200, "employee can get employee by id");
+
+  const employeeCreateDeniedForEmployee = await employeeRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/people/employees",
+      {
+        id: "EMP-2002",
+        organizationId,
+        name: "Lee",
+        email: "lee@example.com",
+        active: true
+      },
+      actorHeaders("employee", "EMP-2001")
+    )
+  );
+  assert.equal(employeeCreateDeniedForEmployee.status, 403, "employee cannot create employee");
+
   const employeeUpdateResponse = await employeeByIdRoute.PATCH(
     jsonRequest(
       "PATCH",

--- a/scripts/tests/integration.test.ts
+++ b/scripts/tests/integration.test.ts
@@ -66,11 +66,25 @@ async function run() {
 
   // Permission checks.
   await requirePermission({ actor: admin, dataAccess: memoryDataAccess }, Permissions.rbacManage);
+  await requirePermission(
+    { actor: employee, dataAccess: memoryDataAccess },
+    Permissions.peopleEmployeesRead
+  );
 
   await assert.rejects(
     () => requirePermission({ actor: unknown, dataAccess: memoryDataAccess }, Permissions.rbacManage),
     isServiceErrorWithStatus(403),
     "unknown role should have no permissions"
+  );
+
+  await assert.rejects(
+    () =>
+      requirePermission(
+        { actor: employee, dataAccess: memoryDataAccess },
+        Permissions.peopleEmployeesManage
+      ),
+    isServiceErrorWithStatus(403),
+    "employee should not gain employee manage permission"
   );
 
   // RBAC-on path should still resolve seeded permissions in memory mode.
@@ -82,6 +96,21 @@ async function run() {
       dataAccess: memoryDataAccess
     });
     assert.equal(permissions.has(Permissions.rbacManage), true, "admin should resolve rbac.manage");
+
+    const employeePermissions = await resolveActorPermissions({
+      actor: employee,
+      dataAccess: memoryDataAccess
+    });
+    assert.equal(
+      employeePermissions.has(Permissions.peopleEmployeesRead),
+      true,
+      "employee should resolve people.employees.read"
+    );
+    assert.equal(
+      employeePermissions.has(Permissions.peopleEmployeesManage),
+      false,
+      "employee should not resolve people.employees.manage"
+    );
   } finally {
     if (previousFlag === undefined) {
       delete process.env.FLOWHR_RBAC_V1;

--- a/src/features/people/service.ts
+++ b/src/features/people/service.ts
@@ -1,5 +1,5 @@
 import type { Actor } from "@/lib/actor";
-import { requirePermission } from "@/lib/permissions";
+import { requireAnyPermission, requirePermission } from "@/lib/permissions";
 import { Permissions, type Permission } from "@/lib/rbac";
 import { ensureTenantMatch, resolveTenantScope } from "@/features/shared/tenant-scope";
 import { seedDefaultWorkSchedulesForEmployee } from "@/features/scheduling/default-work-schedule-seed";
@@ -58,6 +58,14 @@ function getEventPublisher(context: ServiceContext): DomainEventPublisher {
 
 async function requirePeoplePermission(context: ServiceContext, permission: Permission, action: string) {
   await requirePermission(context, permission, `people ${action} requires ${permission}`);
+}
+
+async function requirePeopleEmployeeReadPermission(context: ServiceContext, action: string) {
+  await requireAnyPermission(
+    context,
+    [Permissions.peopleEmployeesRead, Permissions.peopleEmployeesManage],
+    `people ${action} requires ${Permissions.peopleEmployeesRead}`
+  );
 }
 
 function normalizeCode(code: string) {
@@ -1099,7 +1107,7 @@ export async function listEmployees(
   context: ServiceContext,
   input: { active?: boolean; status?: EmployeeStatus; organizationId?: string }
 ): Promise<EmployeeEntity[]> {
-  await requirePeoplePermission(context, Permissions.peopleEmployeesManage, "list employees");
+  await requirePeopleEmployeeReadPermission(context, "list employees");
   const tenantScope = resolveTenantScope(context.actor);
   return context.dataAccess.employees.list({
     active: input.active,
@@ -1112,7 +1120,7 @@ export async function getEmployee(
   context: ServiceContext,
   input: { employeeId: string }
 ): Promise<EmployeeEntity> {
-  await requirePeoplePermission(context, Permissions.peopleEmployeesManage, "get employee");
+  await requirePeopleEmployeeReadPermission(context, "get employee");
   const tenantScope = resolveTenantScope(context.actor);
   const employee = await context.dataAccess.employees.findById(input.employeeId);
   if (!employee) {

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -4,6 +4,7 @@ export const Permissions = {
   rbacManage: "rbac.manage",
 
   peopleOrganizationsManage: "people.organizations.manage",
+  peopleEmployeesRead: "people.employees.read",
   peopleEmployeesManage: "people.employees.manage",
   approvalPolicyRead: "approval.policy.read",
   approvalPolicyWrite: "approval.policy.write",
@@ -85,6 +86,7 @@ export const defaultRolePermissions: Record<ActorRole, readonly Permission[]> = 
     Permissions.payrollDeductionProfileWrite
   ],
   employee: [
+    Permissions.peopleEmployeesRead,
     Permissions.attendanceRecordWriteOwn,
     Permissions.attendanceRecordListOwn,
     Permissions.attendanceAggregateListOwn,


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-1006-employee-people-read-permission.md`
- Related Specs:
- Related ADR: Not required for a scoped RBAC permission split on an existing people read flow.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [ ] UI/UX surface changed (at least one page/component/style updated).
- [x] Backend-only exception approved (reason and next UI WI required).
- UI changed files:
- Backend-only reason: Scoped RBAC update to allow employee directory reads while keeping employee mutations on manage permission.
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
