### PR TITLE
WI-1008 Add leave policy read route

### DIFF
--- a/scripts/tests/e2e-wi1008-leave-policy-read-route.test.ts
+++ b/scripts/tests/e2e-wi1008-leave-policy-read-route.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+function actorHeaders(role: string, actorId: string, organizationId: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId,
+    "x-actor-organization-id": organizationId
+  };
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+async function run() {
+  const { memoryDataAccess, resetMemoryDataAccess } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const leavePolicyByIdRoute = await import(
+    "../../src/app/api/leave/policies/[policyId]/route.ts"
+  );
+
+  resetMemoryDataAccess();
+
+  const organization = await memoryDataAccess.organizations.create({
+    name: "WI-1008 Leave Policy Read Route Org"
+  });
+
+  const customPolicy = await memoryDataAccess.leavePolicy.create({
+    organizationId: organization.id,
+    name: "Carry Cap 12",
+    isStatutory: false,
+    status: "ACTIVE",
+    annualGrantDays: 18,
+    carryOverCapDays: 12,
+    allowHalfDay: false,
+    allowHourly: false,
+    hourlyIncrementMinutes: 60,
+    maxHoursPerRequest: 4,
+    minNoticeDays: 3,
+    maxConsecutiveDays: 7,
+    annualLeavePromotionEnabled: true,
+    annualLeavePromotionThresholdDays: 8,
+    annualLeavePromotionLeadDays: 21,
+    annualLeavePromotionMessageTemplate: "Use your annual leave."
+  });
+
+  const adminHeaders = actorHeaders("admin", "ADMIN-WI1008-1", organization.id);
+
+  const readResponse = await leavePolicyByIdRoute.GET(
+    new Request(
+      `http://localhost/api/leave/policies/${customPolicy.id}?organizationId=${organization.id}`,
+      {
+        method: "GET",
+        headers: adminHeaders
+      }
+    ),
+    {
+      params: Promise.resolve({ policyId: customPolicy.id })
+    } as RouteContext<{ policyId: string }>
+  );
+
+  assert.equal(readResponse.status, 200, "admin should read leave policy by id");
+  const readBody = await readJson<{
+    policy: {
+      organizationId: string;
+      annualGrantDays: number;
+      carryOverCapDays: number;
+      allowHalfDay: boolean;
+      allowHourly: boolean;
+      hourlyIncrementMinutes: number;
+      maxHoursPerRequest: number;
+      minNoticeDays: number;
+      maxConsecutiveDays: number | null;
+      annualLeavePromotionEnabled: boolean;
+      annualLeavePromotionThresholdDays: number;
+      annualLeavePromotionLeadDays: number;
+      annualLeavePromotionMessageTemplate: string;
+      source: "configured" | "default";
+      updatedAt: string | null;
+    };
+  }>(readResponse);
+  assert.equal(readBody.policy.organizationId, organization.id);
+  assert.equal(readBody.policy.annualGrantDays, 18);
+  assert.equal(readBody.policy.carryOverCapDays, 12);
+  assert.equal(readBody.policy.allowHalfDay, false);
+  assert.equal(readBody.policy.allowHourly, false);
+  assert.equal(readBody.policy.hourlyIncrementMinutes, 60);
+  assert.equal(readBody.policy.maxHoursPerRequest, 4);
+  assert.equal(readBody.policy.minNoticeDays, 3);
+  assert.equal(readBody.policy.maxConsecutiveDays, 7);
+  assert.equal(readBody.policy.annualLeavePromotionEnabled, true);
+  assert.equal(readBody.policy.annualLeavePromotionThresholdDays, 8);
+  assert.equal(readBody.policy.annualLeavePromotionLeadDays, 21);
+  assert.equal(readBody.policy.annualLeavePromotionMessageTemplate, "Use your annual leave.");
+  assert.equal(readBody.policy.source, "configured");
+  assert.equal(typeof readBody.policy.updatedAt, "string");
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi1008-leave-policy-read-route.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/app/api/leave/policies/[policyId]/route.ts
+++ b/src/app/api/leave/policies/[policyId]/route.ts
@@ -1,5 +1,5 @@
 import { leavePolicyPathSchema, readLeavePolicyQuerySchema } from "@/features/leave/schemas";
-import { deleteLeavePolicy } from "@/features/leave/service";
+import { deleteLeavePolicy, readLeavePolicy } from "@/features/leave/service";
 import { getRuntimeDataAccess } from "@/features/shared/runtime-data-access";
 import { isServiceError } from "@/features/shared/service-error";
 import { readActor } from "@/lib/actor";
@@ -8,6 +8,41 @@ import { fail, ok } from "@/lib/http";
 type RouteContext = {
   params: Promise<{ policyId: string }>;
 };
+
+export async function GET(request: Request, context: RouteContext) {
+  const { policyId } = await context.params;
+  const pathParsed = leavePolicyPathSchema.safeParse({ policyId });
+  if (!pathParsed.success) {
+    return fail(400, "invalid path", pathParsed.error.flatten());
+  }
+
+  const url = new URL(request.url);
+  const queryParsed = readLeavePolicyQuerySchema.safeParse({
+    organizationId: url.searchParams.get("organizationId") ?? undefined
+  });
+  if (!queryParsed.success) {
+    return fail(400, "invalid query", queryParsed.error.flatten());
+  }
+
+  try {
+    const result = await readLeavePolicy(
+      {
+        actor: await readActor(request),
+        dataAccess: getRuntimeDataAccess()
+      },
+      {
+        organizationId: queryParsed.data.organizationId,
+        policyId: pathParsed.data.policyId
+      }
+    );
+    return ok(result);
+  } catch (error) {
+    if (isServiceError(error)) {
+      return fail(error.status, error.message, error.details);
+    }
+    throw error;
+  }
+}
 
 export async function DELETE(request: Request, context: RouteContext) {
   const { policyId } = await context.params;

--- a/src/features/leave/service.ts
+++ b/src/features/leave/service.ts
@@ -103,6 +103,7 @@ type AutoGrantLeaveAccrualInput = {
 
 type ReadLeavePolicyInput = {
   organizationId?: string;
+  policyId?: string;
 };
 
 type UpsertLeavePolicyInput = {
@@ -1290,10 +1291,22 @@ export async function readLeavePolicy(
   }
   await requirePermission(context, Permissions.leaveBalanceReadAny, "leave policy read requires permission");
 
-  const organizationId = resolveTargetOrganizationId(actor, input.organizationId);
+  const policyId = input.policyId?.trim();
+  const stored = policyId
+    ? await context.dataAccess.leavePolicy.findById(policyId)
+    : await context.dataAccess.leavePolicy.findByOrganizationId(
+        resolveTargetOrganizationId(actor, input.organizationId)
+      );
+  if (policyId && !stored) {
+    throw new ServiceError(404, "leave policy not found");
+  }
+
+  const organizationId = stored?.organizationId ?? resolveTargetOrganizationId(actor, input.organizationId);
+  if (input.organizationId && stored && input.organizationId !== stored.organizationId) {
+    throw new ServiceError(404, "leave policy not found");
+  }
   ensureTenantAccess(actor, organizationId);
 
-  const stored = await context.dataAccess.leavePolicy.findByOrganizationId(organizationId);
   const policy = stored
     ? {
         organizationId: stored.organizationId,


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-1008-leave-policy-read-route.md`
- Related Specs:
- Related ADR: Not required for this route addition to an existing leave policy service flow.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [ ] UI/UX surface changed (at least one page/component/style updated).
- [x] Backend-only exception approved (reason and next UI WI required).
- UI changed files:
- Backend-only reason: Added GET `/api/leave/policies/[policyId]` for backend leave policy detail reads without changing UI surfaces.
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
