### PR TITLE
WI-1023: 알림 페이지 Authorization 헤더 추가

### DIFF
--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -39,11 +39,12 @@ export default function AdminNotificationsPage() {
   const [isFetching, setIsFetching] = useState(false);
   const [pendingReadId, setPendingReadId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const bearerToken = snapshot?.accessToken?.trim() ?? "";
 
   const unreadCount = useMemo(() => notifications.filter((row) => !row.isRead).length, [notifications]);
 
   const loadNotifications = useCallback(async () => {
-    if (!snapshot) {
+    if (!snapshot || bearerToken.length === 0) {
       setNotifications([]);
       setErrorMessage(null);
       setIsFetching(false);
@@ -53,7 +54,12 @@ export default function AdminNotificationsPage() {
     setIsFetching(true);
     setErrorMessage(null);
     try {
-      const response = await fetch("/api/notifications", { cache: "no-store" });
+      const response = await fetch("/api/notifications", {
+        cache: "no-store",
+        headers: {
+          authorization: `Bearer ${bearerToken}`
+        }
+      });
       const requestError = toErrorMessage(response, "알림 목록을 불러오지 못했습니다.");
       if (requestError) {
         setErrorMessage(requestError);
@@ -67,14 +73,21 @@ export default function AdminNotificationsPage() {
     } finally {
       setIsFetching(false);
     }
-  }, [snapshot]);
+  }, [bearerToken, snapshot]);
 
   const handleMarkAsRead = useCallback(async (notificationId: string) => {
+    if (bearerToken.length === 0) {
+      return;
+    }
+
     setPendingReadId(notificationId);
     setErrorMessage(null);
     try {
       const response = await fetch(`/api/notifications/${notificationId}/read`, {
-        method: "PATCH"
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${bearerToken}`
+        }
       });
       const requestError = toErrorMessage(response, "알림 읽음 처리를 하지 못했습니다.");
       if (requestError) {
@@ -101,7 +114,7 @@ export default function AdminNotificationsPage() {
     } finally {
       setPendingReadId((current) => (current === notificationId ? null : current));
     }
-  }, []);
+  }, [bearerToken]);
 
   useEffect(() => {
     if (loading) {

--- a/src/app/employee/notifications/page.tsx
+++ b/src/app/employee/notifications/page.tsx
@@ -39,11 +39,12 @@ export default function EmployeeNotificationsPage() {
   const [isFetching, setIsFetching] = useState(false);
   const [pendingReadId, setPendingReadId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const bearerToken = snapshot?.accessToken?.trim() ?? "";
 
   const unreadCount = useMemo(() => notifications.filter((row) => !row.isRead).length, [notifications]);
 
   const loadNotifications = useCallback(async () => {
-    if (!snapshot) {
+    if (!snapshot || bearerToken.length === 0) {
       setNotifications([]);
       setErrorMessage(null);
       setIsFetching(false);
@@ -53,7 +54,12 @@ export default function EmployeeNotificationsPage() {
     setIsFetching(true);
     setErrorMessage(null);
     try {
-      const response = await fetch("/api/notifications", { cache: "no-store" });
+      const response = await fetch("/api/notifications", {
+        cache: "no-store",
+        headers: {
+          authorization: `Bearer ${bearerToken}`
+        }
+      });
       const requestError = toErrorMessage(response, "알림 목록을 불러오지 못했습니다.");
       if (requestError) {
         setErrorMessage(requestError);
@@ -67,14 +73,21 @@ export default function EmployeeNotificationsPage() {
     } finally {
       setIsFetching(false);
     }
-  }, [snapshot]);
+  }, [bearerToken, snapshot]);
 
   const handleMarkAsRead = useCallback(async (notificationId: string) => {
+    if (bearerToken.length === 0) {
+      return;
+    }
+
     setPendingReadId(notificationId);
     setErrorMessage(null);
     try {
       const response = await fetch(`/api/notifications/${notificationId}/read`, {
-        method: "PATCH"
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${bearerToken}`
+        }
       });
       const requestError = toErrorMessage(response, "알림 읽음 처리를 하지 못했습니다.");
       if (requestError) {
@@ -101,7 +114,7 @@ export default function EmployeeNotificationsPage() {
     } finally {
       setPendingReadId((current) => (current === notificationId ? null : current));
     }
-  }, []);
+  }, [bearerToken]);
 
   useEffect(() => {
     if (loading) {


### PR DESCRIPTION
## Summary

- Work Item: `work-items/WI-1023-notifications-page-auth-header.md`
- Related Specs:
- Related ADR: Not required for this scoped auth-header parity fix.
- Added the session bearer token to admin and employee notifications page `GET`/`PATCH` requests.
- Skipped notifications fetch and mark-as-read requests when no access token is available.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

## Delivery Balance

- [x] UI/UX surface changed (at least one page/component/style updated).
- [ ] Backend-only exception approved (reason and next UI WI required).
- UI changed files: `src/app/admin/notifications/page.tsx`, `src/app/employee/notifications/page.tsx`
- Backend-only reason:
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
