### PR TITLE
WI-1028: 급여 프리뷰에 미승인 출퇴근 제외 안내 추가

### DIFF
--- a/scripts/tests/e2e-wi1028-payroll-preview-unapproved-warning.test.ts
+++ b/scripts/tests/e2e-wi1028-payroll-preview-unapproved-warning.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+
+const runtimeEnv = process.env as Record<string, string | undefined>;
+runtimeEnv.NODE_ENV = "test";
+runtimeEnv.FLOWHR_DATA_ACCESS = "memory";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+runtimeEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+runtimeEnv.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+runtimeEnv.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.DIRECT_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+runtimeEnv.FLOWHR_EVENT_PUBLISHER = "memory";
+runtimeEnv.FLOWHR_PAYROLL_DEDUCTIONS_V1 = "true";
+runtimeEnv.FLOWHR_PAYROLL_KR_BASELINE_V1 = "true";
+
+type JsonPayload = Record<string, unknown>;
+type RouteContext<TParams extends Record<string, string>> = {
+  params: Promise<TParams>;
+};
+
+function actorHeaders(role: string, actorId: string, organizationId?: string) {
+  return {
+    "content-type": "application/json",
+    "x-actor-role": role,
+    "x-actor-id": actorId,
+    ...(organizationId ? { "x-actor-organization-id": organizationId } : {})
+  };
+}
+
+function jsonRequest(method: string, path: string, payload: JsonPayload, headers: Record<string, string>) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}
+
+async function run() {
+  const { memoryDataAccess, resetMemoryDataAccess } = await import(
+    "../../src/features/shared/memory-data-access.ts"
+  );
+  const attendanceCreateRoute = await import("../../src/app/api/attendance/records/route.ts");
+  const attendanceApproveRoute = await import(
+    "../../src/app/api/attendance/records/[recordId]/approve/route.ts"
+  );
+  const payrollPreviewRoute = await import("../../src/app/api/payroll/preview/route.ts");
+
+  resetMemoryDataAccess();
+
+  const organization = await memoryDataAccess.organizations.create({ name: "WI-1028 Org" });
+  const employeeId = "EMP-WI1028-1001";
+  await memoryDataAccess.employees.create({ id: employeeId, organizationId: organization.id });
+
+  const employeeHeaders = actorHeaders("employee", employeeId, organization.id);
+  const managerHeaders = actorHeaders("manager", "MGR-WI1028-1001", organization.id);
+  const payrollHeaders = actorHeaders("payroll_operator", "PAY-WI1028-1001", organization.id);
+
+  const approvedAttendanceResponse = await attendanceCreateRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/attendance/records",
+      {
+        employeeId,
+        checkInAt: "2026-02-10T09:00:00+09:00",
+        checkOutAt: "2026-02-10T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      employeeHeaders
+    )
+  );
+  assert.equal(approvedAttendanceResponse.status, 201, "approved-period attendance creation should succeed");
+  const approvedAttendanceBody = await readJson<{ record: { id: string } }>(approvedAttendanceResponse);
+
+  const approveAttendanceResponse = await attendanceApproveRoute.POST(
+    new Request(
+      `http://localhost/api/attendance/records/${approvedAttendanceBody.record.id}/approve`,
+      {
+        method: "POST",
+        headers: managerHeaders
+      }
+    ),
+    { params: Promise.resolve({ recordId: approvedAttendanceBody.record.id }) } as RouteContext<{
+      recordId: string;
+    }>
+  );
+  assert.equal(approveAttendanceResponse.status, 200, "attendance approval should succeed");
+
+  const pendingAttendanceResponse = await attendanceCreateRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/attendance/records",
+      {
+        employeeId,
+        checkInAt: "2026-02-11T09:00:00+09:00",
+        checkOutAt: "2026-02-11T18:00:00+09:00",
+        breakMinutes: 60,
+        isHoliday: false
+      },
+      employeeHeaders
+    )
+  );
+  assert.equal(pendingAttendanceResponse.status, 201, "pending attendance creation should succeed");
+
+  const approvedOnlyPreviewResponse = await payrollPreviewRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/preview",
+      {
+        periodStart: "2026-02-10T00:00:00+09:00",
+        periodEnd: "2026-02-10T23:59:59+09:00",
+        employeeId,
+        hourlyRateKrw: 12000
+      },
+      payrollHeaders
+    )
+  );
+  assert.equal(approvedOnlyPreviewResponse.status, 200, "approved-only payroll preview should succeed");
+  const approvedOnlyPreviewBody = await readJson<{
+    summary: {
+      sourceRecordCount: number;
+      pendingRecordCount: number;
+      grossPayKrw: number;
+    };
+    warnings: string[];
+  }>(approvedOnlyPreviewResponse);
+  assert.equal(approvedOnlyPreviewBody.summary.sourceRecordCount, 1);
+  assert.equal(approvedOnlyPreviewBody.summary.pendingRecordCount, 0);
+  assert.equal(approvedOnlyPreviewBody.summary.grossPayKrw, 96000);
+  assert.deepEqual(approvedOnlyPreviewBody.warnings, []);
+
+  const monthlyPreviewResponse = await payrollPreviewRoute.POST(
+    jsonRequest(
+      "POST",
+      "/api/payroll/preview",
+      {
+        periodStart: "2026-02-01T00:00:00+09:00",
+        periodEnd: "2026-02-28T23:59:59+09:00",
+        employeeId,
+        hourlyRateKrw: 12000
+      },
+      payrollHeaders
+    )
+  );
+  assert.equal(monthlyPreviewResponse.status, 200, "monthly payroll preview should succeed");
+  const monthlyPreviewBody = await readJson<{
+    summary: {
+      sourceRecordCount: number;
+      pendingRecordCount: number;
+      grossPayKrw: number;
+    };
+    warnings: string[];
+  }>(monthlyPreviewResponse);
+  assert.equal(monthlyPreviewBody.summary.sourceRecordCount, 1);
+  assert.equal(monthlyPreviewBody.summary.pendingRecordCount, 1);
+  assert.equal(monthlyPreviewBody.summary.grossPayKrw, 96000);
+  assert.deepEqual(monthlyPreviewBody.warnings, [
+    "미승인 출퇴근 기록 1건은 급여 계산에서 제외되었습니다."
+  ]);
+}
+
+run()
+  .then(() => {
+    console.log("e2e-wi1028-payroll-preview-unapproved-warning.test passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/features/payroll/service-output-types.ts
+++ b/src/features/payroll/service-output-types.ts
@@ -40,6 +40,7 @@ export type PreviewPayrollWithDeductionsResult = {
     profileId: string | null;
     profileVersion: number | null;
     sourceRecordCount: number;
+    pendingRecordCount: number;
     totals: PayableMinutes;
     grossPayKrw: number;
     withholdingTaxKrw: number;
@@ -55,6 +56,7 @@ export type PreviewPayrollWithDeductionsResult = {
     netPayKrw: number;
     deductionBreakdown: Record<string, unknown>;
   };
+  warnings: string[];
 };
 
 export type PreviewPayrollInsuranceSettlementResult = {

--- a/src/features/payroll/service-preview-helpers.ts
+++ b/src/features/payroll/service-preview-helpers.ts
@@ -25,6 +25,9 @@ import {
 } from "@/features/payroll/service-context-helpers";
 import { calculatePayrollComputation } from "@/features/payroll/service-computation-helpers";
 
+const pendingAttendanceWarningMessage = (count: number) =>
+  `미승인 출퇴근 기록 ${count}건은 급여 계산에서 제외되었습니다.`;
+
 export async function previewPayrollFromHelper(
   context: ServiceContext,
   input: PreviewPayrollInput
@@ -105,6 +108,15 @@ export async function previewPayrollWithDeductionsFromHelper(
     : null;
 
   const computed = await calculatePayrollComputation(context.dataAccess, input, tenantScope);
+  const pendingRecordCount = (
+    await context.dataAccess.attendance.listInPeriod({
+      periodStart: input.periodStart,
+      periodEnd: input.periodEnd,
+      organizationId: tenantScope ?? undefined,
+      employeeId: input.employeeId,
+      state: "PENDING"
+    })
+  ).length;
   const deductionMode = input.deductionMode;
   const organizationId = employee?.organizationId ?? tenantScope ?? null;
   let withholdingTaxKrw = 0;
@@ -289,6 +301,9 @@ export async function previewPayrollWithDeductionsFromHelper(
     }
   });
 
+  const warnings =
+    pendingRecordCount > 0 ? [pendingAttendanceWarningMessage(pendingRecordCount)] : [];
+
   return {
     run,
     summary: {
@@ -296,6 +311,7 @@ export async function previewPayrollWithDeductionsFromHelper(
       profileId,
       profileVersion,
       sourceRecordCount: computed.recordsCount,
+      pendingRecordCount,
       totals: computed.totals,
       grossPayKrw: computed.grossPayKrw,
       withholdingTaxKrw,
@@ -305,6 +321,7 @@ export async function previewPayrollWithDeductionsFromHelper(
       totalDeductionsKrw,
       netPayKrw,
       deductionBreakdown
-    }
+    },
+    warnings
   };
 }


### PR DESCRIPTION
﻿## Summary

- Work Item: `work-items/WI-1028-payroll-preview-unapproved-warning.md`
- Related Specs:
- Related ADR:

Backend change: add `summary.pendingRecordCount` and a warning message when PENDING attendance records are excluded from payroll preview.
Validation run: `npx tsx scripts/tests/e2e-wi1028-payroll-preview-unapproved-warning.test.ts`, `npm.cmd run typecheck`, `npm.cmd run lint`.

## Required Checklist

- [x] Work item file is linked and updated.
- [x] Domain `contract.yaml` is added or updated.
- [x] `test-cases.md` is added or updated.
- [x] Contract version was bumped when contract changed.
- [x] ADR requirement reviewed:
  - [ ] ADR added (required for breaking/cross-domain/security-impacting change), or
  - [x] Not required with reason.
ADR reason: additive backend response field with no breaking, cross-domain, or security impact.
- [x] QA Spec Gate and Code Gate checks are completed.
- [x] QA persona review completed (checklist evidence attached).

## Quality Gate Evidence

- [x] Unit tests
- [x] Integration tests
- [x] Regression checks
- [x] Lint/typecheck
- [x] Migration smoke
- [x] Contract governance checks

Evidence:
- Added regression test for `/api/payroll/preview` pending attendance exclusion warning.
- No migration or contract change in this WI.
- `npm.cmd run lint` completed with existing repository warnings only.

## Delivery Balance

- [ ] UI/UX surface changed (at least one page/component/style updated).
- [x] Backend-only exception approved (reason and next UI WI required).
- UI changed files:
- Backend-only reason: payroll preview API warning field addition
- Next UI WI:

## Emergency Override (Break-Glass Only)

Complete this section only when bypassing normal QA gate.

- [ ] Break-glass trigger category:
  - [ ] P0 outage
  - [ ] Security hotfix
  - [ ] Legal deadline
- Incident ID:
- Approval:
  - Human approver:
  - Co-sign approver (Orchestrator or QA):
- Change scope:
- Risk assessment:
- Rollback plan:
- Customer impact:
- Temporary mitigation:
- RCA due date (<= 48h after merge):
